### PR TITLE
Change analysis files from /tmp/ to project directory

### DIFF
--- a/skills/writer/resources/revision-guide.md
+++ b/skills/writer/resources/revision-guide.md
@@ -15,7 +15,7 @@
 - Review [Why Three Passes?](#why-three-passes) to understand the philosophy
 - Review [Complete Three-Pass Example](#complete-three-pass-example) to see full transformation from draft to polished prose
 
-**IMPORTANT:** For each pass, analyze the ENTIRE draft first and output findings to a temp file, then read the temp file to make improvements. This ensures complete coverage of the document.
+**IMPORTANT:** For each pass, analyze the ENTIRE draft first and output findings to an analysis file in the current directory, then read that file to make improvements. This ensures complete coverage of the document. These analysis files remain in the project for your review.
 
 Use this workflow when revising any draft. Work through all three passes sequentially:
 
@@ -23,8 +23,8 @@ Use this workflow when revising any draft. Work through all three passes sequent
 
 Step 1 - Analysis Phase:
 - [ ] Read the ENTIRE draft from beginning to end
-- [ ] Create a temp file `/tmp/pass1-clutter-analysis.md`
-- [ ] Output to temp file: Identify ALL instances of clutter throughout the entire document:
+- [ ] Create analysis file `writer-pass1-clutter-analysis.md` in current directory
+- [ ] Output to analysis file: Identify ALL instances of clutter throughout the entire document:
   - List all adverbs (-ly words) with line/paragraph references
   - List all qualifiers (very, really, quite, rather, somewhat, fairly)
   - List all passive voice constructions
@@ -34,7 +34,7 @@ Step 1 - Analysis Phase:
   - Calculate total word count and target reduction (10-25%)
 
 Step 2 - Improvement Phase:
-- [ ] Read the temp file `/tmp/pass1-clutter-analysis.md`
+- [ ] Read the analysis file `writer-pass1-clutter-analysis.md`
 - [ ] Work through the ENTIRE draft making improvements:
   - Remove adverbs - cut 70%
   - Delete qualifiers
@@ -51,8 +51,8 @@ See detailed examples and guidance in [Pass 1 section](#pass-1-cut-clutter-zinss
 
 Step 1 - Analysis Phase:
 - [ ] Read the ENTIRE draft from beginning to end
-- [ ] Create a temp file `/tmp/pass2-cognitive-load-analysis.md`
-- [ ] Output to temp file: Identify ALL cognitive load issues throughout the entire document:
+- [ ] Create analysis file `writer-pass2-cognitive-load-analysis.md` in current directory
+- [ ] Output to analysis file: Identify ALL cognitive load issues throughout the entire document:
   - List all garden-path sentences with line/paragraph references
   - List all sentences with buried topics
   - List all cases where subject-verb-object are far apart (>7 words)
@@ -61,7 +61,7 @@ Step 1 - Analysis Phase:
   - Mark any sentences that require re-reading
 
 Step 2 - Improvement Phase:
-- [ ] Read the temp file `/tmp/pass2-cognitive-load-analysis.md`
+- [ ] Read the analysis file `writer-pass2-cognitive-load-analysis.md`
 - [ ] Work through the ENTIRE draft making improvements:
   - Fix all garden-path sentences
   - Signal topic at start of each sentence
@@ -78,8 +78,8 @@ See detailed examples and guidance in [Pass 2 section](#pass-2-reduce-cognitive-
 
 Step 1 - Analysis Phase:
 - [ ] Read the ENTIRE draft from beginning to end
-- [ ] Create a temp file `/tmp/pass3-rhythm-analysis.md`
-- [ ] Output to temp file: Analyze rhythm patterns throughout the entire document:
+- [ ] Create analysis file `writer-pass3-rhythm-analysis.md` in current directory
+- [ ] Output to analysis file: Analyze rhythm patterns throughout the entire document:
   - List sentence lengths for each paragraph (count words per sentence)
   - Identify monotonous patterns (5+ similar-length sentences in a row)
   - List the last word of each sentence - mark weak endings
@@ -88,7 +88,7 @@ Step 1 - Analysis Phase:
   - Mark sections that lack sentence variety
 
 Step 2 - Improvement Phase:
-- [ ] Read the temp file `/tmp/pass3-rhythm-analysis.md`
+- [ ] Read the analysis file `writer-pass3-rhythm-analysis.md`
 - [ ] Work through the ENTIRE draft making improvements:
   - Add short sentences for emphasis after longer ones
   - Replace weak sentence endings with strong words

--- a/skills/writer/resources/structure-types.md
+++ b/skills/writer/resources/structure-types.md
@@ -15,15 +15,15 @@
 
 **Before starting:** Review [Philosophy](#philosophy) and [Why Structure Matters](#why-structure-matters) to understand the principles.
 
-**IMPORTANT:** For analysis steps, output findings to a temp file to ensure thorough coverage of all material.
+**IMPORTANT:** For analysis steps, output findings to analysis files in the current directory to ensure thorough coverage of all material. These analysis files remain in the project for your review.
 
 Use this checklist after intent discovery, before drafting:
 
 **Step 1 - Material Analysis Phase:**
 
 - [ ] [Gather and understand all your material completely](#step-1-gather-your-material)
-- [ ] Create a temp file `/tmp/structure-material-analysis.md`
-- [ ] Output to temp file:
+- [ ] Create analysis file `writer-structure-material-analysis.md` in current directory
+- [ ] Output to analysis file:
   - List ALL key points, anecdotes, data, quotes, examples you have
   - Identify themes and patterns across the material
   - Note what's most important vs. supporting detail
@@ -32,10 +32,10 @@ Use this checklist after intent discovery, before drafting:
 
 **Step 2 - Structure Exploration Phase:**
 
-- [ ] Read the temp file `/tmp/structure-material-analysis.md`
+- [ ] Read the analysis file `writer-structure-material-analysis.md`
 - [ ] Review [Structure Types](#structure-types) - all 8 types with examples
-- [ ] Create a temp file `/tmp/structure-options.md`
-- [ ] Output to temp file - [Sketch 3 different structure options](#step-3-sketch-3-options):
+- [ ] Create analysis file `writer-structure-options.md` in current directory
+- [ ] Output to analysis file - [Sketch 3 different structure options](#step-3-sketch-3-options):
   - **Option 1:** Type, diagram sketch, pros/cons, how material fits
   - **Option 2:** Type, diagram sketch, pros/cons, how material fits
   - **Option 3:** Type, diagram sketch, pros/cons, how material fits
@@ -43,7 +43,7 @@ Use this checklist after intent discovery, before drafting:
 
 **Step 3 - Structure Selection Phase:**
 
-- [ ] Read the temp file `/tmp/structure-options.md`
+- [ ] Read the analysis file `writer-structure-options.md`
 - [ ] [Compare all three options](#step-4-test-each-structure)
 - [ ] [Select the structure that best serves the material](#step-5-select-and-refine)
 - [ ] [Map key moments and transitions](#step-5-select-and-refine)

--- a/skills/writer/resources/success-model.md
+++ b/skills/writer/resources/success-model.md
@@ -19,13 +19,13 @@
 - Review [The Heath Brothers' Framework](#the-heath-brothers-framework) to understand the six principles
 - Review [Complete Example](#complete-example) to see transformation from weak to sticky message
 
-**IMPORTANT:** Analyze the ENTIRE document first and output findings to a temp file, then read the temp file to make improvements. This ensures complete coverage.
+**IMPORTANT:** Analyze the ENTIRE document first and output findings to an analysis file in the current directory, then read that file to make improvements. This ensures complete coverage. The analysis file remains in the project for your review.
 
 **Step 1 - Analysis Phase:**
 
 - [ ] Read the ENTIRE draft from beginning to end
-- [ ] Create a temp file `/tmp/stickiness-analysis.md`
-- [ ] Output to temp file: Assess the entire document against all 6 SUCCESs principles:
+- [ ] Create analysis file `writer-stickiness-analysis.md` in current directory
+- [ ] Output to analysis file: Assess the entire document against all 6 SUCCESs principles:
 
 **Simple** (see [S - Simple](#s---simple))
 - Identify the core message - is it ≤12 words and one main idea?
@@ -61,7 +61,7 @@
 
 **Step 2 - Improvement Phase:**
 
-- [ ] Read the temp file `/tmp/stickiness-analysis.md`
+- [ ] Read the analysis file `writer-stickiness-analysis.md`
 - [ ] Work through the ENTIRE draft making improvements for each weak principle:
   - Simple: Refine core message to ≤12 words
   - Unexpected: Add surprise or curiosity gaps


### PR DESCRIPTION
Updated all three resource files to create analysis files in the user's current project directory instead of /tmp/:

revision-guide.md:
- writer-pass1-clutter-analysis.md
- writer-pass2-cognitive-load-analysis.md
- writer-pass3-rhythm-analysis.md

success-model.md:
- writer-stickiness-analysis.md

structure-types.md:
- writer-structure-material-analysis.md
- writer-structure-options.md

Benefits:
- Analysis files stay in user's project (not system /tmp/)
- User can review analysis files to understand AI's findings
- No orphan files in system directories
- Files are clearly named with 'writer-' prefix
- Visible and accessible in project for inspection

User requested this so analysis files remain in their project for review rather than being hidden in /tmp/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)