### PR TITLE
Fix README: Remove links to gitignored scratchpad files

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,6 @@ Skill Progress:
 
 **In Development**: 39 skills remaining from standard collection
 
-See [COMPLETED-SKILLS.md](/scratchpad/COMPLETED-SKILLS.md) for detailed progress tracking.
-
 ## Key Features
 
 ### Quality Standards
@@ -226,8 +224,6 @@ When creating or refining skills:
 ## Resources
 
 - [Claude Code Documentation](https://docs.claude.com/en/docs/claude-code/)
-- [Skill Refinement Instructions](/scratchpad/SKILL-REFINEMENT-INSTRUCTIONS.md)
-- [Workflow Pattern Guide](/scratchpad/workflow-pattern.md)
 
 ## License
 


### PR DESCRIPTION
Removed broken links to:
- /scratchpad/COMPLETED-SKILLS.md
- /scratchpad/SKILL-REFINEMENT-INSTRUCTIONS.md
- /scratchpad/workflow-pattern.md

These files are in .gitignore and not available to repository users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)