### PR TITLE
Improve skill invocation rules and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![Run in Smithery](https://smithery.ai/badge/skills/lyndonkl)](https://smithery.ai/skills?ns=lyndonkl&utm_source=github&utm_medium=badge)
 
 
-> **Claude Code Plugin Available** — Install all 63 skills instantly with `/plugin marketplace add lyndonkl/claude` then `/plugin install thinking-frameworks-skills`
+> **Claude Code Plugin Available** — Install all 69 skills instantly with `/plugin marketplace add lyndonkl/claude` then `/plugin install thinking-frameworks-skills`
 
 A comprehensive collection of production-ready skills for Claude Code, covering thinking frameworks, decision-making tools, research methods, design patterns, and specialized domains.
 
 ## Overview
 
-This repository contains **63 skills** designed to enhance Claude Code's capabilities across strategic thinking, product development, research, experimentation, and creative problem-solving. Each skill includes:
+This repository contains **69 skills** designed to enhance Claude Code's capabilities across strategic thinking, product development, research, experimentation, and creative problem-solving. Each skill includes:
 
 - **Structured workflows** with step-by-step guidance
 - **Practical templates** for immediate use
@@ -29,6 +29,7 @@ This repository contains **63 skills** designed to enhance Claude Code's capabil
   - [🏗️ Architecture & Design](#️-architecture--design)
   - [🔒 Security & Risk](#-security--risk)
   - [📝 Communication & Documentation](#-communication--documentation)
+  - [🔬 Scientific Writing](#-scientific-writing)
   - [🎯 Estimation & Forecasting](#-estimation--forecasting)
   - [💼 Business & Product Management](#-business--product-management)
   - [⏱️ Productivity & Learning](#️-productivity--learning)
@@ -156,6 +157,20 @@ This repository contains **63 skills** designed to enhance Claude Code's capabil
 **writer** - Transform writing into precise, compelling prose using structured revision (Zinsser, King, Pinker), structural architecture (McPhee), and stickiness techniques (SUCCESs framework).
 
 **one-pager-prd** - Create concise product specifications (1-2 pages) for stakeholder alignment covering problem statement (user pain with quantified impact), solution overview (high-level approach without over-specifying), user personas and use cases, SMART metrics (baselines + targets, leading/lagging indicators), scope boundaries (MVP vs future, in/out explicit), constraints and assumptions, and open questions. Apply problem framing techniques: Jobs-to-be-Done ("When I [situation], I want to [motivation], so I can [outcome]"), 5 Whys root cause analysis, problem statement formula with evidence (interviews, analytics, support tickets). Use metric trees to decompose North Star into actionable sub-metrics. Apply scope prioritization: MoSCoW (Must/Should/Could/Won't), RICE scoring (Reach × Impact × Confidence / Effort), Kano model (basic/performance/delight needs), value-effort matrix. Write for clarity using pyramid principle (lead with conclusion), active voice, concrete language, abundant examples, scannable formatting (bullets, headers, tables). Manage stakeholders by tailoring content (engineering: constraints/dependencies, design: flows/personas, business: impact/ROI, legal: compliance). Apply user story mapping to visualize journey and slice features vertically. Includes one-pager template (1 page, bullets, quick approval) and full PRD template (1-2 pages, detailed requirements, execution guide). Covers feature proposals, new products, technical initiatives, platform projects, internal tools, strategic initiatives. For B2B (emphasize ROI, security, integrations), B2C (emphasize delight, viral potential), enterprise (emphasize compliance, customization).
+
+### 🔬 Scientific Writing
+
+**scientific-manuscript-review** - Review and edit research manuscripts using IMRaD structure (Introduction, Methods, Results, Discussion). Provides section-specific guidance for abstracts, introductions (knowledge gap → research question → hypothesis), methods (reproducibility checklist), results (figure/table integration, statistical reporting), and discussion (interpretation, limitations, future directions). Includes clarity checking for scientific claims, evidence-claim alignment, and appropriate hedging.
+
+**grant-proposal-assistant** - Assist with NIH/NSF grant proposals using established frameworks. Covers Specific Aims page structure (one-page with hook, gap, solution, aims), Research Strategy sections (Significance, Innovation, Approach), and reviewer perspective analysis. Includes templates for R01, R21, R03, and K-series applications with compliance checklists and common pitfall avoidance.
+
+**academic-letter-architect** - Craft compelling academic letters including recommendations, nominations, and references. Provides framework for context gathering (relationship, duration, context), evidence collection (specific achievements with quantification), comparative statements (percentile rankings, peer comparisons), and tone calibration by letter type and career stage.
+
+**scientific-email-polishing** - Polish professional scientific correspondence including cover letters to editors, responses to reviewers, collaboration requests, and conference communications. Covers subject line optimization, tone calibration (formal to collegial), clear ask formulation, and response-to-reviewers strategy (acknowledge, address, explain pattern).
+
+**scientific-clarity-checker** - Cross-cutting scientific logic review for any document type. Audits claims against evidence, checks hedging appropriateness (matches evidence strength), validates terminology consistency, maps argument logic flow, and identifies gaps in mechanistic explanations. Applies to manuscripts, grants, or any scientific writing.
+
+**career-document-architect** - Develop academic career documents including research statements, teaching statements/philosophy, diversity statements, CVs, and biosketches. Covers narrative development (vision + track record), audience analysis (search committee priorities), institutional fit demonstration, and format-specific templates (NIH biosketch, academic CV, faculty application statements).
 
 ### 🎯 Estimation & Forecasting
 
@@ -297,10 +312,11 @@ Skill Progress:
 
 ## Skill Development Status
 
-**Production Ready**: 35 skills
+**Production Ready**: 41 skills
 - ✓ 33 refined skills from standard collection
 - ✓ 1 original skill (writer)
 - ✓ 1 custom skill (chef-assistant)
+- ✓ 6 scientific writing skills (manuscript review, grants, letters, emails, clarity, career docs)
 
 **In Development**: 23 skills remaining from standard collection
 
@@ -370,4 +386,4 @@ Skills draw from established frameworks and expert practitioners:
 
 ---
 
-**Status**: 63 production-ready skills | Active development | Last updated: 2025-11-19
+**Status**: 69 production-ready skills | Active development | Last updated: 2025-12-13

--- a/agents/superforecaster.md
+++ b/agents/superforecaster.md
@@ -41,28 +41,59 @@ Superforecasting Pipeline Progress:
 
 Execute these phases in order. **Do not skip steps.**
 
-### CRITICAL RULES (Apply to ALL Phases)
+---
 
-**Rule 0: SKILL INVOCATION - When a Step Says "Invoke Skill", You MUST Do It**
+## CRITICAL: Skill Invocation Rules
+
+**You are an ORCHESTRATOR, not a doer. When a step says to invoke a skill, you MUST invoke the corresponding skill.**
+
+### Rule 1: ALWAYS Invoke Skills - Never Do The Work Yourself
 - When instructions say "Invoke: `skill-name` skill", you MUST actually invoke that skill
-- To invoke a skill, explicitly state: "I will now use the `skill-name` skill to handle this step."
+- To invoke a skill, explicitly state: "I will now use the `skill-name` skill to [purpose]."
 - **DO NOT** attempt to do the skill's work yourself - let the skill handle it
 - **DO NOT** summarize or simulate what the skill would do
-- The skill has specialized methodology and templates - use them
-- After skill invocation, continue from where the skill output leaves off
+- **DO NOT** apply your own logic - the skills have specialized methodology and templates
 - If a skill is marked "(if available)", check if it exists; if not, follow the manual fallback
 
-**Example of correct skill invocation:**
+### Rule 2: Explicit Skill Invocation Syntax
+When invoking a skill, use this exact pattern:
+```
+I will now use the `[skill-name]` skill to [specific purpose for this step].
+```
+
+### Rule 3: Let The Skill Do Its Work
+- After invoking a skill, the skill's workflow takes over
+- The skill will apply its own checklist, templates, and methodology
+- Your job is orchestration and sequencing, not execution
+- Continue from where the skill output leaves off
+
+### Example of CORRECT Behavior:
 ```
 Step 1.2 says to invoke `reference-class-forecasting` skill.
 
-CORRECT: "I will now use the `reference-class-forecasting` skill to determine the appropriate reference class and base rate."
-[Skill executes and provides output]
+CORRECT:
+"I will now use the `reference-class-forecasting` skill to determine the appropriate reference class and base rate for this forecast."
+[Skill takes over and executes its workflow]
 
-INCORRECT: "Let me think about what reference class to use..." [doing the work yourself]
+INCORRECT:
+"Let me think about what reference class to use..."
+[Doing the work yourself instead of invoking the skill]
 ```
 
-**Rule 1: NEVER Generate Data - Always Search**
+### Example of CORRECT Multi-Skill Usage:
+```
+User: "Forecast whether this startup will succeed"
+
+CORRECT:
+"I'll use multiple skills for this forecast. First, I will use the `reference-class-forecasting` skill to establish the base rate. Then I will use the `estimation-fermi` skill to decompose the problem. Finally, I will use the `bayesian-reasoning-calibration` skill to update with evidence."
+[Skills execute in sequence]
+```
+
+---
+
+### CRITICAL RULES (Apply to ALL Phases)
+
+**Rule 4: NEVER Generate Data - Always Search**
 - **DO NOT** make up base rates, statistics, or data points
 - **DO NOT** estimate from memory or general knowledge
 - **ALWAYS** use web search tools to find actual published data
@@ -70,14 +101,14 @@ INCORRECT: "Let me think about what reference class to use..." [doing the work y
 - If you cannot find data after searching, state "No data found" and explain the gap
 - Only then (as last resort) can you make an explicit assumption, clearly labeled as such
 
-**Rule 2: Collaborate with User on Every Assumption**
+**Rule 5: Collaborate with User on Every Assumption**
 - Before accepting any assumption, **ask the user** if they agree
 - For domain-specific knowledge, **defer to the user's expertise**
 - When you lack information, **ask the user** rather than guessing
 - Present your reasoning and **invite the user to challenge it**
 - Every skill invocation should involve user collaboration, not solo analysis
 
-**Rule 3: Document All Sources**
+**Rule 6: Document All Sources**
 - Every data point must have a source (URL, study name, report title)
 - Format: `[Finding] - Source: [URL or citation]`
 - If user provides data, note: `[Finding] - Source: User provided`
@@ -113,7 +144,9 @@ Use the **Goldilocks Framework:**
 
 #### Step 1.2: Reference Class Selection
 
-**Invoke:** `reference-class-forecasting` skill (for deep dive) OR apply quickly:
+**ACTION:** Say "I will now use the `reference-class-forecasting` skill to identify the appropriate reference class and base rate" and invoke it.
+
+**If skill unavailable, apply manually:**
 
 **Process:**
 1. **Propose reference class** to user: "I think the appropriate reference class is [X]. Does that seem right?"
@@ -210,7 +243,9 @@ Phase 2 Progress:
 
 #### Step 2.1a: Propose Decomposition Structure
 
-**Invoke:** `estimation-fermi` skill (if available) OR apply decomposition manually
+**ACTION:** Say "I will now use the `estimation-fermi` skill to decompose this forecast into estimable components" and invoke it.
+
+**If skill unavailable, apply decomposition manually:**
 
 **Propose decomposition structure to user:**
 "I'm breaking this into [components]. Does this make sense?"
@@ -339,7 +374,9 @@ Evidence from Web Search:
 
 #### Step 3.2: Bayesian Updating
 
-**Invoke:** `bayesian-reasoning-calibration` skill (if available) OR apply manually
+**ACTION:** Say "I will now use the `bayesian-reasoning-calibration` skill to systematically update the probability with each piece of evidence" and invoke it.
+
+**If skill unavailable, apply manually:**
 
 **Starting point:** Set Prior = Weighted Estimate from Phase 2
 
@@ -397,7 +434,9 @@ Phase 4 Progress:
 
 #### Step 4.1a: Run Premortem - Imagine Failure
 
-**Invoke:** `forecast-premortem` skill (if available)
+**ACTION:** Say "I will now use the `forecast-premortem` skill to identify failure modes by imagining the forecast has failed" and invoke it.
+
+**If skill unavailable, proceed manually:**
 
 **Frame the scenario:** "Let's assume our prediction has FAILED. We're now in the future looking back."
 
@@ -460,7 +499,9 @@ Post-Premortem Probability: [Adjusted]%
 
 #### Step 4.2a: Run Bias Tests
 
-**Invoke:** `scout-mindset-bias-check` skill (if available)
+**ACTION:** Say "I will now use the `scout-mindset-bias-check` skill to systematically test for cognitive biases" and invoke it.
+
+**If skill unavailable, proceed manually:**
 
 **Run these tests collaboratively with user:**
 


### PR DESCRIPTION
## Summary

- Updates `superforecaster.md` with comprehensive skill invocation rules matching `scientific-writing-editor.md` format
- Adds explicit **ACTION:** syntax for all skill invocation points with fallback instructions
- Updates README with new Scientific Writing category (6 skills) and updated counts

## Changes

### superforecaster.md
- Added "CRITICAL: Skill Invocation Rules" section with Rules 1-3 (ALWAYS Invoke, Explicit Syntax, Let Skill Work)
- Added examples of CORRECT vs INCORRECT behavior and multi-skill usage
- Updated all 5 skill invocation points to use ACTION format:
  - `reference-class-forecasting` (Step 1.2)
  - `estimation-fermi` (Step 2.1a)
  - `bayesian-reasoning-calibration` (Step 3.2)
  - `forecast-premortem` (Step 4.1a)
  - `scout-mindset-bias-check` (Step 4.2a)
- Renumbered existing rules to Rules 4-6

### README.md
- Added Scientific Writing category with 6 skills
- Updated skill count: 63 → 69
- Updated production ready count: 35 → 41
- Updated last updated date

## Test plan

- [ ] Invoke superforecaster agent and verify it correctly invokes skills using the ACTION format
- [ ] Verify skill invocation examples are clear and actionable
- [ ] Check README displays correctly with new category

🤖 Generated with [Claude Code](https://claude.com/claude-code)