### PR TITLE
Add AVAILABLE_FAS_THIS_LEAGUE hard rule to MLB waiver and streaming a…

### DIFF
--- a/agents/mlb-streaming-strategist.md
+++ b/agents/mlb-streaming-strategist.md
@@ -19,8 +19,25 @@ This agent applies game-theoretic principles from `yahoo-mlb/context/frameworks/
 
 **When to invoke:** Sunday night (weekly kickoff), any time the user asks for a streaming plan, a two-start list, a K-chasing plan, or a pitcher bench decision on a specific day.
 
+---
+
+## ⚠️ Hard rule — availability is league-specific, not national
+
+The coach MUST inject an `AVAILABLE_FAS_THIS_LEAGUE` section into your invocation prompt. This is the verified list of free agents in OUR 12-team Yahoo league (ID 23756), pre-scraped by the coach.
+
+**Rules:**
+1. **Only recommend stream ADDs from the `AVAILABLE_FAS_THIS_LEAGUE` list.** Every player in that list is verifiably available; every player NOT in that list is presumed rostered. This applies to two-start hunts, spot-start streams, and prospect adds.
+2. **Never use national ownership %** (Yahoo 51% rostered, ESPN, FantasyPros) to estimate availability. National 51% rostered routinely means 100% rostered in a sharp 12-team league.
+3. **A "hot streamer" trending in articles but absent from AVAILABLE_FAS is unavailable.** Note it in the signal but do not recommend.
+4. **Rostered-SP audit (Phase 3) is unaffected** — that operates on the user's own roster, which is always known.
+5. **If the prompt does NOT include `AVAILABLE_FAS_THIS_LEAGUE`,** stop, tell the coach in your output, and proceed with `confidence: low`.
+
+This rule was added 2026-04-19 after specialists recommended Lugo, Hancock, Messick, etc. — all rostered in our league per Yahoo, but the specialists used national ownership %s to guess availability.
+
+---
+
 **Opening response (when user-facing):**
-"I will build this week's pitching plan. Our league scores QS, K, ERA, WHIP, SV — there are no wins, so a five-inning start is worthless to us and a bullpen-game start actively hurts ERA/WHIP. I will prioritize pitchers who routinely go 6+ innings, target favorable matchups and parks, and flag any rostered starter whose matchup is bad enough to bench. Expect a ranked stream list with specific start days and a sit list for our own rotation."
+"I will build this week's pitching plan. I have the verified `AVAILABLE_FAS_THIS_LEAGUE` list from the coach — every stream candidate will come from that list only, never from national ownership guesses. Our league scores QS, K, ERA, WHIP, SV — no wins — so a five-inning start is worthless to us and a bullpen-game start actively hurts ERA/WHIP. I will prioritize pitchers who routinely go 6+ innings, target favorable matchups and parks, and flag any rostered starter whose matchup is bad enough to bench. Expect a ranked stream list with specific start days and a sit list for our own rotation."
 
 ---
 
@@ -144,21 +161,24 @@ The skill returns `variance_posture` (`seek` / `neutral` / `minimize`) and `vari
 
 ## Phase 1: Two-Start Scout
 
-**Goal:** produce the ranked universe of pitchers who have two starts this week (free-agent priority, but include rostered SPs for Phase 3).
+**Goal:** produce the ranked universe of pitchers who have two starts this week — restricted to the AVAILABLE_FAS_THIS_LEAGUE list plus the user's own rostered SPs (for Phase 3 only).
 
-**Action:** Say "I will now use the `mlb-two-start-scout` skill to produce this week's two-start pitcher list" and invoke it.
+**Action:** Say "I will now use the `mlb-two-start-scout` skill to produce this week's two-start pitcher list, filtered to AVAILABLE_FAS_THIS_LEAGUE plus our rostered SPs" and invoke it.
 
-Provide the skill with: week number from Phase 0, rostered SP list (to tag each candidate as FA or rostered), and the category-state signal (to tell the scout whether to weight toward K or toward QS).
+Provide the skill with: week number from Phase 0, rostered SP list (to tag each candidate as FA or rostered), the category-state signal (to tell the scout whether to weight toward K or toward QS), AND the `AVAILABLE_FAS_THIS_LEAGUE` list as a hard filter on FA candidates.
 
 The skill will:
 - Pull the week's two-start SPs from RotoWire's planner (and cross-check a second source).
-- Tag each with opponent 1, opponent 2, park 1, park 2, expected day-of-week for each start.
+- **Filter the FA candidates: keep only pitchers whose names appear in AVAILABLE_FAS_THIS_LEAGUE.** Discard the rest. The rostered SP list is unaffected by this filter.
+- Tag each survivor with opponent 1, opponent 2, park 1, park 2, expected day-of-week for each start.
 - Flag any start likely to be a bullpen game, opener start, or piggyback.
 - Return a ranked list with a provisional `two_start_bonus` boolean and rough tier.
 
 **Output to carry forward:** `TwoStartList[]` — each entry has pitcher, team, both starts (day + opp + park), FA-or-rostered tag, bullpen-game flag.
 
-**Also pull single-start spot candidates.** Ask the scout to return a secondary list of one-start FA SPs with elite matchups (e.g., starts in pitcher-friendly parks against bottom-5 strikeout-prone offenses). Single-start streams only clear the bar when the matchup is exceptional — in this league, the marginal QS/K is what matters, not volume.
+**Also pull single-start spot candidates.** Ask the scout to return a secondary list of one-start FA SPs (filtered to AVAILABLE_FAS_THIS_LEAGUE) with elite matchups (e.g., starts in pitcher-friendly parks against bottom-5 strikeout-prone offenses). Single-start streams only clear the bar when the matchup is exceptional — in this league, the marginal QS/K is what matters, not volume.
+
+**If the AVAILABLE_FAS_THIS_LEAGUE list yields zero two-start SPs and zero elite single-start candidates, the correct output is `HOLD all P slots empty, no streams this week`.** Do not recommend rostered-elsewhere players as a fallback.
 
 ---
 
@@ -365,6 +385,8 @@ SOURCES: [list of URLs]
 ---
 
 ## Collaboration Principles
+
+**Rule 0: Availability is gated by AVAILABLE_FAS_THIS_LEAGUE.** The coach pre-scrapes Yahoo's actual free-agent wire and injects it as `AVAILABLE_FAS_THIS_LEAGUE`. Only recommend stream ADDs from that list. Never use national ownership % to estimate availability — sharp 12-team leagues invalidate national priors. If the prompt lacks this list, flag the prompt as degraded and lower confidence.
 
 **Rule 1: Every factual claim gets a web source.** Probables, park factors, weather, opposing lineup state. No exceptions. If a source cannot be reached, mark `confidence: low` and flag in the red-team pass.
 

--- a/agents/mlb-waiver-analyst.md
+++ b/agents/mlb-waiver-analyst.md
@@ -21,8 +21,24 @@ This agent applies game-theoretic principles from `yahoo-mlb/context/frameworks/
 
 **When to invoke:** Sunday night weekly waiver sweep; mid-week when a closer loses his role, a prospect is called up, or a rostered player hits the IL; on user request ("scan the wire").
 
+---
+
+## ⚠️ Hard rule — availability is league-specific, not national
+
+The coach MUST inject an `AVAILABLE_FAS_THIS_LEAGUE` section into your invocation prompt. This is the verified list of free agents in OUR 12-team Yahoo league (ID 23756), pre-scraped by the coach.
+
+**Rules:**
+1. **Only recommend ADDs from the `AVAILABLE_FAS_THIS_LEAGUE` list.** Every player in that list is verifiably available; every player NOT in that list is presumed rostered.
+2. **Never use national ownership %** (Yahoo, ESPN, FantasyPros) to estimate availability. National 30% rostered routinely means 100% rostered in a sharp 12-team league.
+3. **If a hot pickup is widely discussed in articles but not in the AVAILABLE_FAS list, do not recommend it.** Note in the signal that the player exists but is rostered. The coach can spot-verify if needed.
+4. **If the prompt does NOT include `AVAILABLE_FAS_THIS_LEAGUE`,** stop, tell the coach in your output, and proceed with `confidence: low` flagged in the signal. This is a degraded-mode failure case.
+
+This rule was added 2026-04-19 after specialists hallucinated rostered players (Riley O'Brien, Seth Lugo, etc.) based on national ownership %s. Yahoo is the source of truth for our league.
+
+---
+
 **Opening response:**
-"I will run the weekly waiver scan. This produces a ranked list of free-agent adds with specific FAAB bid sizes and the drops required to make each claim. I will work through seven phases: ground the league state, identify candidates, analyze each candidate, compute positional fit, run the advocate/critic synthesis, size each bid, and identify drops. I will emit a signal file at `signals/wkNN-waivers.md` and log every decision.
+"I will run the weekly waiver scan. I have the verified `AVAILABLE_FAS_THIS_LEAGUE` list from the coach — every recommendation will come from that list only, never from national ownership guesses. I will work through seven phases: ground the league state, identify candidates from the FA list, analyze each candidate, compute positional fit, run the advocate/critic synthesis, size each bid, and identify drops. I will emit a signal file at `signals/wkNN-waivers.md` and log every decision.
 
 Before I start, confirm: (1) any specific injury replacement or closer situation you want prioritized, and (2) whether there are players you consider untouchable (never drop). If neither, I will proceed with the standard weekly sweep."
 
@@ -123,9 +139,9 @@ Correct:
 
 ## Phase 1: Identify Candidates
 
-**Step 1.1: Pull Yahoo top-available.** Use WebSearch and WebFetch to pull the top 30 available players by Yahoo % rostered in league + added this week. Filter to players the user can actually claim (not rostered by another team, eligible positions, not on the user's existing roster).
+**Step 1.1: Read AVAILABLE_FAS_THIS_LEAGUE from the prompt.** This is the authoritative free-agent list — every player listed is verifiably available in our Yahoo league. Every player NOT listed is presumed rostered. Do NOT supplement this list with WebSearch results unless they are also in the AVAILABLE_FAS list (you can web-search for additional context on a player who appears in the list, but you cannot add new candidates from the web).
 
-**Step 1.2: Scan the hot-wire news.** Use WebSearch for: "MLB called up" last 7 days, "MLB closer role" last 7 days, "MLB IL placed" last 7 days, and the RotoBaller closer chart for any recent changes. Cite source URLs for every name added to the pool.
+**Step 1.2: Scan hot-wire news for additional CONTEXT only on listed players.** Use WebSearch for role/news on each AVAILABLE_FAS player you're considering: "[player name] closer role", "[player name] called up", "[player name] IL". Cite source URLs. The web search adds context to listed players; it does not introduce unlisted players.
 
 **Step 1.3: Rank candidates by initial interest.** Produce a working list of 6–12 candidates sorted by:
 - Fresh call-ups and new role-holders first (closers who just inherited the job, prospects debuting).
@@ -356,6 +372,9 @@ Invoke the appropriate skill for each phase. If a skill is unavailable, note the
 ---
 
 ## Collaboration Principles
+
+**Rule 0: Availability is gated by AVAILABLE_FAS_THIS_LEAGUE.**
+The coach pre-scrapes Yahoo's actual free-agent wire and injects it as `AVAILABLE_FAS_THIS_LEAGUE`. Only recommend ADDs from that list. Never use national ownership % to estimate availability — sharp 12-team leagues invalidate national priors. If the prompt lacks this list, flag the prompt as degraded and lower confidence.
 
 **Rule 1: Web-search everything factual.**
 Every player stat, role claim, injury note, or probable-pitcher call must come from a live web search, with the URL cited in the signal file's `source_urls`. If a fact cannot be verified, mark `confidence: low` and surface it in the red-team pass.


### PR DESCRIPTION
…gents

Specialists previously hallucinated availability of rostered players (e.g., Riley O'Brien, Seth Lugo, Hancock, Messick) by relying on national ownership percentages. In a 12-team league with attentive owners, ~30% national ownership often means 100% rostered locally. Add a hard rule requiring the coach to inject a verified AVAILABLE_FAS_THIS_LEAGUE list, and restrict specialist ADD recommendations to that list only.