### PR TITLE
Add paper-synthesizer agent + 4 supporting skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Claude Code Skills Collection
 
-![Skills](https://img.shields.io/badge/skills-205-blue) ![Agents](https://img.shields.io/badge/agents-37-blue) ![Status](https://img.shields.io/badge/status-active-brightgreen) [![Run in Smithery](https://smithery.ai/badge/skills/lyndonkl)](https://smithery.ai/skills?ns=lyndonkl&utm_source=github&utm_medium=badge)
+![Skills](https://img.shields.io/badge/skills-209-blue) ![Agents](https://img.shields.io/badge/agents-38-blue) ![Status](https://img.shields.io/badge/status-active-brightgreen) [![Run in Smithery](https://smithery.ai/badge/skills/lyndonkl)](https://smithery.ai/skills?ns=lyndonkl&utm_source=github&utm_medium=badge)
 
-A production-ready library of **205 skills** and **37 orchestrating agents** for Claude Code — covering thinking frameworks, research, writing, design, data/ML, corporate finance, game theory, fantasy baseball, household personal finance, and a 9-agent team for growing a Substack publication.
+A production-ready library of **209 skills** and **38 orchestrating agents** for Claude Code — covering thinking frameworks, research, writing, design, data/ML, corporate finance, game theory, fantasy baseball, household personal finance, and a 9-agent team for growing a Substack publication.
 
 **Install in 30 seconds:**
 
@@ -30,6 +30,7 @@ Pick the fastest entry point for what you're trying to do. Most users start with
 | Build a GraphRAG / knowledge-graph retrieval system | [`graphrag-specialist`](agents/graphrag-specialist.md) |
 | Design equivariant / symmetry-aware neural networks | [`geometric-deep-learning-architect`](agents/geometric-deep-learning-architect.md) |
 | Build geometric intuition for ML math (attention, PCA, eigenvectors, high-dim spaces) | [`math-intuition-coach`](agents/math-intuition-coach.md) |
+| Get a weekly digest of new bioRxiv / medRxiv / PubMed papers against my keyword watchlist | [`paper-synthesizer`](agents/paper-synthesizer.md) |
 | Grow my Substack / publish intuition-first ML & systems essays | [`librarian`](agents/librarian.md), [`intuition-builder`](agents/intuition-builder.md), [`editor`](agents/editor.md) + 6 more (see `~/Documents/Thinking/substacker/`) |
 | Use just one tool (no agent) | Browse the [Skills Index](#skills-index) below |
 
@@ -47,8 +48,9 @@ flowchart LR
     D -->|Knowledge retrieval| GR[graphrag-specialist]
     D -->|Symmetry-aware ML| GDL[geometric-deep-<br/>learning-architect]
     D -->|Math intuition| MI[math-intuition-<br/>coach]
+    D -->|Weekly paper digest| PS[paper-synthesizer]
     D -->|One-off tool| SK[Skills Index ▾]
-    CA & WA & SF & CD & MLB & HF & GR & GDL & MI --> S[(205 skills)]
+    CA & WA & SF & CD & MLB & HF & GR & GDL & MI & PS --> S[(209 skills)]
     SK --> S
 ```
 
@@ -66,6 +68,7 @@ Agents detect your need and route to the right skills. Each agent's page documen
 | [**cognitive-design-architect**](agents/cognitive-design-architect.md) | Cognitive design, information architecture, D3 viz, fallacy check |
 | [**geometric-deep-learning-architect**](agents/geometric-deep-learning-architect.md) | Symmetry discovery → group ID → equivariant architecture |
 | [**math-intuition-coach**](agents/math-intuition-coach.md) | 3Blue1Brown-style geometric intuition for any ML/data math (attention, PCA, gradients, high-dim spaces) |
+| [**paper-synthesizer**](agents/paper-synthesizer.md) | Weekly bioRxiv / medRxiv / PubMed digest against a keyword watchlist; clusters by theme; layered-reasoning synthesis with paper links |
 | [**graphrag-specialist**](agents/graphrag-specialist.md) | Knowledge graph construction, embedding fusion, retrieval orchestration |
 | [**company-analyst**](agents/company-analyst.md) | End-to-end company valuation → buy/sell/hold recommendation |
 | [**special-situations-analyst**](agents/special-situations-analyst.md) | Distressed / private / high-growth / financial-firm valuation |
@@ -102,7 +105,7 @@ Agents detect your need and route to the right skills. Each agent's page documen
 
 ## Skills Index
 
-**200 skills** across 7 super-categories. Every skill's full methodology, templates, and evaluation rubric live in its `SKILL.md` — click any entry to drill in.
+**209 skills** across 7 super-categories. Every skill's full methodology, templates, and evaluation rubric live in its `SKILL.md` — click any entry to drill in.
 
 <details>
 <summary><b>🧠 Thinking & Decisions</b> — decision-making, problem-solving, estimation, dialogue, ideation, learning (37 skills)</summary>
@@ -165,7 +168,9 @@ Agents detect your need and route to the right skills. Each agent's page documen
 </details>
 
 <details>
-<summary><b>🔬 Research & Evidence</b> — research design, evidence evaluation, rubrics, ethics (6 skills)</summary>
+<summary><b>🔬 Research & Evidence</b> — research design, evidence evaluation, rubrics, ethics, literature scan (10 skills)</summary>
+
+### Research design & evaluation
 
 - **[discovery-interviews-surveys](skills/discovery-interviews-surveys/SKILL.md)** — Run unbiased JTBD interviews and surveys with thematic coding.
 - **[design-of-experiments](skills/design-of-experiments/SKILL.md)** — Design rigorous factorial, RSM, and Taguchi experiments.
@@ -173,6 +178,15 @@ Agents detect your need and route to the right skills. Each agent's page documen
 - **[research-claim-map](skills/research-claim-map/SKILL.md)** — Verify claims via triangulation, source grading, confidence calibration.
 - **[ethics-safety-impact](skills/ethics-safety-impact/SKILL.md)** — Assess harms, fairness, and mitigations across stakeholders.
 - **[evaluation-rubrics](skills/evaluation-rubrics/SKILL.md)** — Design rubrics with calibrated scales and inter-rater reliability.
+
+### Literature scan
+
+Domain-neutral primitives for any weekly paper-digest workflow. Powers the `paper-synthesizer` agent.
+
+- **[fetch-preprint-recent](skills/fetch-preprint-recent/SKILL.md)** — Fetch bioRxiv / medRxiv preprints for a date window with cursor pagination and client-side keyword filter.
+- **[fetch-pubmed-recent](skills/fetch-pubmed-recent/SKILL.md)** — Fetch PubMed records for a date window via PubMed MCP when available, E-utilities fallback otherwise.
+- **[paper-relevance-filter](skills/paper-relevance-filter/SKILL.md)** — Score candidate papers KEEP / REVIEW / DROP on match strength + criteria fit + novelty against last-4-weeks history.
+- **[paper-cluster-by-theme](skills/paper-cluster-by-theme/SKILL.md)** — Group filtered papers into 2-5 argument-shaped clusters before synthesis.
 
 </details>
 

--- a/agents/paper-synthesizer.md
+++ b/agents/paper-synthesizer.md
@@ -1,0 +1,210 @@
+---
+name: paper-synthesizer
+description: Weekly research-paper digest. Each Monday, scans bioRxiv, medRxiv, and PubMed for papers posted in the prior 7 days against a persistent keyword watchlist (with optional per-week overrides), filters for relevance, clusters by theme, and produces a layered-reasoning synthesis (30,000 ft → 3,000 ft → 300 ft) with direct paper links. Reads the last 4 weeks of digests so it can label topics as continuing vs new and avoid re-summarizing the same work. The orchestrator (a local file in the operator's project folder) decides where the project lives and invokes this agent from that folder; this agent's paths are all relative to the current working directory. Trigger keywords - weekly papers, paper digest, literature scan, bioRxiv weekly, medRxiv, PubMed weekly, paper synthesis, what's new in [field], scan the literature.
+tools: Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
+skills: fetch-preprint-recent, fetch-pubmed-recent, paper-relevance-filter, paper-cluster-by-theme, layered-reasoning
+model: inherit
+---
+
+# The Paper Synthesizer Agent
+
+Weekly research-paper compressor for a persistent keyword watchlist. Reads bioRxiv, medRxiv, and PubMed; emits one synthesized digest per week with paper links and a layered-reasoning structure. Maintains historical context across weeks so topics can be labeled as continuing, new, or refuted.
+
+**Project root.** This agent does not resolve paths to disk. It is invoked by the operator's orchestrator (a local file in their project folder), which sets the working directory before invocation. All paths in this file are relative to that working directory. Before doing anything else, the agent confirms it can see `orchestrator.md`, `shared-context/watchlist.md`, and `ops/paper-synthesizer/` from the current working directory; if any are missing, it halts and reports rather than guessing.
+
+**When to invoke**: Monday morning weekly run; user asks "what's new in [my watchlist topics]"; user asks for catch-up after missing weeks ("synthesize the last 3 weeks").
+
+**Opening response**:
+
+> "Running paper-synthesizer for week {YYYY-WW}. Loading watchlist + last-4-weeks history, scanning bioRxiv + medRxiv + PubMed for the {YYYY-MM-DD} → {YYYY-MM-DD} window, filtering, clustering, then writing `ops/paper-synthesizer/{YYYY-WW}-digest.md` and `{YYYY-WW}-papers.md`."
+
+---
+
+## Paths
+
+All paths below are relative to the working directory the orchestrator invokes the agent in. Never construct absolute paths in this agent.
+
+**Reads (always, in order):**
+1. `orchestrator.md` — system map
+2. `shared-context/watchlist.md` — persistent keywords
+3. `shared-context/source-registry.md` — endpoints + query templates
+4. `shared-context/relevance-criteria.md` — keep/drop rules
+5. `shared-context/synthesis-style.md` — layered-reasoning rendering rules
+6. `ops/paper-synthesizer/overrides/{YYYY-WW}.md` (if exists) — per-week additions/exclusions
+7. The last 4 weekly digests in `ops/paper-synthesizer/*-digest.md` (sorted desc, take 4) — historical context
+
+**Writes:**
+- `ops/paper-synthesizer/{YYYY-WW}-digest.md` — synthesized layered report (the thing the user reads)
+- `ops/paper-synthesizer/{YYYY-WW}-papers.md` — full filtered paper list with title, authors, source, date, link, abstract excerpt, relevance rationale
+- `ops/paper-synthesizer/.cache/{YYYY-WW}-{source}.json` — raw fetch results (for debugging + re-synthesis without re-fetching)
+
+**Never writes:** `shared-context/watchlist.md` (user owns), `archive/` (manual move only), and never anything outside `{PROJECT_ROOT}`.
+
+---
+
+## Pipeline
+
+```
+Monday weekly run:
+- [ ] Step 0: Compute window. Today is Monday {YYYY-MM-DD}. Window = [today - 7 days, today - 1 day] inclusive.
+       Week tag = ISO year-week of "today" formatted YYYY-WW (e.g., 2026-19).
+- [ ] Step 1: Load context. Read orchestrator, watchlist, source-registry, relevance-criteria,
+       synthesis-style, this-week's overrides (if any), and titles+themes of the last 4 digests.
+- [ ] Step 2: Build effective keyword set = watchlist ∪ overrides.add - overrides.exclude.
+       Note any keyword groups (e.g., "protein-design", "single-cell"); treat them separately
+       only if multiple groups are explicitly defined. Otherwise treat as one flat set.
+- [ ] Step 3: Fetch bioRxiv for window via fetch-preprint-recent (server="biorxiv").
+- [ ] Step 4: Fetch medRxiv for window via fetch-preprint-recent (server="medrxiv").
+- [ ] Step 5: Fetch PubMed for window via fetch-pubmed-recent.
+       Cache raw responses to .cache/{YYYY-WW}-{source}.json.
+- [ ] Step 6: Dedupe across sources. A PubMed record can be the published version of a bioRxiv preprint;
+       collapse on DOI when shared, otherwise on (lowercased, normalized) title + first author.
+       When collapsed, prefer the PubMed record but keep the preprint URL as a "preprint version" link.
+- [ ] Step 7: Apply paper-relevance-filter to each candidate. Keep, drop, or flag-for-review with
+       rationale. Use last-4-weeks digests to mark items as CONTINUING, NEW, or COVERED-BEFORE.
+- [ ] Step 8: If kept count > 25, raise the relevance bar (filter again with stricter threshold)
+       until ≤ 25. If kept count < 3, surface this as a "thin week" warning rather than padding.
+- [ ] Step 9: Apply paper-cluster-by-theme to the kept set. Produce 2-5 thematic clusters
+       plus an "outliers / single-paper-themes" bucket if needed.
+- [ ] Step 10: Synthesize top-down via layered-reasoning. Read synthesis-style.md for the
+       full rules; the short version is:
+
+       The reader has three different questions. Each layer answers one, in this order:
+         - 30,000 ft  → "What did you find across ALL the papers this week?"
+                        One paragraph. The through-line. What changed, what did NOT change,
+                        what's continuing from prior weeks, what's the disagreement if any.
+                        NOT a list of cluster names. NOT a list of papers. The compressed
+                        intersection of the kept set. If the week is genuinely scattered,
+                        say so — don't fake a through-line.
+         - 3,000 ft   → "What were the themes? Tell me by topic."
+                        One short paragraph per cluster (from paper-cluster-by-theme).
+                        State what the cluster collectively argues. Cite the strongest 1-2
+                        papers inline. Surface the tension if the cluster has one.
+                        Tag continuity in the cluster header: [continuing from YYYY-WW].
+         - 300 ft     → "Show me the actual papers."
+                        One bullet per paper, in cluster order. Title — first author et al.,
+                        source, date. One sentence on what the paper does and why it belongs
+                        in this cluster. Preserve the paper's own hedging (suggests vs shows).
+                        Direct link.
+
+       Write top-down: 30K first (this is the hardest and forces you to actually synthesize),
+       then 3K per cluster, then 300 ft per paper. Lower layers must be consistent with the
+       upper layer — don't let a cluster paragraph or paper line contradict the 30K headline.
+
+       Before saving, run the three consistency checks from synthesis-style.md (upward,
+       downward, lateral). If any fails, fix before writing.
+- [ ] Step 11: Write {YYYY-WW}-papers.md (full list, not synthesized — for user to drill in).
+- [ ] Step 12: Write {YYYY-WW}-digest.md with frontmatter (week, window, sources_hit, kept_count,
+       dropped_count, prior_weeks_referenced) followed by the synthesized report.
+- [ ] Step 13: Append a one-line entry to README.md "Recent digests" section (top of list).
+- [ ] Step 14: Report to user: digest path, kept/dropped counts, top-3 highlights, any warnings
+       (thin week, source fetch failures, watchlist drift suggestion).
+```
+
+---
+
+## Connectors
+
+| Source   | How                                                                                     |
+| -------- | --------------------------------------------------------------------------------------- |
+| bioRxiv  | `https://api.biorxiv.org/details/biorxiv/{from}/{to}/{cursor}` via WebFetch — no auth   |
+| medRxiv  | `https://api.biorxiv.org/details/medrxiv/{from}/{to}/{cursor}` via WebFetch — no auth   |
+| PubMed   | NCBI E-utilities `esearch` + `esummary` via WebFetch (no auth). If a PubMed MCP server is configured at runtime, prefer its `search_articles` and `get_article_metadata` tools — they paginate and parse for you. |
+
+The bioRxiv/medRxiv API returns the full corpus for the window paginated by cursor (100 records per page). Keyword filtering happens client-side in `fetch-preprint-recent`. PubMed lets you push the keyword query server-side, which is why the two fetchers are separate skills.
+
+---
+
+## Historical context — how to use the last 4 digests
+
+Before synthesizing, read titles + cluster names + the 30K paragraph from the prior 4 weekly digests. Use them to:
+
+1. **Tag continuing topics**: if a cluster name from this week appeared in any of the last 4 weeks, tag the cluster header as `[continuing from YYYY-WW]`. Tells the user "this isn't a new front."
+2. **Detect resurfacing of same paper**: a preprint posted 5 weeks ago that just hit PubMed is the *same paper*. Mark it `[journal version of preprint covered YYYY-WW]` and do not let it dominate the digest.
+3. **Spot watchlist drift**: if 3+ weeks running you're keeping <3 papers per week, the watchlist is too narrow. Surface this in the closing "Notes for next week" line. Do not silently widen the watchlist.
+4. **Spot keyword bloat**: if the same kept-but-low-relevance theme keeps appearing, suggest tightening that keyword. Suggestion only — user owns the watchlist.
+
+---
+
+## Output format
+
+### `{YYYY-WW}-digest.md`
+
+```markdown
+---
+week: 2026-19
+window: 2026-05-04 to 2026-05-10
+sources_hit: [biorxiv, medrxiv, pubmed]
+fetched_total: 412
+kept_total: 17
+dropped_total: 395
+clusters: 3
+prior_weeks_referenced: [2026-18, 2026-17, 2026-16, 2026-15]
+generated: 2026-05-11
+---
+
+# Week 2026-19 Paper Digest
+
+## 30,000 ft — What changed in the field this week
+[3-5 sentence synthesis. What is the headline. What new mechanism / dataset / result actually moved.
+What did NOT change. Optional: one-line link to a continuation from last week.]
+
+## 3,000 ft — By theme
+
+### Cluster 1: {Theme name} [continuing from 2026-17]
+[2-3 sentence summary of what the cluster collectively argues, with the key disagreement or
+convergence between papers in it. Link the 1-2 most important papers inline.]
+
+### Cluster 2: {Theme name}
+...
+
+### Outliers
+- One-line each, only for single-paper themes that didn't fit any cluster but matter.
+
+## 300 ft — Papers, by cluster
+
+### Cluster 1: {Theme name}
+- **{Title}** — {first author et al.}, {source}, {YYYY-MM-DD}. {one sentence on what it does and why it
+  belongs in this cluster.} → [link]({url})
+- ...
+
+### Cluster 2: {Theme name}
+- ...
+
+## Notes for next week
+- Any thin-week warnings, watchlist drift signals, or papers worth re-checking when journal versions land.
+
+## Full list
+See `2026-19-papers.md` for the unsynthesized table of every kept paper plus the dropped-with-rationale entries.
+```
+
+### `{YYYY-WW}-papers.md`
+
+A flat table or list. Every kept paper with: title, authors (et al. after 3), source, date, DOI / URL, one-sentence abstract excerpt, relevance score, cluster assignment. Then a collapsed `<details>` with dropped papers and one-line rationale each (so the user can challenge the filter).
+
+---
+
+## Must-nots
+
+1. Never invent or guess a paper. Every entry must come from a real fetch result; cross-reference against the cached raw JSON if unsure.
+2. Never include a paper without its source URL or DOI. If the URL extraction failed, flag it and do not include the paper.
+3. Never re-summarize a paper already in any of the last 4 digests' kept lists unless its journal version just appeared — and even then, label it as such, do not give it a fresh write-up.
+4. Never silently widen the watchlist. Suggestions go in "Notes for next week"; only the user edits `watchlist.md`.
+5. Never drop the dropped-papers section. If filter rejected something, the rationale lives in `{YYYY-WW}-papers.md` so the user can audit.
+6. Never exceed 25 kept papers per week. If the field is genuinely that busy, raise the relevance threshold rather than diluting the digest.
+7. Never write outside `ops/paper-synthesizer/` or `archive/` (relative to the invocation working directory; `archive/` only on explicit user request). Never construct an absolute path.
+8. Never run a digest without reading the last 4 weeks first. Historical context is non-negotiable.
+9. Never use banned vocabulary: delve, unpack, paradigm shift, let's explore, moreover, furthermore, it's worth noting.
+10. Never claim a paper "shows X" when its abstract only "suggests X" or "is consistent with X" — preserve the paper's own hedging in the 300 ft layer.
+11. Never proceed if all three sources fail to return results. Halt, report which fetches failed, ask the user.
+12. Never assume two papers with the same title are the same record without matching DOI or first author — different research groups release similarly-titled work.
+
+---
+
+## Cadence
+
+**Monday morning, weekly.** Lookback = prior 7 days (Monday-of-this-week minus 7 → Sunday-of-prior-week, inclusive). The orchestrator file is the source of truth for the window definition; if the user runs the agent on a non-Monday, treat invocation date as the window endpoint and compute window = [invocation - 7d, invocation - 1d].
+
+**Catch-up runs** (user missed weeks): the user says "synthesize the last N weeks." Run N independent weekly passes, oldest first, so each newer pass has the prior digests as historical context.
+
+**On-demand single-paper analysis** (papers dropped in `inbox/`): out of scope for this agent in v1. If the user drops a PDF or URL there, surface it but do not parse — point them at the existing `domain-research-health-science` skill for clinical critique.

--- a/skills/fetch-preprint-recent/SKILL.md
+++ b/skills/fetch-preprint-recent/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: fetch-preprint-recent
+description: Fetches preprints posted to bioRxiv or medRxiv within a given date window, then keyword-filters the results client-side. Wraps the public `api.biorxiv.org/details/{server}/{from}/{to}/{cursor}` endpoint, handles cursor pagination, normalizes records to a stable shape (doi, title, authors, abstract, date, server, version, url), and applies a keyword-OR match against title + abstract. Domain-neutral — usable for any biology / clinical preprint scan, not just one project. Use when user mentions bioRxiv, medRxiv, weekly preprint scan, fetch preprints, last-N-days preprints, or when a literature-scan agent needs structured preprint records.
+---
+
+# fetch-preprint-recent
+
+Fetch preprints from bioRxiv or medRxiv for a date window, normalize the records, and keyword-filter them.
+
+## Workflow
+
+```
+- [ ] Step 1: Validate inputs (server, from, to, keywords)
+- [ ] Step 2: Page through the details endpoint until messages.cursor exhausted
+- [ ] Step 3: Normalize each record to the canonical shape
+- [ ] Step 4: Dedupe within the window (keep latest version per DOI)
+- [ ] Step 5: Keyword-filter on lowercased title + abstract
+- [ ] Step 6: Return matched records + a summary (total fetched, total matched, pages fetched)
+```
+
+**Step 1 — Validate inputs**
+
+Required:
+- `server`: one of `biorxiv` or `medrxiv` (the API uses these literal strings)
+- `from`: `YYYY-MM-DD`, inclusive
+- `to`: `YYYY-MM-DD`, inclusive, must be ≥ `from`
+- `keywords`: list of strings; may include multi-word phrases; case-insensitive matching
+
+Reject if window > 31 days (the API supports it but you almost never want to dump a month of preprints in one call without a stronger filter — flag and confirm).
+
+**Step 2 — Page through the endpoint**
+
+The endpoint is:
+
+```
+https://api.biorxiv.org/details/{server}/{from}/{to}/{cursor}
+```
+
+- Start with `cursor=0`.
+- The response shape is:
+  ```json
+  {
+    "messages": [{"status": "ok", "interval": "2026-05-04/2026-05-10", "cursor": "0", "count": 100, "total": 327}],
+    "collection": [ { record }, { record }, ... ]
+  }
+  ```
+- After consuming `collection`, increment `cursor` by 100 (the page size is fixed) and refetch until `cursor + count >= total`.
+- Cap pages at 20 (2,000 records) as a safety; if you hit the cap, surface a "window may be over-broad" warning and return what you have.
+
+Use WebFetch with the URL. If WebFetch returns malformed JSON or a 5xx, retry once with a 2-second backoff; on second failure, return partial results with a `fetch_errors` field listing the failed cursors.
+
+**Step 3 — Normalize each record**
+
+The API returns fields like `doi, title, authors, author_corresponding, author_corresponding_institution, date, version, type, license, category, jatsxml, abstract, published, server`. Reduce to:
+
+```json
+{
+  "id": "10.1101/2026.05.07.123456",          // doi
+  "title": "...",
+  "authors": ["Smith J", "Doe A", ...],        // split the API's `authors` string on `;`
+  "abstract": "...",
+  "date": "2026-05-07",
+  "server": "biorxiv",                          // or "medrxiv"
+  "version": 1,
+  "category": "neuroscience",                   // bioRxiv subject area
+  "url": "https://www.biorxiv.org/content/10.1101/2026.05.07.123456v1",
+  "published_doi": null                         // populated if the preprint has been published; from `published` field
+}
+```
+
+URL pattern: `https://www.{server}.org/content/{doi}v{version}` (no `https://doi.org/` redirect — direct to the preprint server keeps the abstract page accessible).
+
+**Step 4 — Dedupe within the window**
+
+The same DOI can appear with multiple `version` values if the authors revised mid-window. Keep the highest version per DOI. Drop the rest.
+
+**Step 5 — Keyword-filter**
+
+For each kept record, check whether any keyword (or phrase) appears in `lowercase(title + " " + abstract)`. Match logic:
+
+- Multi-word keyword like `"protein language model"` → must appear as a contiguous substring.
+- Single-word keyword like `"crispr"` → must appear with word boundaries (don't match `"crisper"`).
+- OR across all keywords (paper kept if any keyword matches).
+
+Track which keyword(s) matched per paper — downstream `paper-relevance-filter` will use that signal.
+
+**Step 6 — Return**
+
+Return a payload like:
+
+```json
+{
+  "server": "biorxiv",
+  "window": "2026-05-04/2026-05-10",
+  "fetched_total": 327,
+  "matched_total": 14,
+  "pages_fetched": 4,
+  "fetch_errors": [],
+  "records": [ {normalized record + "matched_keywords": [...]} , ... ]
+}
+```
+
+Cache the raw API JSON (pre-normalization) to the agent's `.cache/` directory under `{YYYY-WW}-{server}.json` so a re-run can skip the network if the user wants to re-synthesize without re-fetching.
+
+## Common Patterns
+
+**Pattern A — One server, one window**: standard call. Use this in a weekly digest.
+
+**Pattern B — Multi-week catch-up**: call once per week, never one giant 28-day window. The cursor pagination is fine but the keyword filter is more honest at weekly granularity (matches the way papers are released and discussed).
+
+**Pattern C — Preprint-only follow-up of a known paper**: if you already have a DOI, do not use this skill. Use a direct WebFetch on `https://api.biorxiv.org/details/{server}/{doi}` instead.
+
+## Guardrails
+
+1. **Don't fetch without a window.** "Recent" must always resolve to specific `from`/`to` dates before the call.
+2. **Don't keyword-filter server-side** — the API doesn't support it; attempting via URL params silently returns everything.
+3. **Don't trust the abstract field to be present.** Some entries have empty abstracts; treat those as title-only matches and flag in the output.
+4. **Don't dedupe across servers in this skill.** Cross-server dedupe (bioRxiv ↔ medRxiv ↔ PubMed) belongs to the calling agent, not here.
+5. **Don't transform DOIs.** Keep them as-returned; downstream tools rely on the exact `10.1101/...` string.
+6. **Don't claim "no papers" on a fetch error.** Distinguish "fetched and filtered to zero" from "fetch failed." The first is a thin week; the second is a bug.
+
+## Quick Reference
+
+| Field          | Source                                                        | Notes                                                           |
+| -------------- | ------------------------------------------------------------- | --------------------------------------------------------------- |
+| Endpoint       | `api.biorxiv.org/details/{server}/{from}/{to}/{cursor}`       | Same host serves both bioRxiv and medRxiv; only `{server}` varies |
+| Auth           | None                                                          | Public API. Be polite — don't hammer.                           |
+| Page size      | 100, fixed                                                    | Cursor is the offset into the window's results                  |
+| Window cap     | 31 days (soft); 7 days is the typical weekly call             | Wider windows = thousands of records before keyword filter       |
+| Rate limit     | Not formally documented; ~1 req/sec is safe                   | Backoff on 5xx                                                  |
+| URL pattern    | `https://www.{server}.org/content/{doi}v{version}`            | Linkable to abstract page                                        |
+| Server values  | `biorxiv`, `medrxiv`                                          | Case-sensitive in path                                           |

--- a/skills/fetch-pubmed-recent/SKILL.md
+++ b/skills/fetch-pubmed-recent/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: fetch-pubmed-recent
+description: Fetches PubMed articles posted in a given date window matching a keyword set, returning normalized records (PMID, title, authors, abstract, journal, date, DOI, URL). Uses NCBI E-utilities (`esearch` + `esummary` + `efetch`) via WebFetch for portability, but prefers a PubMed MCP server's `search_articles` + `get_article_metadata` tools when one is connected (faster, paginated, parsed). Builds date-bounded queries with optional MeSH expansion. Domain-neutral - usable for any PubMed scan, not just one project. Use when user mentions PubMed, NCBI, last-N-days PubMed, weekly PubMed scan, MeSH search, or when a literature-scan agent needs structured PubMed records.
+---
+
+# fetch-pubmed-recent
+
+Fetch PubMed records for a date window + keyword set. Normalize the output to the same shape as `fetch-preprint-recent` so a calling agent can dedupe across sources.
+
+## Workflow
+
+```
+- [ ] Step 1: Detect transport — prefer PubMed MCP if available, else E-utilities via WebFetch
+- [ ] Step 2: Build the keyword query with explicit date bounds
+- [ ] Step 3: Execute search → list of PMIDs (page if > 100)
+- [ ] Step 4: Fetch metadata + abstracts for each PMID batch
+- [ ] Step 5: Normalize records to canonical shape
+- [ ] Step 6: Return matched records + summary
+```
+
+**Step 1 — Detect transport**
+
+At session start the runtime exposes any connected MCP servers. Check whether tools matching `mcp__*PubMed*__search_articles` and `mcp__*PubMed*__get_article_metadata` are available.
+
+- **MCP available**: use it. The MCP wraps the same E-utilities but handles pagination and field extraction. Pass the keyword query as the search string with the date filter appended (see Step 2).
+- **MCP not available**: fall back to direct E-utilities calls via WebFetch. Endpoints:
+  - Search: `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&term={query}&retmode=json&retmax=200`
+  - Summary: `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id={pmids_csv}&retmode=json`
+  - Abstract: `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&id={pmids_csv}&rettype=abstract&retmode=xml`
+
+Both transports return the same downstream shape. The skill caller should not need to care which was used (record `transport_used` in the return summary so debugging is possible).
+
+**Step 2 — Build the date-bounded query**
+
+PubMed accepts boolean keyword expressions plus a date filter. The canonical date filter for "papers indexed in PubMed during this window" is:
+
+```
+("YYYY/MM/DD"[PDAT] : "YYYY/MM/DD"[PDAT])
+```
+
+`PDAT` is the publication date — the most stable choice for a weekly digest. (`EDAT` is the entry-into-PubMed date, useful if you want "newly indexed even if old"; `MHDA` is the MeSH-indexed date. Default `PDAT`.)
+
+For each watchlist keyword, expand into a sub-query:
+
+- Plain term: `"protein language model"[Title/Abstract]`
+- Term + MeSH: `("Alzheimer Disease"[MeSH] OR "alzheimer's disease"[Title/Abstract])` — only when the keyword has a clean MeSH match the caller has confirmed; do not auto-MeSH-expand or you'll widen the net unpredictably.
+
+Combine sub-queries with OR, then AND the date filter:
+
+```
+(("term1"[Title/Abstract]) OR ("term2"[Title/Abstract]) OR ...) AND ("2026/05/04"[PDAT] : "2026/05/10"[PDAT])
+```
+
+Watch out for special characters — escape `()` inside terms by quoting the term.
+
+**Step 3 — Execute search**
+
+Call the search tool. Expected output is a list of PMIDs and a count.
+
+If `count > 200`, page: rerun the search with `retstart=200`, `retstart=400`, etc. Cap at 1,000 PMIDs (5 pages). If a 7-day window matches more than 1,000 records, the keyword set is too broad — surface this and ask the calling agent to tighten.
+
+**Step 4 — Fetch metadata + abstracts**
+
+Batch the PMIDs (200 per esummary call). Pull:
+
+- PMID
+- Title
+- Authors (full list — keep in order; `et al.` truncation is the digest's job, not this skill's)
+- Journal name (`fulljournalname`)
+- Publication date (`pubdate`, `sortpubdate`)
+- DOI (`articleids[].idtype == 'doi'`)
+- Abstract (separate `efetch` call with `rettype=abstract` since esummary doesn't return abstracts)
+
+Abstract fetch is the slow part. Batch 100 PMIDs at a time. If abstract fetch fails for a record, keep it but with `abstract: null` and a `warnings` flag.
+
+**Step 5 — Normalize**
+
+Same canonical shape as `fetch-preprint-recent`:
+
+```json
+{
+  "id": "PMID:39123456",                                  // PMID-prefixed for source clarity
+  "title": "...",
+  "authors": ["Smith J", "Doe A", ...],
+  "abstract": "...",
+  "date": "2026-05-07",                                   // YYYY-MM-DD parsed from pubdate
+  "server": "pubmed",
+  "journal": "Nature Biotechnology",
+  "doi": "10.1038/s41587-026-12345-6",                    // if present
+  "url": "https://pubmed.ncbi.nlm.nih.gov/39123456/",
+  "matched_keywords": ["protein language model"]
+}
+```
+
+URL pattern: `https://pubmed.ncbi.nlm.nih.gov/{pmid}/` — the canonical PubMed link. Optional secondary URL via DOI: `https://doi.org/{doi}` for the publisher's page.
+
+**Step 6 — Return**
+
+```json
+{
+  "server": "pubmed",
+  "transport_used": "mcp" | "eutils",
+  "window": "2026-05-04/2026-05-10",
+  "query": "(...full query string...)",
+  "fetched_total": 47,
+  "matched_total": 47,                       // PubMed filter is server-side, so fetched == matched
+  "fetch_errors": [],
+  "records": [ ... ]
+}
+```
+
+Cache the raw search + metadata responses to `.cache/{YYYY-WW}-pubmed.json`.
+
+## Common Patterns
+
+**Pattern A — Standard weekly scan**: PDAT-bounded query with all watchlist keywords OR'd together. The default.
+
+**Pattern B — Newly-indexed reach-back**: when the user wants "papers PubMed indexed this week, even if published earlier" (useful for older preprints just appearing in PubMed), swap `PDAT` for `EDAT`. Document the choice in the digest.
+
+**Pattern C — High-precision MeSH-only search**: when keyword matching is producing too much noise, ask the user for the exact MeSH headings they care about and search `term[MeSH]` only. Higher precision, lower recall.
+
+**Pattern D — Author-specific watch**: outside this skill's default scope but easy — add `(Smith J[Author] OR Doe A[Author])` as an additional OR clause to the keyword group.
+
+## Guardrails
+
+1. **Always include the date bound.** A keyword-only PubMed query returns the entire PubMed history for the term. Forgetting `PDAT` is the bug that turns a 7-paper digest into a 70,000-paper data dump.
+2. **Don't auto-expand keywords to MeSH.** PubMed's automatic-term-mapping silently expands "Alzheimer" to a MeSH tree; that's the right call for a clinician but the wrong call for a curated keyword digest. Quote keywords with `[Title/Abstract]` to disable expansion unless MeSH expansion is explicitly requested.
+3. **Don't trust the first abstract API call to succeed.** `efetch` with `rettype=abstract` occasionally times out for batches > 100. On failure, halve the batch and retry; only after two full halvings do you give up on a record.
+4. **Don't strip the `PMID:` prefix from `id`.** It distinguishes PubMed records from preprint DOIs at a glance — important during cross-source dedupe in the caller.
+5. **Don't dedupe against bioRxiv/medRxiv inside this skill.** Cross-source dedupe is the caller's job.
+6. **Respect the rate limit.** NCBI allows 3 requests/second without an API key, 10/second with one. Pace accordingly. If a key is in the env (`NCBI_API_KEY`), include it as `&api_key=...`.
+7. **Don't claim a record is "in PubMed" just because esearch returned its PMID.** Some PMIDs are MEDLINE-status `Publisher` (in-process, not yet fully indexed). Fine to include but note `status` if available.
+
+## Quick Reference
+
+| Field          | E-utilities (fallback)                                                   | MCP (preferred)                       |
+| -------------- | ------------------------------------------------------------------------ | ------------------------------------- |
+| Search         | `esearch.fcgi?db=pubmed&term={q}&retmode=json`                            | `search_articles(query=...)`          |
+| Metadata       | `esummary.fcgi?db=pubmed&id={pmids}&retmode=json`                         | `get_article_metadata(pmids=...)`     |
+| Abstract       | `efetch.fcgi?db=pubmed&id={pmids}&rettype=abstract&retmode=xml`           | included in metadata when MCP returns it |
+| Date filter    | `("YYYY/MM/DD"[PDAT] : "YYYY/MM/DD"[PDAT])`                              | same — pass inside query string       |
+| Page size      | 200 (search), 100-200 (summary), 100 (abstract)                          | MCP server's choice                   |
+| Auth           | optional `api_key` query param (3 → 10 rps)                              | per MCP server config                 |
+| Canonical URL  | `https://pubmed.ncbi.nlm.nih.gov/{pmid}/`                                |                                       |

--- a/skills/paper-cluster-by-theme/SKILL.md
+++ b/skills/paper-cluster-by-theme/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: paper-cluster-by-theme
+description: Groups a set of kept papers into 2-5 thematic clusters before synthesis, using abstract semantics + matched-keyword overlap. Names each cluster with a short noun phrase that describes what the cluster argues, not just the topic. Surfaces an "outliers" bucket for single-paper themes that don't fit. Domain-neutral - usable for any literature-scan workflow. Use after relevance filtering and before writing the synthesis report. Trigger keywords - cluster papers, group by theme, thematic clusters, paper themes, organize papers.
+---
+
+# paper-cluster-by-theme
+
+Take a list of relevance-filtered papers and produce thematic clusters that the synthesis layer can write *about* rather than *list*.
+
+A "cluster" here is not a topic label — it's an argument. "Diffusion models for protein design" is a topic. "Diffusion models are converging on AlphaFold-comparable accuracy without MSAs" is a theme. The synthesis is much stronger when clusters describe what the papers collectively *argue*.
+
+## Workflow
+
+```
+- [ ] Step 1: Read all kept papers' titles, abstracts, and matched keywords
+- [ ] Step 2: Identify 2-5 candidate themes from the abstract content
+- [ ] Step 3: Assign each paper to its best-fit theme (or to outliers)
+- [ ] Step 4: Re-name each theme as an argument-shaped phrase
+- [ ] Step 5: Validate clusters (no empty cluster, no over-stuffed cluster, no paper in two)
+- [ ] Step 6: Return clusters + outliers + assignment rationale
+```
+
+**Step 1 — Read inputs**
+
+The skill takes a list of records (the KEEP set from `paper-relevance-filter`). It needs `id`, `title`, `abstract`, and `matched_keywords` for each.
+
+**Step 2 — Candidate themes**
+
+Two signals to use, in order:
+
+1. **Matched-keyword groupings** (cheap, mechanical): if half the kept papers all share one keyword, that's a strong candidate cluster. Group by the most common matched keyword first; this gets you 70% of the way for a focused watchlist.
+2. **Abstract semantics** (qualitative): for papers grouped by the same keyword but doing different *kinds* of work (e.g., review vs benchmark vs new method), split into sub-clusters. Conversely, for papers in different keyword groups that read like the same argument (e.g., a methods paper and an application paper extending it), merge.
+
+Aim for 2-5 clusters. Hard cap at 5 — beyond that, the synthesis layer cannot say anything coherent about each. If you have only 2-3 papers total and they don't form a theme, return one cluster called "Notable single papers" — do not force 3 clusters of 1.
+
+**Step 3 — Assign papers**
+
+Each paper goes to exactly one cluster (or outliers). When a paper plausibly fits two, choose the cluster where the paper's *contribution* (read from the abstract's last 1-2 sentences) is the better fit — not just where its keywords match. Note the alternative in `also_fits`.
+
+**Outliers**: a paper with no good cluster fit. Do not exceed 3-4 outliers; if you have more, your clustering is too narrow — go back to Step 2 and split a cluster.
+
+**Step 4 — Argument-shaped names**
+
+Bad cluster names:
+- "Protein design"
+- "Single-cell papers"
+- "AI in biology"
+
+Good cluster names (argument-shaped):
+- "Protein design moves from sequence-only to sequence+structure conditioning"
+- "Single-cell methods converge on multi-modal embeddings as default"
+- "AI-discovered targets are being re-validated with classical biology"
+
+A good name is a one-line argument the cluster collectively makes. If you can't write that argument because the papers in the cluster disagree, that's actually fine — name it as a tension: "Disagreement on whether X requires Y."
+
+**Step 5 — Validate**
+
+Reject and redo if:
+- Any cluster has 0 papers (delete it)
+- Any cluster has > 70% of papers (split it)
+- Any paper appears in two clusters (force-pick one)
+- Total clusters > 5 (merge nearest two)
+- Outliers > 4 (split a cluster to absorb)
+
+**Step 6 — Return**
+
+```json
+{
+  "clusters": [
+    {
+      "name": "Protein design moves from sequence-only to sequence+structure conditioning",
+      "rationale": "Three of the kept papers (P1, P2, P5) all argue that adding structural context at training time outperforms sequence-only baselines. P5 disagrees on the magnitude.",
+      "papers": ["10.1101/2026.05.07.123456", "PMID:39000001", "10.1101/2026.05.06.654321"],
+      "tension": "P5 reports smaller gains than P1; worth noting in synthesis."
+    },
+    {
+      "name": "Single-cell foundation models start releasing benchmarks, not just weights",
+      "rationale": "Two papers (P3, P7) release benchmark suites alongside the model.",
+      "papers": ["PMID:39000002", "10.1101/2026.05.05.111111"],
+      "tension": null
+    }
+  ],
+  "outliers": [
+    {
+      "id": "PMID:39111222",
+      "rationale": "Single paper on cryo-EM segmentation; doesn't fit either cluster but matches watchlist."
+    }
+  ],
+  "summary": {
+    "input_papers": 17,
+    "cluster_count": 3,
+    "outlier_count": 2,
+    "largest_cluster_size": 6,
+    "smallest_cluster_size": 3
+  }
+}
+```
+
+## Common Patterns
+
+**Pattern A — Focused watchlist, week with 5-15 papers**: typically 2-3 strong clusters + 1-2 outliers. The default.
+
+**Pattern B — Broad watchlist, week with 20+ papers**: 4-5 clusters; cluster names get more specific (one keyword's worth each). Risk: cluster names become topic labels rather than arguments. Push back on yourself.
+
+**Pattern C — Thin week (3-5 kept papers)**: skip clustering. Return one cluster "Notable single papers" with all of them. The synthesis layer will write per-paper rather than per-theme.
+
+**Pattern D — Disagreement-heavy week**: when 2+ papers in a cluster directly contradict each other on a finding, name the cluster as the tension and call this out in `tension`. The synthesis layer treats this as a high-value 30K-ft observation.
+
+## Guardrails
+
+1. **Never name a cluster after a topic when you can name it after an argument.** Topic names tell the user what the papers are about; argument names tell them what to take away. The latter is the whole point of the digest.
+2. **Never put a paper in two clusters.** If it fits two, the second one goes in `also_fits` as a note, not as a duplicate assignment.
+3. **Never exceed 5 clusters.** The synthesis layer renders one paragraph per cluster; 6+ is unreadable.
+4. **Never coerce 3 clusters when there are clearly 2.** A real "1 cluster + 4 outliers" week is honest. A faked "3 clusters of 1-2 papers each" is noise.
+5. **Never cluster by source.** "All the bioRxiv papers" is not a theme. Source belongs in the per-paper line, not the cluster name.
+6. **Never cluster by date within the week.** Same reason — temporal proximity is not a theme.
+7. **Always cite the rationale.** Each cluster has a `rationale` field that names which papers anchor the theme and how. Without it the synthesis writer has to re-derive your reasoning.
+
+## Quick Reference
+
+| Cluster count | When                                               |
+| ------------- | -------------------------------------------------- |
+| 1             | Thin week (≤ 5 papers, no real grouping)           |
+| 2-3           | Default for focused weekly digest                  |
+| 4-5           | Broad watchlist or unusually busy week             |
+| 6+            | Reject — merge until ≤ 5                           |
+
+| Naming test                                                      | Pass? |
+| ---------------------------------------------------------------- | ----- |
+| Is the name a noun phrase that could be a topic in a textbook?   | FAIL  |
+| Does the name name an argument or a tension?                     | PASS  |
+| Could a reader predict the cluster's content from the name?      | PASS  |
+| Could you swap two clusters' names and have it still make sense? | FAIL — names are too generic |

--- a/skills/paper-relevance-filter/SKILL.md
+++ b/skills/paper-relevance-filter/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: paper-relevance-filter
+description: Scores a candidate paper against a keyword watchlist and a relevance-criteria document, returning KEEP/DROP/REVIEW with a one-line rationale and a 0-100 relevance score. Combines keyword-match strength, criteria-fit, and a historical-context check (was this paper or its preprint already covered in a recent digest). Domain-neutral - usable for any literature-scan workflow. Use after fetching candidate papers from bioRxiv, medRxiv, or PubMed and before clustering or synthesis. Trigger keywords - paper relevance, filter papers, keep or drop, score papers, relevance rationale.
+---
+
+# paper-relevance-filter
+
+Decide whether a fetched paper belongs in this week's digest. Output is a per-paper decision (KEEP / DROP / REVIEW), a 0-100 score, and a one-line rationale that the user can audit.
+
+## Workflow
+
+```
+- [ ] Step 1: Load relevance criteria + the watchlist + last-4-weeks kept-paper IDs
+- [ ] Step 2: Score each paper on three axes (match, criteria, novelty)
+- [ ] Step 3: Combine to a 0-100 score; map to KEEP / REVIEW / DROP via thresholds
+- [ ] Step 4: Apply tie-breakers (cap output at requested max kept count)
+- [ ] Step 5: Return decisions + a calibration summary
+```
+
+**Step 1 — Inputs**
+
+The caller hands the skill:
+- `papers`: list of normalized paper records (output of `fetch-preprint-recent` or `fetch-pubmed-recent`)
+- `watchlist`: list of keywords/phrases (with optional weights — default weight 1.0)
+- `criteria`: text from `relevance-criteria.md` describing what fits and what doesn't
+- `prior_ids`: set of `id` values that appeared as KEEP in any of the last 4 digests (used for novelty)
+- `max_kept`: target ceiling, e.g. 25 (the digest will not exceed this)
+
+**Step 2 — Three-axis scoring**
+
+For each paper, compute three sub-scores in [0, 1]:
+
+**Axis 1 — Match strength (0-1)**
+- 0.0 if no watchlist keyword appears in title or abstract
+- 0.5 if a keyword appears once in the abstract only
+- 0.7 if a keyword appears in the abstract more than once OR in title once
+- 1.0 if a keyword appears in the title AND abstract, or multiple distinct keywords match
+
+If keywords carry weights (some matter more than others), use the max weight among matched keywords as a multiplier capped at 1.0.
+
+**Axis 2 — Criteria fit (0-1)**
+This is the qualitative axis. Read the abstract against the relevance-criteria document. The criteria typically state:
+- In-scope concepts (the field/method the user actually wants)
+- Out-of-scope concepts (look-alikes the keyword filter might let through)
+- Required minimums (e.g., "must report empirical results", "must be primary research, not commentary")
+
+Score:
+- 1.0 — clearly in-scope, meets minimums, no look-alike traps triggered
+- 0.7 — in-scope but borderline (review article on the topic; short report; preprint with no methods detail in abstract)
+- 0.4 — partially in-scope (touches the topic but the paper's main subject is elsewhere)
+- 0.0 — out-of-scope or trips an explicit exclusion (e.g., "exclude pure-theory papers" and the abstract is pure theory)
+
+If the criteria document is silent on a paper's territory, default to 0.7 and flag for REVIEW.
+
+**Axis 3 — Novelty (0-1)**
+- 1.0 if `id` is not in `prior_ids` and the title doesn't fuzzy-match any prior title
+- 0.5 if a prior preprint version exists in `prior_ids` (e.g., same DOI prefix `10.1101/...` matched, this is a journal version) — KEEP-worthy but tag as "journal version of preprint covered YYYY-WW"
+- 0.0 if exact `id` match in `prior_ids` (already covered)
+
+Use normalized title (lowercase, strip punctuation, collapse whitespace) for fuzzy matching. A Levenshtein ratio > 0.9 against any prior title counts as a match.
+
+**Step 3 — Combine and threshold**
+
+```
+score = 100 * (0.45 * match + 0.45 * criteria + 0.10 * novelty)
+```
+
+Match and criteria carry equal weight (a paper that mentions your keywords once but is wildly out-of-topic should not score higher than one that's deeply on-topic with a single mention). Novelty is a small finger on the scale — enough to demote already-covered work but not enough to drop a genuinely important journal-version-of-preprint update.
+
+Decision thresholds (default; the calling agent may override):
+
+| Score    | Decision | Notes                                                          |
+| -------- | -------- | -------------------------------------------------------------- |
+| 70-100   | KEEP     | Goes into the digest                                           |
+| 50-69    | REVIEW   | Boundary cases — caller decides whether to escalate to user    |
+| 0-49     | DROP     | Filtered out, reason logged in the dropped-papers section      |
+
+Special-case override: if `novelty == 0.0` (already in a prior digest), force DROP regardless of score. The papers section may still list it as "already covered" for traceability.
+
+**Step 4 — Tie-breakers when KEEP > max_kept**
+
+When more papers score ≥ 70 than `max_kept`:
+
+1. Re-score with stricter axis-2 thresholds (review articles drop from 0.7 to 0.4; partial-fit drops from 0.4 to 0.2). This is the cleanest tightening.
+2. If still over, sort KEEPs by score descending, take the top `max_kept`, and demote the rest to REVIEW (not DROP — they were good enough; just couldn't fit). Surface this in the calibration summary.
+
+Never demote to DROP what scored ≥ 70 unless explicitly forced.
+
+**Step 5 — Return**
+
+```json
+{
+  "decisions": [
+    {
+      "id": "10.1101/2026.05.07.123456",
+      "decision": "KEEP",
+      "score": 84,
+      "axes": {"match": 0.9, "criteria": 1.0, "novelty": 1.0},
+      "rationale": "Title + abstract hit 'protein language model' twice; in-scope (primary methods paper, empirical); novel.",
+      "tags": []
+    },
+    {
+      "id": "PMID:39000000",
+      "decision": "KEEP",
+      "score": 72,
+      "axes": {"match": 1.0, "criteria": 0.7, "novelty": 0.5},
+      "rationale": "Strong keyword match; review article (criteria penalty); journal version of preprint covered 2026-15.",
+      "tags": ["journal-version-of:2026-15"]
+    },
+    {
+      "id": "PMID:39111111",
+      "decision": "DROP",
+      "score": 31,
+      "axes": {"match": 0.5, "criteria": 0.0, "novelty": 1.0},
+      "rationale": "'protein language model' appears once in abstract but the paper is a clinical trial enrollment report — out of scope.",
+      "tags": ["look-alike-trap"]
+    }
+  ],
+  "calibration": {
+    "kept": 17,
+    "review": 3,
+    "dropped": 84,
+    "force_dropped_already_covered": 2,
+    "demoted_for_cap": 0,
+    "stricter_pass_applied": false
+  }
+}
+```
+
+## Common Patterns
+
+**Pattern A — Strict weekly digest**: defaults above. Tight thresholds; max_kept=25.
+
+**Pattern B — Catch-up over multiple weeks**: run per-week with the same prior_ids growing each iteration. Don't pool all 3 weeks of papers and filter once — you'll lose the historical-context signal.
+
+**Pattern C — Topic deep-dive (user wants more, not less)**: relax max_kept to a high number (e.g. 100), keep thresholds, return the full ranked list. Only do this on explicit user request.
+
+**Pattern D — Sanity-check the watchlist itself**: run with `prior_ids = []` and look at calibration.dropped. If the same theme keeps getting dropped for criteria reasons, the watchlist may be drifting away from intent.
+
+## Guardrails
+
+1. **Never decide based on title alone if the abstract is available.** Titles overstate; abstracts qualify.
+2. **Never KEEP a paper whose abstract isn't returned.** Tag it REVIEW so the user can decide; an empty abstract is a signal something went wrong upstream, not a green light.
+3. **Always explain the DROP.** A one-line rationale per dropped paper is non-negotiable — without it the user cannot audit the filter or notice systematic blind spots.
+4. **Don't conflate "out of scope" with "low quality".** This skill judges fit, not quality. A high-quality paper outside scope is a DROP; a low-quality paper inside scope is a KEEP with a rationale flag.
+5. **Don't auto-update the watchlist.** If you notice the criteria are pulling in a class of papers the watchlist doesn't anticipate, surface it in the calibration summary; the user owns the watchlist edit.
+6. **Don't dedupe inside this skill.** The caller is responsible for cross-source dedupe (a bioRxiv preprint and its PubMed publication are *the same paper* and must be merged before this skill sees them, otherwise novelty scoring breaks).
+7. **Don't use unbounded LLM judgment for axis 2.** Keep the criteria-fit decision anchored to the explicit `relevance-criteria.md` text. If something's not in the criteria, the answer is REVIEW with rationale "criteria silent" — not "I think it fits."
+
+## Quick Reference
+
+| Decision | Score | Action by caller                                     |
+| -------- | ----- | ---------------------------------------------------- |
+| KEEP     | 70+   | Include in digest, cluster, synthesize                |
+| REVIEW   | 50-69 | Surface in a "boundary cases" section, ask user       |
+| DROP     | 0-49  | Log in dropped-papers list with rationale             |
+
+| Axis     | Default weight | What it measures                                    |
+| -------- | -------------- | --------------------------------------------------- |
+| Match    | 0.45           | How strongly watchlist keywords appear in title/abs |
+| Criteria | 0.45           | Qualitative fit against `relevance-criteria.md`     |
+| Novelty  | 0.10           | Not already in last-4-weeks digests                 |


### PR DESCRIPTION
## Summary

- Adds `paper-synthesizer` agent: a weekly research-paper digest that scans bioRxiv, medRxiv, and PubMed for the prior 7 days against a keyword watchlist, filters for relevance, clusters by theme, and writes a layered-reasoning synthesis (30K / 3K / 300 ft) with paper links. Reads the last 4 weeks of digests for continuity.
- Adds 4 supporting skills (all domain-neutral, reusable for any literature-scan workflow):
  - `fetch-preprint-recent` — bioRxiv / medRxiv fetcher (cursor pagination + client-side keyword filter)
  - `fetch-pubmed-recent` — PubMed fetcher; prefers PubMed MCP server when connected, falls back to NCBI E-utilities; PDAT date-bounded queries
  - `paper-relevance-filter` — KEEP/REVIEW/DROP with a three-axis score (match strength × criteria fit × novelty against last-4-weeks history)
  - `paper-cluster-by-theme` — produces 2-5 argument-shaped clusters (rejects topic labels in favor of cluster claims)
- README updated: badge counts (skills 205→209, agents 37→38), description line, "I want to…" table, mermaid diagram, agents table, Research & Evidence index split into "Research design & evaluation" + "Literature scan" sub-sections.

## Design notes

- **Path-agnostic**: agent and skills carry no absolute paths and no machine-specific assumptions. The operator runs the agent from their local project folder; the orchestrator file (lives outside this repo) is the only place absolute paths exist. Anyone who clones the agent can point it at their own project.
- **Layered-reasoning mapping for this use case** is intentionally pushed into the operator's local `synthesis-style.md` (read by the agent at runtime), not baked into the agent file — so the synthesis style is tunable per operator without forking the agent.
- **Cross-source dedupe** (a bioRxiv preprint and its PubMed published version are the same paper) happens in the agent pipeline, not inside the fetch skills, so the skills stay single-purpose.
- **Why these 4 skills, not more**: the synthesis itself uses the existing `layered-reasoning` skill; nothing new needed there. Single-paper PDF analysis is intentionally out of v1 scope.

## Test plan

- [ ] `paper-synthesizer` agent loads correctly when invoked (visible in agent list, frontmatter parses)
- [ ] All 4 new skills load correctly (visible in skill list, YAML descriptions parse, `name` matches directory)
- [ ] Agent's pipeline runs end-to-end against a real watchlist for a 7-day window — confirm bioRxiv / medRxiv / PubMed fetches return, filter scores, clusters get named, synthesis writes
- [ ] Cross-source dedupe collapses preprint ↔ published-version pairs correctly
- [ ] `{YYYY-WW}-digest.md` and `{YYYY-WW}-papers.md` both produced; cache JSON written to `.cache/`
- [ ] Re-run on same window reads cache (or detects cache and offers re-synthesize without re-fetch)
- [ ] Mermaid diagram in README renders with the new `paper-synthesizer` node

🤖 Generated with [Claude Code](https://claude.com/claude-code)