### PR TITLE
paper-synthesizer: add arXiv as a fourth source (CS / ML coverage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Claude Code Skills Collection
 
-![Skills](https://img.shields.io/badge/skills-209-blue) ![Agents](https://img.shields.io/badge/agents-38-blue) ![Status](https://img.shields.io/badge/status-active-brightgreen) [![Run in Smithery](https://smithery.ai/badge/skills/lyndonkl)](https://smithery.ai/skills?ns=lyndonkl&utm_source=github&utm_medium=badge)
+![Skills](https://img.shields.io/badge/skills-210-blue) ![Agents](https://img.shields.io/badge/agents-38-blue) ![Status](https://img.shields.io/badge/status-active-brightgreen) [![Run in Smithery](https://smithery.ai/badge/skills/lyndonkl)](https://smithery.ai/skills?ns=lyndonkl&utm_source=github&utm_medium=badge)
 
-A production-ready library of **209 skills** and **38 orchestrating agents** for Claude Code — covering thinking frameworks, research, writing, design, data/ML, corporate finance, game theory, fantasy baseball, household personal finance, and a 9-agent team for growing a Substack publication.
+A production-ready library of **210 skills** and **38 orchestrating agents** for Claude Code — covering thinking frameworks, research, writing, design, data/ML, corporate finance, game theory, fantasy baseball, household personal finance, and a 9-agent team for growing a Substack publication.
 
 **Install in 30 seconds:**
 
@@ -30,7 +30,7 @@ Pick the fastest entry point for what you're trying to do. Most users start with
 | Build a GraphRAG / knowledge-graph retrieval system | [`graphrag-specialist`](agents/graphrag-specialist.md) |
 | Design equivariant / symmetry-aware neural networks | [`geometric-deep-learning-architect`](agents/geometric-deep-learning-architect.md) |
 | Build geometric intuition for ML math (attention, PCA, eigenvectors, high-dim spaces) | [`math-intuition-coach`](agents/math-intuition-coach.md) |
-| Get a weekly digest of new bioRxiv / medRxiv / PubMed papers against my keyword watchlist | [`paper-synthesizer`](agents/paper-synthesizer.md) |
+| Get a weekly digest of new bioRxiv / medRxiv / PubMed / arXiv papers (life sciences + CS / ML) against my keyword watchlist | [`paper-synthesizer`](agents/paper-synthesizer.md) |
 | Grow my Substack / publish intuition-first ML & systems essays | [`librarian`](agents/librarian.md), [`intuition-builder`](agents/intuition-builder.md), [`editor`](agents/editor.md) + 6 more (see `~/Documents/Thinking/substacker/`) |
 | Use just one tool (no agent) | Browse the [Skills Index](#skills-index) below |
 
@@ -50,7 +50,7 @@ flowchart LR
     D -->|Math intuition| MI[math-intuition-<br/>coach]
     D -->|Weekly paper digest| PS[paper-synthesizer]
     D -->|One-off tool| SK[Skills Index ▾]
-    CA & WA & SF & CD & MLB & HF & GR & GDL & MI & PS --> S[(209 skills)]
+    CA & WA & SF & CD & MLB & HF & GR & GDL & MI & PS --> S[(210 skills)]
     SK --> S
 ```
 
@@ -68,7 +68,7 @@ Agents detect your need and route to the right skills. Each agent's page documen
 | [**cognitive-design-architect**](agents/cognitive-design-architect.md) | Cognitive design, information architecture, D3 viz, fallacy check |
 | [**geometric-deep-learning-architect**](agents/geometric-deep-learning-architect.md) | Symmetry discovery → group ID → equivariant architecture |
 | [**math-intuition-coach**](agents/math-intuition-coach.md) | 3Blue1Brown-style geometric intuition for any ML/data math (attention, PCA, gradients, high-dim spaces) |
-| [**paper-synthesizer**](agents/paper-synthesizer.md) | Weekly bioRxiv / medRxiv / PubMed digest against a keyword watchlist; clusters by theme; layered-reasoning synthesis with paper links |
+| [**paper-synthesizer**](agents/paper-synthesizer.md) | Weekly bioRxiv / medRxiv / PubMed / arXiv digest against a keyword watchlist (life sciences + CS / ML); clusters by theme; layered-reasoning synthesis with paper links |
 | [**graphrag-specialist**](agents/graphrag-specialist.md) | Knowledge graph construction, embedding fusion, retrieval orchestration |
 | [**company-analyst**](agents/company-analyst.md) | End-to-end company valuation → buy/sell/hold recommendation |
 | [**special-situations-analyst**](agents/special-situations-analyst.md) | Distressed / private / high-growth / financial-firm valuation |
@@ -105,7 +105,7 @@ Agents detect your need and route to the right skills. Each agent's page documen
 
 ## Skills Index
 
-**209 skills** across 7 super-categories. Every skill's full methodology, templates, and evaluation rubric live in its `SKILL.md` — click any entry to drill in.
+**210 skills** across 7 super-categories. Every skill's full methodology, templates, and evaluation rubric live in its `SKILL.md` — click any entry to drill in.
 
 <details>
 <summary><b>🧠 Thinking & Decisions</b> — decision-making, problem-solving, estimation, dialogue, ideation, learning (37 skills)</summary>
@@ -168,7 +168,7 @@ Agents detect your need and route to the right skills. Each agent's page documen
 </details>
 
 <details>
-<summary><b>🔬 Research & Evidence</b> — research design, evidence evaluation, rubrics, ethics, literature scan (10 skills)</summary>
+<summary><b>🔬 Research & Evidence</b> — research design, evidence evaluation, rubrics, ethics, literature scan (11 skills)</summary>
 
 ### Research design & evaluation
 
@@ -185,6 +185,7 @@ Domain-neutral primitives for any weekly paper-digest workflow. Powers the `pape
 
 - **[fetch-preprint-recent](skills/fetch-preprint-recent/SKILL.md)** — Fetch bioRxiv / medRxiv preprints for a date window with cursor pagination and client-side keyword filter.
 - **[fetch-pubmed-recent](skills/fetch-pubmed-recent/SKILL.md)** — Fetch PubMed records for a date window via PubMed MCP when available, E-utilities fallback otherwise.
+- **[fetch-arxiv-recent](skills/fetch-arxiv-recent/SKILL.md)** — Fetch arXiv papers for a date window with optional category restriction (cs.LG, cs.CL, stat.ML, q-bio.QM, etc.); Atom XML parsing.
 - **[paper-relevance-filter](skills/paper-relevance-filter/SKILL.md)** — Score candidate papers KEEP / REVIEW / DROP on match strength + criteria fit + novelty against last-4-weeks history.
 - **[paper-cluster-by-theme](skills/paper-cluster-by-theme/SKILL.md)** — Group filtered papers into 2-5 argument-shaped clusters before synthesis.
 

--- a/agents/paper-synthesizer.md
+++ b/agents/paper-synthesizer.md
@@ -1,14 +1,16 @@
 ---
 name: paper-synthesizer
-description: Weekly research-paper digest. Each Monday, scans bioRxiv, medRxiv, and PubMed for papers posted in the prior 7 days against a persistent keyword watchlist (with optional per-week overrides), filters for relevance, clusters by theme, and produces a layered-reasoning synthesis (30,000 ft → 3,000 ft → 300 ft) with direct paper links. Reads the last 4 weeks of digests so it can label topics as continuing vs new and avoid re-summarizing the same work. The orchestrator (a local file in the operator's project folder) decides where the project lives and invokes this agent from that folder; this agent's paths are all relative to the current working directory. Trigger keywords - weekly papers, paper digest, literature scan, bioRxiv weekly, medRxiv, PubMed weekly, paper synthesis, what's new in [field], scan the literature.
+description: Weekly research-paper digest spanning life sciences and computer science. Each Monday, scans bioRxiv, medRxiv, PubMed, and arXiv (configurable category subset — typically cs.LG / cs.CL / cs.CV / stat.ML for CS-focused weeks, q-bio.* for cross-disciplinary, or all of arXiv for the widest net) for papers posted in the prior 7 days against a persistent keyword watchlist (with optional per-week overrides), filters for relevance, clusters by theme, and produces a layered-reasoning synthesis (30,000 ft → 3,000 ft → 300 ft) with direct paper links. Reads the last 4 weeks of digests so it can label topics as continuing vs new and avoid re-summarizing the same work. The orchestrator (a local file in the operator's project folder) decides where the project lives and which arXiv categories to use; invokes this agent from that folder; this agent's paths are all relative to the current working directory. Trigger keywords - weekly papers, paper digest, literature scan, bioRxiv weekly, medRxiv, PubMed weekly, arXiv weekly, CS papers, ML papers, paper synthesis, what's new in [field], scan the literature.
 tools: Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
-skills: fetch-preprint-recent, fetch-pubmed-recent, paper-relevance-filter, paper-cluster-by-theme, layered-reasoning
+skills: fetch-preprint-recent, fetch-pubmed-recent, fetch-arxiv-recent, paper-relevance-filter, paper-cluster-by-theme, layered-reasoning
 model: inherit
 ---
 
 # The Paper Synthesizer Agent
 
-Weekly research-paper compressor for a persistent keyword watchlist. Reads bioRxiv, medRxiv, and PubMed; emits one synthesized digest per week with paper links and a layered-reasoning structure. Maintains historical context across weeks so topics can be labeled as continuing, new, or refuted.
+Weekly research-paper compressor for a persistent keyword watchlist spanning life sciences and computer science. Reads bioRxiv, medRxiv, PubMed, and arXiv; emits one synthesized digest per week with paper links and a layered-reasoning structure. Maintains historical context across weeks so topics can be labeled as continuing, new, or refuted.
+
+The four sources cover different fields by design — bioRxiv + medRxiv for biology / clinical preprints, PubMed for the published literature across life sciences, arXiv for CS / ML / stats / math / physics / quantitative-biology preprints. The operator's `source-registry.md` controls which arXiv categories to query (omit categories to search all of arXiv).
 
 **Project root.** This agent does not resolve paths to disk. It is invoked by the operator's orchestrator (a local file in their project folder), which sets the working directory before invocation. All paths in this file are relative to that working directory. Before doing anything else, the agent confirms it can see `orchestrator.md`, `shared-context/watchlist.md`, and `ops/paper-synthesizer/` from the current working directory; if any are missing, it halts and reports rather than guessing.
 
@@ -56,10 +58,16 @@ Monday weekly run:
 - [ ] Step 3: Fetch bioRxiv for window via fetch-preprint-recent (server="biorxiv").
 - [ ] Step 4: Fetch medRxiv for window via fetch-preprint-recent (server="medrxiv").
 - [ ] Step 5: Fetch PubMed for window via fetch-pubmed-recent.
-       Cache raw responses to .cache/{YYYY-WW}-{source}.json.
-- [ ] Step 6: Dedupe across sources. A PubMed record can be the published version of a bioRxiv preprint;
-       collapse on DOI when shared, otherwise on (lowercased, normalized) title + first author.
-       When collapsed, prefer the PubMed record but keep the preprint URL as a "preprint version" link.
+- [ ] Step 5b: Fetch arXiv for window via fetch-arxiv-recent. Pass the `arxiv_categories` list from
+       `source-registry.md` (omit to search all of arXiv). Source-registry decides whether the operator
+       wants CS-only (cs.LG / cs.CL / cs.CV / cs.AI / stat.ML), cross-disciplinary, or everything.
+       Cache raw responses to .cache/{YYYY-WW}-{source}.json (one per source).
+- [ ] Step 6: Dedupe across sources. A PubMed record can be the published version of a bioRxiv preprint
+       or an arXiv paper; an arXiv paper can also be cross-listed on bioRxiv. Collapse on DOI when shared,
+       otherwise on (lowercased, normalized) title + first author. Preference order when merging:
+       PubMed (published) > bioRxiv/medRxiv (biology preprint with DOI) > arXiv (CS preprint).
+       When collapsed, keep the alternate URLs as "also: {server} version" links so the user can drill
+       into either the preprint or the published version.
 - [ ] Step 7: Apply paper-relevance-filter to each candidate. Keep, drop, or flag-for-review with
        rationale. Use last-4-weeks digests to mark items as CONTINUING, NEW, or COVERED-BEFORE.
 - [ ] Step 8: If kept count > 25, raise the relevance bar (filter again with stricter threshold)
@@ -110,8 +118,14 @@ Monday weekly run:
 | bioRxiv  | `https://api.biorxiv.org/details/biorxiv/{from}/{to}/{cursor}` via WebFetch — no auth   |
 | medRxiv  | `https://api.biorxiv.org/details/medrxiv/{from}/{to}/{cursor}` via WebFetch — no auth   |
 | PubMed   | NCBI E-utilities `esearch` + `esummary` via WebFetch (no auth). If a PubMed MCP server is configured at runtime, prefer its `search_articles` and `get_article_metadata` tools — they paginate and parse for you. |
+| arXiv    | `http://export.arxiv.org/api/query?search_query=...` via WebFetch — no auth, Atom XML response, 1 req / 3 sec rate limit |
 
-The bioRxiv/medRxiv API returns the full corpus for the window paginated by cursor (100 records per page). Keyword filtering happens client-side in `fetch-preprint-recent`. PubMed lets you push the keyword query server-side, which is why the two fetchers are separate skills.
+Why four fetchers, not one? The four sources have meaningfully different APIs:
+- bioRxiv / medRxiv: same JSON endpoint, cursor pagination, no server-side keyword filter, share one skill.
+- PubMed: server-side keyword + date filter via E-utilities (or a PubMed MCP). Different transport.
+- arXiv: Atom XML, datetime-range query syntax, hard rate limit, different category taxonomy. Different transport.
+
+Each fetcher returns the same canonical record shape so cross-source dedupe works against the union.
 
 ---
 
@@ -134,7 +148,7 @@ Before synthesizing, read titles + cluster names + the 30K paragraph from the pr
 ---
 week: 2026-19
 window: 2026-05-04 to 2026-05-10
-sources_hit: [biorxiv, medrxiv, pubmed]
+sources_hit: [biorxiv, medrxiv, pubmed, arxiv]
 fetched_total: 412
 kept_total: 17
 dropped_total: 395
@@ -196,7 +210,7 @@ A flat table or list. Every kept paper with: title, authors (et al. after 3), so
 8. Never run a digest without reading the last 4 weeks first. Historical context is non-negotiable.
 9. Never use banned vocabulary: delve, unpack, paradigm shift, let's explore, moreover, furthermore, it's worth noting.
 10. Never claim a paper "shows X" when its abstract only "suggests X" or "is consistent with X" — preserve the paper's own hedging in the 300 ft layer.
-11. Never proceed if all three sources fail to return results. Halt, report which fetches failed, ask the user.
+11. Never proceed if all four sources fail to return results. Halt, report which fetches failed, ask the user. If 1-2 sources fail but the others returned, proceed and surface the partial coverage prominently in the digest's "Notes for next week" line.
 12. Never assume two papers with the same title are the same record without matching DOI or first author — different research groups release similarly-titled work.
 
 ---

--- a/skills/fetch-arxiv-recent/SKILL.md
+++ b/skills/fetch-arxiv-recent/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: fetch-arxiv-recent
+description: Fetches arXiv papers submitted within a given date window matching a keyword set, with optional restriction to one or more arXiv categories (e.g. cs.LG, cs.CL, cs.CV, stat.ML, math.ST, q-bio.QM). Wraps the public `export.arxiv.org/api/query` endpoint, parses Atom XML, handles pagination, and normalizes records to the same canonical shape as `fetch-preprint-recent` and `fetch-pubmed-recent` so a calling agent can dedupe across sources. Domain-neutral — usable for any literature scan that crosses CS, ML, statistics, math, physics, or quantitative biology. Use when user mentions arXiv, cs.LG, ML papers, NeurIPS-adjacent preprints, weekly arXiv scan, or when a literature-scan agent needs arXiv records alongside bioRxiv / medRxiv / PubMed.
+---
+
+# fetch-arxiv-recent
+
+Fetch arXiv papers submitted within a date window, optionally restricted to specific arXiv categories, and keyword-filter the results. Returns records in the same canonical shape as the other three literature fetchers.
+
+## Workflow
+
+```
+- [ ] Step 1: Validate inputs (from, to, keywords, optional categories)
+- [ ] Step 2: Build the search_query string with date range + categories + keywords
+- [ ] Step 3: Page through the API until results exhausted or window endpoint passed
+- [ ] Step 4: Parse Atom XML; normalize each entry
+- [ ] Step 5: Dedupe by arXiv ID (keep latest version)
+- [ ] Step 6: Return matched records + summary
+```
+
+**Step 1 — Validate inputs**
+
+Required:
+- `from`: `YYYY-MM-DD`, inclusive
+- `to`: `YYYY-MM-DD`, inclusive, `to >= from`
+- `keywords`: list of strings (case-insensitive substring match against title + abstract)
+
+Optional:
+- `categories`: list of arXiv category codes — e.g. `["cs.LG", "cs.CL", "stat.ML"]`. If omitted, search all of arXiv. Common groupings the caller may want to expose:
+  - **CS / ML**: `cs.LG, cs.CL, cs.CV, cs.AI, cs.NE, stat.ML`
+  - **Math / stats**: `math.ST, math.PR, math.OC, stat.ME, stat.AP`
+  - **Quantitative biology**: `q-bio.QM, q-bio.GN, q-bio.MN, q-bio.NC`
+  - **Physics-adjacent**: `physics.data-an, cond-mat.stat-mech`
+
+  The skill itself does not hard-code these groupings; it accepts whatever categories the caller passes. The orchestrator's `source-registry.md` can document the groupings the operator cares about.
+
+Reject if window > 31 days (same rule as `fetch-preprint-recent` — wider windows almost always indicate a misuse).
+
+**Step 2 — Build the query string**
+
+The arXiv search API accepts a query language with fielded search. Compose:
+
+```
+search_query = (date_clause) AND (category_clause)? AND (keyword_clause)
+```
+
+- **Date clause** (always include — without it you'll get the whole arXiv history):
+  ```
+  submittedDate:[YYYYMMDDHHMM TO YYYYMMDDHHMM]
+  ```
+  Use `from + 0000` and `to + 2359` so the window is fully inclusive of both days.
+
+- **Category clause** (optional): join categories with OR.
+  ```
+  (cat:cs.LG OR cat:cs.CL OR cat:stat.ML)
+  ```
+
+- **Keyword clause**: join with OR. Use `all:` for full-record search (covers title + abstract + authors, which is what we want for a wide-net keyword scan):
+  ```
+  (all:"protein language model" OR all:"diffusion model" OR all:gnn)
+  ```
+  Multi-word phrases must be double-quoted. Single words don't need quotes.
+
+Final assembled example:
+```
+submittedDate:[202605040000 TO 202605102359]
+  AND (cat:cs.LG OR cat:cs.CL OR cat:stat.ML)
+  AND (all:"protein language model" OR all:"diffusion model" OR all:transformer)
+```
+
+URL-encode and pass as `search_query` to:
+
+```
+http://export.arxiv.org/api/query?search_query={URL_ENCODED}&sortBy=submittedDate&sortOrder=descending&start={offset}&max_results=200
+```
+
+`sortBy=submittedDate&sortOrder=descending` is important — it lets you stop paginating as soon as the result dates fall before `from`, instead of having to walk the whole result set.
+
+**Step 3 — Pagination**
+
+arXiv returns 200 records per page (max). After each page:
+- If response has 0 entries, stop.
+- If the *last* entry's `published` date is older than `from`, stop (the rest are out of window).
+- Otherwise, increment `start` by 200, request again.
+- Cap at 10 pages (2,000 records). If hit, surface "window may be over-broad" and return what you have.
+
+Rate limit: arXiv asks for **1 request every 3 seconds**. Sleep between paginated requests. Don't hammer.
+
+**Step 4 — Parse Atom XML**
+
+The API returns an Atom feed. Each `<entry>` has:
+- `<id>`: full URL like `http://arxiv.org/abs/2605.12345v1` — the canonical paper ID is the trailing `2605.12345` (post-2007 format) or `arxiv.org/abs/cs.LG/0301001` (legacy format)
+- `<title>`: paper title (may have newlines + indentation; collapse whitespace)
+- `<summary>`: abstract (same whitespace caveat)
+- `<author><name>`: one per author; preserve order
+- `<published>`: ISO timestamp of v1 submission (use this as `date`)
+- `<updated>`: ISO timestamp of latest version (different if revised)
+- `<arxiv:primary_category term="cs.LG">`: primary category
+- `<category term="..."/>`: list of all categories
+- `<link rel="alternate" type="text/html" href="..."/>`: abstract page URL
+- `<link title="pdf" rel="related" type="application/pdf" href="..."/>`: PDF URL
+- `<arxiv:doi>`: optional, present once paper is published in a journal
+
+If the Atom parser fails, retry the request once with a 5-second backoff. On second failure, log the error to `fetch_errors` and skip the page.
+
+**Step 5 — Dedupe by arXiv ID**
+
+The paginated results may include the same paper twice if a v2 was submitted within the window. Keep the highest version per ID.
+
+The arXiv ID alone (e.g. `2605.12345`) is the canonical key — strip the `v1`/`v2` suffix from the URL and use that.
+
+**Step 6 — Normalize and return**
+
+Same canonical record shape as the other fetchers:
+
+```json
+{
+  "id": "arxiv:2605.12345",                                   // arxiv-prefixed for source clarity
+  "title": "...",
+  "authors": ["Smith J", "Doe A", ...],
+  "abstract": "...",
+  "date": "2026-05-07",                                       // YYYY-MM-DD parsed from <published>
+  "server": "arxiv",
+  "primary_category": "cs.LG",
+  "categories": ["cs.LG", "stat.ML"],
+  "version": 2,
+  "doi": "10.1145/...",                                       // if present, otherwise null
+  "url": "https://arxiv.org/abs/2605.12345",                  // abstract page (preferred for digest links)
+  "pdf_url": "https://arxiv.org/pdf/2605.12345.pdf",
+  "matched_keywords": ["protein language model"]
+}
+```
+
+Apply the keyword filter client-side (the API's `all:` is full-record OR but doesn't preserve the match-keyword info). For each record, check title + abstract against the keyword list, populate `matched_keywords`, and drop records that match none (the API's recall is broader than the operator's intent — the skill must filter).
+
+Return summary:
+
+```json
+{
+  "server": "arxiv",
+  "window": "2026-05-04/2026-05-10",
+  "categories": ["cs.LG", "cs.CL", "stat.ML"],
+  "query": "(...full search_query...)",
+  "fetched_total": 1240,
+  "matched_total": 18,
+  "pages_fetched": 7,
+  "fetch_errors": [],
+  "records": [ ... ]
+}
+```
+
+Cache the raw Atom XML responses (one per page) to `.cache/{YYYY-WW}-arxiv-{page}.xml`.
+
+## Common Patterns
+
+**Pattern A — CS-only weekly scan**: `categories=["cs.LG", "cs.CL", "cs.CV", "cs.AI", "stat.ML"]`. The default for an ML/CS-leaning watchlist.
+
+**Pattern B — Cross-disciplinary scan (CS + quant-bio)**: `categories=["cs.LG", "stat.ML", "q-bio.QM", "q-bio.GN"]`. When the operator wants computational-biology preprints from arXiv that bioRxiv may miss.
+
+**Pattern C — All of arXiv**: `categories=None`. Maximum recall, maximum noise. Only useful when the keyword filter is very tight.
+
+**Pattern D — Track a specific arXiv account**: outside this skill's default scope. Add `(au:"Smith, J" OR au:"Doe, A")` to the search_query as an additional AND clause.
+
+## Guardrails
+
+1. **Always include the date clause.** Without `submittedDate:[... TO ...]` arXiv returns the entire history of the matching query — millions of records. This is the single most common arXiv-API mistake.
+2. **Sort by submittedDate descending.** Otherwise you cannot bail out of pagination early when the dates fall out of window — you'd have to walk the whole result set.
+3. **Respect the 3-second rate limit.** arXiv enforces it loosely but consistent abuse triggers IP-level throttling. Sleep 3s between paginated requests.
+4. **Don't trust the `<title>` and `<summary>` whitespace.** Atom feeds often contain literal `\n` plus 6 spaces of indentation. Collapse all internal whitespace runs to single spaces before storing.
+5. **Don't conflate the `id` URL with the canonical ID.** `<id>http://arxiv.org/abs/2605.12345v2</id>` — the canonical ID is `2605.12345`. The `v2` is the version suffix; strip it for dedupe.
+6. **Don't drop the legacy ID format silently.** Pre-2007 arXiv IDs look like `cs.LG/0301001`. The skill should accept both formats, never assert the modern one. Match `^[a-z-]+\.[A-Z]+/\d+$|^\d{4}\.\d{4,5}$` to validate.
+7. **Don't dedupe across sources here.** A paper on arXiv may also be on bioRxiv (for cross-listing) or have a PubMed publication — that's the calling agent's job, not this skill's.
+8. **Don't expand keywords automatically.** arXiv's full-record `all:` search is already broad; further synonym expansion silently widens the net. The watchlist is the gate.
+
+## Quick Reference
+
+| Field          | Source                                                       | Notes                                                         |
+| -------------- | ------------------------------------------------------------ | ------------------------------------------------------------- |
+| Endpoint       | `http://export.arxiv.org/api/query?search_query={q}&...`     | HTTPS works too but the docs use HTTP                         |
+| Auth           | None                                                         | Public API. Use a User-Agent header if WebFetch lets you set one. |
+| Page size      | 200 max (`max_results=200`)                                  |                                                               |
+| Rate limit     | 1 request / 3 seconds                                        | Sleep between paginated requests                              |
+| Window cap     | 31 days (soft); 7 days for weekly digests                    |                                                               |
+| Date format    | `YYYYMMDDHHMM` (no dashes, no colons)                        | Use `0000` for `from`, `2359` for `to`                        |
+| ID format      | `2605.12345` (post-2007), `cs.LG/0301001` (legacy)           | Strip `vN` suffix from the URL; canonical ID excludes version |
+| Canonical URL  | `https://arxiv.org/abs/{id}`                                 | Abstract page; preferred for digest links                     |
+| PDF URL        | `https://arxiv.org/pdf/{id}.pdf`                             | Optional secondary link                                       |
+| Sort           | `sortBy=submittedDate&sortOrder=descending`                  | Required for early-bail pagination                            |
+| Common cats    | `cs.LG, cs.CL, cs.CV, cs.AI, stat.ML, math.ST, q-bio.QM`     | Operator decides; skill takes any list                        |


### PR DESCRIPTION
## Summary

Extends `paper-synthesizer` (merged in #52) beyond life sciences to cover CS / ML / stats / math preprints from arXiv. The operator's `source-registry.md` decides which arXiv categories to query (cs.LG, cs.CL, stat.ML, q-bio.QM, etc.) — or omits the restriction to search all of arXiv.

## Changes

- **New skill `fetch-arxiv-recent`**: Atom XML parsing, datetime-range query syntax (`submittedDate:[YYYYMMDDHHMM TO YYYYMMDDHHMM]`), optional category restriction, 1 req / 3 sec rate limit, early-bail pagination via `submittedDate` descending sort. Returns the same canonical record shape as `fetch-preprint-recent` and `fetch-pubmed-recent` so cross-source dedupe still works.

- **Agent updates**:
  - Description now spans life sciences + CS / ML; trigger keywords expanded.
  - Pipeline gains Step 5b (fetch arXiv with optional category restriction).
  - Connectors table adds the arXiv row + a "why four fetchers, not one" note explaining the API differences.
  - Cross-source dedupe extended: arXiv papers can also have a PubMed publication or be cross-listed on bioRxiv. Preference order PubMed > bio/medRxiv > arXiv when collapsing.
  - Must-not #11 updated: 1-2 source failures proceed with partial-coverage warning; 4-source failure halts.

- **README**:
  - Skills 209 → 210, Research & Evidence section 10 → 11.
  - "I want to…" row + agents-table row reflect the broadened scope.

## Why a separate arXiv fetcher (not extending fetch-preprint-recent)

The four sources have meaningfully different APIs:
- bioRxiv / medRxiv: same JSON endpoint, cursor pagination, no server-side keyword filter — share one skill (`fetch-preprint-recent`)
- PubMed: server-side keyword + date filter via E-utilities or PubMed MCP
- arXiv: Atom XML, datetime-range query syntax, hard rate limit, different category taxonomy

Forcing arXiv into `fetch-preprint-recent` would compromise both — the response parsing, query syntax, pagination strategy, and rate-limit handling all differ. Sibling skills with one shared canonical output shape is the cleaner factoring.

## Test plan

- [ ] `fetch-arxiv-recent` skill loads (YAML metadata parses, name matches directory)
- [ ] `paper-synthesizer` invocation now lists arxiv in `sources_hit` frontmatter
- [ ] arXiv fetch completes for a 7-day window with categories `["cs.LG", "cs.CL", "stat.ML"]`
- [ ] arXiv fetch with `categories=None` (all of arXiv) returns broader results
- [ ] Cross-source dedupe collapses arXiv ↔ bioRxiv ↔ PubMed pairs correctly when DOIs match
- [ ] `1 request / 3 seconds` rate limit honored (no arXiv 429s)
- [ ] Early-bail pagination triggers when oldest result on a page falls before `from`

🤖 Generated with [Claude Code](https://claude.com/claude-code)