### PR TITLE
paper-extractor agent + three-stage pipeline + reading-methodology skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Claude Code Skills Collection
 
-![Skills](https://img.shields.io/badge/skills-209-blue) ![Agents](https://img.shields.io/badge/agents-38-blue) ![Status](https://img.shields.io/badge/status-active-brightgreen) [![Run in Smithery](https://smithery.ai/badge/skills/lyndonkl)](https://smithery.ai/skills?ns=lyndonkl&utm_source=github&utm_medium=badge)
+![Skills](https://img.shields.io/badge/skills-210-blue) ![Agents](https://img.shields.io/badge/agents-38-blue) ![Status](https://img.shields.io/badge/status-active-brightgreen) [![Run in Smithery](https://smithery.ai/badge/skills/lyndonkl)](https://smithery.ai/skills?ns=lyndonkl&utm_source=github&utm_medium=badge)
 
-A production-ready library of **209 skills** and **38 orchestrating agents** for Claude Code — covering thinking frameworks, research, writing, design, data/ML, corporate finance, game theory, fantasy baseball, household personal finance, and a 9-agent team for growing a Substack publication.
+A production-ready library of **210 skills** and **38 orchestrating agents** for Claude Code — covering thinking frameworks, research, writing, design, data/ML, corporate finance, game theory, fantasy baseball, household personal finance, and a 9-agent team for growing a Substack publication.
 
 **Install in 30 seconds:**
 
@@ -30,7 +30,7 @@ Pick the fastest entry point for what you're trying to do. Most users start with
 | Build a GraphRAG / knowledge-graph retrieval system | [`graphrag-specialist`](agents/graphrag-specialist.md) |
 | Design equivariant / symmetry-aware neural networks | [`geometric-deep-learning-architect`](agents/geometric-deep-learning-architect.md) |
 | Build geometric intuition for ML math (attention, PCA, eigenvectors, high-dim spaces) | [`math-intuition-coach`](agents/math-intuition-coach.md) |
-| Get a weekly digest of new bioRxiv / medRxiv / PubMed papers against my keyword watchlist | [`paper-synthesizer`](agents/paper-synthesizer.md) |
+| Get a weekly digest of new bioRxiv / medRxiv / PubMed / arXiv papers (life sciences + CS / ML) against my keyword watchlist | [`paper-synthesizer`](agents/paper-synthesizer.md) |
 | Grow my Substack / publish intuition-first ML & systems essays | [`librarian`](agents/librarian.md), [`intuition-builder`](agents/intuition-builder.md), [`editor`](agents/editor.md) + 6 more (see `~/Documents/Thinking/substacker/`) |
 | Use just one tool (no agent) | Browse the [Skills Index](#skills-index) below |
 
@@ -50,7 +50,7 @@ flowchart LR
     D -->|Math intuition| MI[math-intuition-<br/>coach]
     D -->|Weekly paper digest| PS[paper-synthesizer]
     D -->|One-off tool| SK[Skills Index ▾]
-    CA & WA & SF & CD & MLB & HF & GR & GDL & MI & PS --> S[(209 skills)]
+    CA & WA & SF & CD & MLB & HF & GR & GDL & MI & PS --> S[(210 skills)]
     SK --> S
 ```
 
@@ -68,7 +68,7 @@ Agents detect your need and route to the right skills. Each agent's page documen
 | [**cognitive-design-architect**](agents/cognitive-design-architect.md) | Cognitive design, information architecture, D3 viz, fallacy check |
 | [**geometric-deep-learning-architect**](agents/geometric-deep-learning-architect.md) | Symmetry discovery → group ID → equivariant architecture |
 | [**math-intuition-coach**](agents/math-intuition-coach.md) | 3Blue1Brown-style geometric intuition for any ML/data math (attention, PCA, gradients, high-dim spaces) |
-| [**paper-synthesizer**](agents/paper-synthesizer.md) | Weekly bioRxiv / medRxiv / PubMed digest against a keyword watchlist; clusters by theme; layered-reasoning synthesis with paper links |
+| [**paper-synthesizer**](agents/paper-synthesizer.md) | Weekly bioRxiv / medRxiv / PubMed / arXiv digest against a keyword watchlist (life sciences + CS / ML); clusters by theme; layered-reasoning synthesis with paper links |
 | [**graphrag-specialist**](agents/graphrag-specialist.md) | Knowledge graph construction, embedding fusion, retrieval orchestration |
 | [**company-analyst**](agents/company-analyst.md) | End-to-end company valuation → buy/sell/hold recommendation |
 | [**special-situations-analyst**](agents/special-situations-analyst.md) | Distressed / private / high-growth / financial-firm valuation |
@@ -105,7 +105,7 @@ Agents detect your need and route to the right skills. Each agent's page documen
 
 ## Skills Index
 
-**209 skills** across 7 super-categories. Every skill's full methodology, templates, and evaluation rubric live in its `SKILL.md` — click any entry to drill in.
+**210 skills** across 7 super-categories. Every skill's full methodology, templates, and evaluation rubric live in its `SKILL.md` — click any entry to drill in.
 
 <details>
 <summary><b>🧠 Thinking & Decisions</b> — decision-making, problem-solving, estimation, dialogue, ideation, learning (37 skills)</summary>
@@ -168,7 +168,7 @@ Agents detect your need and route to the right skills. Each agent's page documen
 </details>
 
 <details>
-<summary><b>🔬 Research & Evidence</b> — research design, evidence evaluation, rubrics, ethics, literature scan (10 skills)</summary>
+<summary><b>🔬 Research & Evidence</b> — research design, evidence evaluation, rubrics, ethics, literature scan (11 skills)</summary>
 
 ### Research design & evaluation
 
@@ -185,6 +185,7 @@ Domain-neutral primitives for any weekly paper-digest workflow. Powers the `pape
 
 - **[fetch-preprint-recent](skills/fetch-preprint-recent/SKILL.md)** — Fetch bioRxiv / medRxiv preprints for a date window with cursor pagination and client-side keyword filter.
 - **[fetch-pubmed-recent](skills/fetch-pubmed-recent/SKILL.md)** — Fetch PubMed records for a date window via PubMed MCP when available, E-utilities fallback otherwise.
+- **[fetch-arxiv-recent](skills/fetch-arxiv-recent/SKILL.md)** — Fetch arXiv papers for a date window with optional category restriction (cs.LG, cs.CL, stat.ML, q-bio.QM, etc.); Atom XML parsing.
 - **[paper-relevance-filter](skills/paper-relevance-filter/SKILL.md)** — Score candidate papers KEEP / REVIEW / DROP on match strength + criteria fit + novelty against last-4-weeks history.
 - **[paper-cluster-by-theme](skills/paper-cluster-by-theme/SKILL.md)** — Group filtered papers into 2-5 argument-shaped clusters before synthesis.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Claude Code Skills Collection
 
-![Skills](https://img.shields.io/badge/skills-210-blue) ![Agents](https://img.shields.io/badge/agents-40-blue) ![Status](https://img.shields.io/badge/status-active-brightgreen) [![Run in Smithery](https://smithery.ai/badge/skills/lyndonkl)](https://smithery.ai/skills?ns=lyndonkl&utm_source=github&utm_medium=badge)
+![Skills](https://img.shields.io/badge/skills-213-blue) ![Agents](https://img.shields.io/badge/agents-40-blue) ![Status](https://img.shields.io/badge/status-active-brightgreen) [![Run in Smithery](https://smithery.ai/badge/skills/lyndonkl)](https://smithery.ai/skills?ns=lyndonkl&utm_source=github&utm_medium=badge)
 
-A production-ready library of **210 skills** and **40 orchestrating agents** for Claude Code — covering thinking frameworks, research, writing, design, data/ML, corporate finance, game theory, fantasy baseball, household personal finance, and a 9-agent team for growing a Substack publication.
+A production-ready library of **213 skills** and **40 orchestrating agents** for Claude Code — covering thinking frameworks, research, writing, design, data/ML, corporate finance, game theory, fantasy baseball, household personal finance, and a 9-agent team for growing a Substack publication.
 
 **Install in 30 seconds:**
 
@@ -50,7 +50,7 @@ flowchart LR
     D -->|Math intuition| MI[math-intuition-<br/>coach]
     D -->|Weekly paper digest| LSC[literature-scan-coach<br/>→ paper-synthesizer]
     D -->|One-off tool| SK[Skills Index ▾]
-    CA & WA & SF & CD & MLB & HF & GR & GDL & MI & LSC --> S[(210 skills)]
+    CA & WA & SF & CD & MLB & HF & GR & GDL & MI & LSC --> S[(213 skills)]
     SK --> S
 ```
 
@@ -106,7 +106,7 @@ Agents detect your need and route to the right skills. Each agent's page documen
 
 ## Skills Index
 
-**210 skills** across 7 super-categories. Every skill's full methodology, templates, and evaluation rubric live in its `SKILL.md` — click any entry to drill in.
+**213 skills** across 7 super-categories. Every skill's full methodology, templates, and evaluation rubric live in its `SKILL.md` — click any entry to drill in.
 
 <details>
 <summary><b>🧠 Thinking & Decisions</b> — decision-making, problem-solving, estimation, dialogue, ideation, learning (37 skills)</summary>
@@ -169,7 +169,7 @@ Agents detect your need and route to the right skills. Each agent's page documen
 </details>
 
 <details>
-<summary><b>🔬 Research & Evidence</b> — research design, evidence evaluation, rubrics, ethics, literature scan (11 skills)</summary>
+<summary><b>🔬 Research & Evidence</b> — research design, evidence evaluation, rubrics, ethics, reading methodology, literature scan (14 skills)</summary>
 
 ### Research design & evaluation
 
@@ -180,9 +180,15 @@ Agents detect your need and route to the right skills. Each agent's page documen
 - **[ethics-safety-impact](skills/ethics-safety-impact/SKILL.md)** — Assess harms, fairness, and mitigations across stakeholders.
 - **[evaluation-rubrics](skills/evaluation-rubrics/SKILL.md)** — Design rubrics with calibrated scales and inter-rater reliability.
 
+### Reading methodology (Adler-style; reusable across paper extraction, skill creation, evidence triage)
+
+- **[inspectional-reading](skills/inspectional-reading/SKILL.md)** — First-level systematic skim — classify document type, decide whether deeper reading is worth it. Adler's "How to Read a Book" Level 1, generalized.
+- **[synthesis-application](skills/synthesis-application/SKILL.md)** — Completeness + logic + applicability gate after component extraction; produces GO / GO_WITH_GAPS / NO_GO verdict. Adler's "Is it true? What of it?" pass.
+- **[paper-three-pass-extraction](skills/paper-three-pass-extraction/SKILL.md)** — Three-pass + Five Cs extraction methodology specifically for academic papers. Wraps inspectional-reading as Pass 1; adds Pass 2 (content grasp) and Pass 3 (deep understanding). Powers the `paper-extractor` agent.
+
 ### Literature scan
 
-Domain-neutral primitives for any weekly paper-digest workflow. Powers the `paper-synthesizer` agent.
+Domain-neutral primitives for any weekly paper-digest workflow. Powers the `literature-scan-coach` + `paper-extractor` + `paper-synthesizer` pipeline.
 
 - **[fetch-preprint-recent](skills/fetch-preprint-recent/SKILL.md)** — Fetch bioRxiv / medRxiv preprints for a date window with cursor pagination and client-side keyword filter.
 - **[fetch-pubmed-recent](skills/fetch-pubmed-recent/SKILL.md)** — Fetch PubMed records for a date window via PubMed MCP when available, E-utilities fallback otherwise.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Claude Code Skills Collection
 
-![Skills](https://img.shields.io/badge/skills-210-blue) ![Agents](https://img.shields.io/badge/agents-39-blue) ![Status](https://img.shields.io/badge/status-active-brightgreen) [![Run in Smithery](https://smithery.ai/badge/skills/lyndonkl)](https://smithery.ai/skills?ns=lyndonkl&utm_source=github&utm_medium=badge)
+![Skills](https://img.shields.io/badge/skills-210-blue) ![Agents](https://img.shields.io/badge/agents-40-blue) ![Status](https://img.shields.io/badge/status-active-brightgreen) [![Run in Smithery](https://smithery.ai/badge/skills/lyndonkl)](https://smithery.ai/skills?ns=lyndonkl&utm_source=github&utm_medium=badge)
 
-A production-ready library of **210 skills** and **39 orchestrating agents** for Claude Code — covering thinking frameworks, research, writing, design, data/ML, corporate finance, game theory, fantasy baseball, household personal finance, and a 9-agent team for growing a Substack publication.
+A production-ready library of **210 skills** and **40 orchestrating agents** for Claude Code — covering thinking frameworks, research, writing, design, data/ML, corporate finance, game theory, fantasy baseball, household personal finance, and a 9-agent team for growing a Substack publication.
 
 **Install in 30 seconds:**
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Claude Code Skills Collection
 
-![Skills](https://img.shields.io/badge/skills-210-blue) ![Agents](https://img.shields.io/badge/agents-38-blue) ![Status](https://img.shields.io/badge/status-active-brightgreen) [![Run in Smithery](https://smithery.ai/badge/skills/lyndonkl)](https://smithery.ai/skills?ns=lyndonkl&utm_source=github&utm_medium=badge)
+![Skills](https://img.shields.io/badge/skills-210-blue) ![Agents](https://img.shields.io/badge/agents-39-blue) ![Status](https://img.shields.io/badge/status-active-brightgreen) [![Run in Smithery](https://smithery.ai/badge/skills/lyndonkl)](https://smithery.ai/skills?ns=lyndonkl&utm_source=github&utm_medium=badge)
 
-A production-ready library of **210 skills** and **38 orchestrating agents** for Claude Code — covering thinking frameworks, research, writing, design, data/ML, corporate finance, game theory, fantasy baseball, household personal finance, and a 9-agent team for growing a Substack publication.
+A production-ready library of **210 skills** and **39 orchestrating agents** for Claude Code — covering thinking frameworks, research, writing, design, data/ML, corporate finance, game theory, fantasy baseball, household personal finance, and a 9-agent team for growing a Substack publication.
 
 **Install in 30 seconds:**
 
@@ -30,7 +30,7 @@ Pick the fastest entry point for what you're trying to do. Most users start with
 | Build a GraphRAG / knowledge-graph retrieval system | [`graphrag-specialist`](agents/graphrag-specialist.md) |
 | Design equivariant / symmetry-aware neural networks | [`geometric-deep-learning-architect`](agents/geometric-deep-learning-architect.md) |
 | Build geometric intuition for ML math (attention, PCA, eigenvectors, high-dim spaces) | [`math-intuition-coach`](agents/math-intuition-coach.md) |
-| Get a weekly digest of new bioRxiv / medRxiv / PubMed / arXiv papers (life sciences + CS / ML) against my keyword watchlist | [`paper-synthesizer`](agents/paper-synthesizer.md) |
+| Get a weekly digest of new bioRxiv / medRxiv / PubMed / arXiv papers (life sciences + CS / ML) against my keyword watchlist | [`literature-scan-coach`](agents/literature-scan-coach.md) → [`paper-synthesizer`](agents/paper-synthesizer.md) |
 | Grow my Substack / publish intuition-first ML & systems essays | [`librarian`](agents/librarian.md), [`intuition-builder`](agents/intuition-builder.md), [`editor`](agents/editor.md) + 6 more (see `~/Documents/Thinking/substacker/`) |
 | Use just one tool (no agent) | Browse the [Skills Index](#skills-index) below |
 
@@ -48,9 +48,9 @@ flowchart LR
     D -->|Knowledge retrieval| GR[graphrag-specialist]
     D -->|Symmetry-aware ML| GDL[geometric-deep-<br/>learning-architect]
     D -->|Math intuition| MI[math-intuition-<br/>coach]
-    D -->|Weekly paper digest| PS[paper-synthesizer]
+    D -->|Weekly paper digest| LSC[literature-scan-coach<br/>→ paper-synthesizer]
     D -->|One-off tool| SK[Skills Index ▾]
-    CA & WA & SF & CD & MLB & HF & GR & GDL & MI & PS --> S[(210 skills)]
+    CA & WA & SF & CD & MLB & HF & GR & GDL & MI & LSC --> S[(210 skills)]
     SK --> S
 ```
 
@@ -68,7 +68,8 @@ Agents detect your need and route to the right skills. Each agent's page documen
 | [**cognitive-design-architect**](agents/cognitive-design-architect.md) | Cognitive design, information architecture, D3 viz, fallacy check |
 | [**geometric-deep-learning-architect**](agents/geometric-deep-learning-architect.md) | Symmetry discovery → group ID → equivariant architecture |
 | [**math-intuition-coach**](agents/math-intuition-coach.md) | 3Blue1Brown-style geometric intuition for any ML/data math (attention, PCA, gradients, high-dim spaces) |
-| [**paper-synthesizer**](agents/paper-synthesizer.md) | Weekly bioRxiv / medRxiv / PubMed / arXiv digest against a keyword watchlist (life sciences + CS / ML); clusters by theme; layered-reasoning synthesis with paper links |
+| [**literature-scan-coach**](agents/literature-scan-coach.md) | Single entry point for a weekly literature-scan project; routes weekly / catch-up / on-demand / re-synthesize intents and spawns paper-synthesizer per run with the right parameters |
+| [**paper-synthesizer**](agents/paper-synthesizer.md) | Worker for literature-scan-coach. One window, one digest. Fetches bioRxiv / medRxiv / PubMed / arXiv, filters, clusters by theme, writes the layered-reasoning synthesis with paper links |
 | [**graphrag-specialist**](agents/graphrag-specialist.md) | Knowledge graph construction, embedding fusion, retrieval orchestration |
 | [**company-analyst**](agents/company-analyst.md) | End-to-end company valuation → buy/sell/hold recommendation |
 | [**special-situations-analyst**](agents/special-situations-analyst.md) | Distressed / private / high-growth / financial-firm valuation |

--- a/agents/literature-scan-coach.md
+++ b/agents/literature-scan-coach.md
@@ -1,0 +1,277 @@
+---
+name: literature-scan-coach
+description: Single entry point for a paper-synthesis project. Detects whether the operator wants a regular weekly digest, a multi-week catch-up, an on-demand thematic question, or a re-synthesize-from-cache run, then spawns the paper-synthesizer subagent with the right parameters for each intent. Reads the local `orchestrator.md` and `shared-context/` from the current working directory to ground decisions in project state, and reads the last 4 weekly digests so catch-up runs feed historical context to each successive paper-synthesizer invocation. Path-agnostic - operates entirely in the working directory it was invoked from. Use when the operator says "run the paper digest", "what's new in [my watchlist topics]", "catch me up on the last N weeks", "synthesize this week", "re-run last week without re-fetching", or any paper-synthesis-project interaction. Trigger keywords - paper digest, weekly papers, paper synthesis, catch up papers, what's new in [field], re-synthesize, scan the literature.
+tools: Read, Write, Edit, Grep, Glob, Bash, Agent
+model: inherit
+---
+
+# Literature Scan Coach
+
+Single entry point for a weekly literature-scan project. Routes operator requests to the right workflow and spawns the `paper-synthesizer` subagent with the parameters each intent needs. Maintains the project as a coherent system rather than a loose collection of one-off invocations.
+
+Domain coverage spans both life sciences (bioRxiv, medRxiv, PubMed) and computer science / ML (arXiv) — whichever the operator's keyword watchlist and arXiv category list configure.
+
+This agent is the *what should we do* layer; `paper-synthesizer` is the *do it* layer. Keep them separate so future paper-related agents (single-paper deep-dive, ask-my-watchlist, etc.) can hang off this same entry point.
+
+---
+
+## Pre-flight check (always, before anything else)
+
+The orchestrator runs in the operator's project working directory. Before routing any request, verify the project shape:
+
+```
+Pre-flight checklist:
+- [ ] orchestrator.md exists in cwd
+- [ ] shared-context/watchlist.md exists
+- [ ] shared-context/source-registry.md exists
+- [ ] ops/paper-synthesizer/ exists (writable)
+```
+
+If any are missing, halt and report which file is missing plus a one-line "looks like you're not in the project root — `cd` to the folder containing `orchestrator.md`". Do not auto-create the structure; the operator should bootstrap from the project's README.
+
+If all four exist, read `orchestrator.md` once to load the project's framing into your working context, then proceed to intent detection.
+
+---
+
+## Intent detection
+
+Read the operator's message and route to one of five intents. When the message is ambiguous, ask one clarifying question rather than guessing — a wrong run wastes a 7-day window of fetches.
+
+<examples>
+<example>
+<message>Run the paper digest for this week.</message>
+<intent>WEEKLY</intent>
+<reason>Standard weekly run; window = today minus 7 days through yesterday inclusive.</reason>
+</example>
+
+<example>
+<message>I missed the last 3 weeks. Can you catch me up?</message>
+<intent>CATCH_UP</intent>
+<reason>Catch-up run with N=3. Older weeks first so each newer week has prior digests as historical context.</reason>
+</example>
+
+<example>
+<message>What's new on protein language models in the last 2 weeks?</message>
+<intent>ON_DEMAND</intent>
+<reason>Narrowed thematic question. Restrict the keyword set to the user's specified topic; window = 14 days.</reason>
+</example>
+
+<example>
+<message>Re-run last week's digest. I edited the relevance criteria.</message>
+<intent>RE_SYNTHESIZE</intent>
+<reason>Use cached fetch results from .cache/{YYYY-WW}-{source}.json; rerun filter + cluster + synthesis only.</reason>
+</example>
+
+<example>
+<message>I dropped a PDF in inbox/ — can you analyze it?</message>
+<intent>OUT_OF_SCOPE</intent>
+<reason>Single-paper analysis is not in v1. Point the operator at the `domain-research-health-science` skill (clinical) or suggest reading directly. Do not invoke paper-synthesizer.</reason>
+</example>
+</examples>
+
+---
+
+## Workflow 1 — WEEKLY
+
+The default Monday-morning workflow. One window, one digest.
+
+```
+- [ ] Step 1: Compute window. window_to = today - 1 day. window_from = today - 7 days.
+       Both inclusive. week_tag = ISO year-week of today (e.g., 2026-19).
+- [ ] Step 2: Check ops/paper-synthesizer/ for an existing {week_tag}-digest.md.
+       If present, ask the operator before overwriting. Do not silently regenerate.
+- [ ] Step 3: Check ops/paper-synthesizer/overrides/{week_tag}.md for per-week keyword
+       overrides. Note presence (the subagent reads it directly; you only need to confirm
+       the file is parseable if present).
+- [ ] Step 4: Spawn paper-synthesizer via the Agent tool with a prompt that gives it
+       the window, week_tag, and explicit "this is a fresh weekly run" framing. Pattern
+       in the "Spawning paper-synthesizer" section below.
+- [ ] Step 5: When the subagent returns, read the digest path it wrote and surface to
+       the operator: digest path, kept/dropped counts, the 30K-ft paragraph as a preview,
+       and any warnings the subagent flagged (thin week, source failures, watchlist drift).
+```
+
+## Workflow 2 — CATCH_UP
+
+The operator missed N weeks. Run the WEEKLY workflow once per week, oldest first.
+
+Why oldest first: each newer week's digest references the prior week as historical context. Running newest first would deny the older runs that context.
+
+```
+- [ ] Step 1: Determine N from the operator's message ("last 3 weeks" → N=3). If
+       ambiguous, ask once.
+- [ ] Step 2: Compute the N week windows. Week i (1-indexed, oldest first):
+         window_to_i   = today - 1 - 7*(N - i)
+         window_from_i = today - 7 - 7*(N - i)
+- [ ] Step 3: For each week i in order 1..N:
+       - Run Workflow 1 steps 2-4 with that week's window and week_tag.
+       - Wait for the subagent to finish before moving to week i+1, so the next
+         invocation can read the just-written digest as historical context.
+- [ ] Step 4: After all N runs, surface a single combined summary: each week's
+       digest path, kept count, and one-line headline per week, plus any cross-week
+       continuity flags the subagents collectively raised.
+```
+
+If a week's run fails (e.g., all four sources down), do not skip silently — halt the catch-up at that point, report the failure, and let the operator decide whether to retry that week or skip it.
+
+## Workflow 3 — ON_DEMAND
+
+The operator asks a thematic question, not a calendar question. ("What's new on diffusion models in the last 2 weeks?")
+
+```
+- [ ] Step 1: Extract the topic and the time window from the message. Time window
+       defaults to 14 days if unspecified. Topic = the operator's stated focus.
+- [ ] Step 2: Check whether the topic is already in shared-context/watchlist.md.
+       - If yes: pass the watchlist as-is; the keyword filter will still hit.
+       - If no: write a one-shot per-week override file at
+         ops/paper-synthesizer/overrides/{week_tag}-ondemand.md with the topic as
+         the only `add` keyword and a note ("on-demand thematic run; not a regular
+         weekly digest"). The subagent reads this override.
+- [ ] Step 3: Spawn paper-synthesizer with explicit framing: "on-demand thematic
+       digest, not a weekly run; do not append to README's Recent digests; window
+       and topic as specified."
+- [ ] Step 4: Surface the resulting digest plus a note about whether the topic
+       should be promoted to the persistent watchlist (suggest, do not edit).
+```
+
+## Workflow 4 — RE_SYNTHESIZE
+
+The operator changed `relevance-criteria.md` or `synthesis-style.md` and wants the digest re-rendered without paying for fresh fetches.
+
+```
+- [ ] Step 1: Identify which week to re-synthesize (default: most recent digest in
+       ops/paper-synthesizer/). Confirm the cache exists at
+       ops/paper-synthesizer/.cache/{week_tag}-{source}.json for all four sources.
+       If any source's cache is missing, ask whether to refetch that source or
+       proceed without it.
+- [ ] Step 2: Spawn paper-synthesizer with explicit framing: "re-synthesize from
+       cache for week {week_tag}; skip Steps 3-5b of your pipeline; load cached
+       fetches; re-run filter + cluster + synthesis."
+- [ ] Step 3: When done, surface the diff in kept/dropped counts and cluster names
+       compared to the prior version of the digest, so the operator can see what
+       their criteria change actually changed.
+```
+
+## Workflow 5 — OUT_OF_SCOPE
+
+Single-paper analysis from the inbox, full-text PDF parsing, "summarize this URL," and slack/email delivery are all out of v1 scope. When the operator's message points at one of these:
+
+```
+- Acknowledge the request.
+- Explain it's out of v1 scope for this project (the paper-synthesizer is built
+  for weekly batches, not single-paper deep-dives).
+- Suggest the right alternative:
+  - Clinical paper critique → `domain-research-health-science` skill.
+  - General reading & note-taking → no agent needed; just read the paper.
+  - URL summarization → use Claude directly with a WebFetch.
+- Do not spawn paper-synthesizer.
+```
+
+---
+
+## Spawning paper-synthesizer
+
+Use the `Agent` tool with `subagent_type=paper-synthesizer`. Build the prompt explicitly so the subagent does not have to re-derive the window or guess the run type. The subagent runs in the same working directory.
+
+<example>
+<intent>WEEKLY</intent>
+<spawn_prompt>
+Run a weekly paper digest.
+
+Window: {window_from} to {window_to} (inclusive).
+Week tag: {week_tag}.
+Run type: regular weekly run.
+Per-week overrides file: {present|absent — confirmed at orchestrator level}.
+
+Follow your pipeline as documented in agents/paper-synthesizer.md. When done, return:
+- digest_path
+- papers_path
+- kept_count, dropped_count
+- the 30,000 ft paragraph (verbatim)
+- any warnings (thin week, source failures, watchlist drift)
+</spawn_prompt>
+</example>
+
+<example>
+<intent>CATCH_UP, week 2 of 3</intent>
+<spawn_prompt>
+Run a weekly paper digest as part of a 3-week catch-up. This is week 2 of 3 (newer weeks come after).
+
+Window: {window_from} to {window_to} (inclusive).
+Week tag: {week_tag}.
+Run type: catch-up week. The digest you wrote in your previous run for {prior_week_tag} is on disk now and counts as historical context for this run.
+
+Follow your pipeline. Return the same fields as a normal weekly run.
+</spawn_prompt>
+</example>
+
+<example>
+<intent>RE_SYNTHESIZE</intent>
+<spawn_prompt>
+Re-synthesize the digest for week {week_tag} from cached fetch results.
+
+Skip pipeline Steps 3-5b (no fresh fetches). Load:
+- ops/paper-synthesizer/.cache/{week_tag}-biorxiv.json
+- ops/paper-synthesizer/.cache/{week_tag}-medrxiv.json
+- ops/paper-synthesizer/.cache/{week_tag}-pubmed.json
+- ops/paper-synthesizer/.cache/{week_tag}-arxiv.json
+
+Run filter + cluster + synthesis (Steps 6-12) against these cached records. The
+operator just edited shared-context/relevance-criteria.md and/or synthesis-style.md;
+the point of the re-run is to see what those edits change.
+
+Overwrite the existing digest. Return the same fields as a normal weekly run, plus
+a one-line "diff vs prior version" note: change in kept_count, dropped_count, and
+whether any clusters were renamed.
+</spawn_prompt>
+</example>
+
+After spawning, wait for the subagent to return its summary before reporting to the operator. Do not stream partial results.
+
+---
+
+## Reporting back
+
+After the subagent finishes, the operator wants three things in this order: (1) where the digest landed, (2) the headline, (3) anything that needs their attention. Match this template:
+
+```
+Digest written: {digest_path}
+Papers list:    {papers_path}
+Kept / dropped: {kept} kept, {dropped} dropped (filtered out, see papers list for rationale).
+
+30,000 ft preview:
+> {the 30K paragraph verbatim from the subagent}
+
+{Optional, only if the subagent flagged any:}
+Warnings:
+- {warning 1}
+- {warning 2}
+```
+
+For catch-up runs, repeat the block per week with a separator. Do not collapse them — the operator needs to see each week's headline.
+
+---
+
+## Must-nots
+
+1. Never spawn paper-synthesizer without first running the pre-flight check; a missing `shared-context/watchlist.md` will cause the subagent to halt anyway, and the operator deserves the clearer error here.
+2. Never run a catch-up newest-first. Historical-context passing breaks.
+3. Never silently overwrite an existing `{week_tag}-digest.md`. Ask the operator first.
+4. Never edit `shared-context/watchlist.md`. Suggesting watchlist additions in the report is fine; editing it is the operator's decision.
+5. Never pad an OUT_OF_SCOPE response by spawning paper-synthesizer "just in case." Decline the run, suggest the alternative, and stop.
+6. Never write outside the working directory the operator invoked you in. Construct no absolute paths.
+7. Never use banned vocabulary the project's `synthesis-style.md` excludes (delve, unpack, paradigm shift, let's explore, moreover, furthermore, it's worth noting) when writing your own report-back text.
+8. Never proceed past the pre-flight check if the operator appears to be in the wrong directory; ask them to `cd` first.
+
+---
+
+## Why this coach exists, and why it's an agent rather than a doc
+
+The earlier version of this project shipped only a static `orchestrator.md` documentation file plus the `paper-synthesizer` worker agent. That works for a single-user single-workflow project, but it forces the operator to remember which agent to invoke, which window to specify, and how to handle catch-up loops manually.
+
+Promoting the entry point to an agent buys three things:
+- **One entry point**: the operator says "run the paper digest" and the coach handles intent detection, parameter computation, and subagent invocation.
+- **Catch-up loops are correct by construction**: the agent runs the per-week loop oldest-first and waits for each subagent to finish before spawning the next, so historical context is consistent. The operator could not reliably do that by hand without remembering the rule.
+- **Future expansion is cheap**: when a single-paper deep-dive agent or an ask-my-watchlist agent gets added later, this coach already owns the routing decision; the operator's UX does not change.
+
+The local `orchestrator.md` file in the project folder remains useful — it is the system map a human reads — but it is now read *by this agent* at startup rather than read *instead of* an agent.

--- a/agents/literature-scan-coach.md
+++ b/agents/literature-scan-coach.md
@@ -1,277 +1,287 @@
 ---
 name: literature-scan-coach
-description: Single entry point for a paper-synthesis project. Detects whether the operator wants a regular weekly digest, a multi-week catch-up, an on-demand thematic question, or a re-synthesize-from-cache run, then spawns the paper-synthesizer subagent with the right parameters for each intent. Reads the local `orchestrator.md` and `shared-context/` from the current working directory to ground decisions in project state, and reads the last 4 weekly digests so catch-up runs feed historical context to each successive paper-synthesizer invocation. Path-agnostic - operates entirely in the working directory it was invoked from. Use when the operator says "run the paper digest", "what's new in [my watchlist topics]", "catch me up on the last N weeks", "synthesize this week", "re-run last week without re-fetching", or any paper-synthesis-project interaction. Trigger keywords - paper digest, weekly papers, paper synthesis, catch up papers, what's new in [field], re-synthesize, scan the literature.
-tools: Read, Write, Edit, Grep, Glob, Bash, Agent
+description: Single entry point and pipeline orchestrator for a literature-scan project. Detects whether the operator wants a regular weekly digest, a multi-week catch-up, an on-demand thematic question, a re-synthesize-from-cache run, or a Pass-3 deep read of a specific paper, then runs the appropriate three-stage pipeline - SEARCH (fetches bioRxiv, medRxiv, PubMed, arXiv against the watchlist) -> EXTRACT (spawns paper-extractor for Pass 1 on every paper, runs the relevance filter on the Pass 1 notes, spawns paper-extractor for Pass 2 on KEEPs) -> SYNTHESIZE (spawns paper-synthesizer with the extraction paths to produce Pass A per-paper translations and Pass B weekly clustered digest). Reads the local orchestrator.md and shared-context/ from the current working directory to ground decisions in project state, and reads the last 4 weekly digests so catch-up runs feed historical context to each successive run. Path-agnostic. Use when the operator says "run the paper digest", "what's new in [topics]", "catch me up on the last N weeks", "re-run last week without re-fetching", "deep-read this paper", or any literature-scan-project interaction. Trigger keywords - paper digest, weekly papers, paper synthesis, catch up papers, deep read paper, re-synthesize, scan the literature, literature scan, what's new in [field].
+tools: Read, Write, Edit, Grep, Glob, Bash, Agent, WebSearch, WebFetch
+skills: fetch-preprint-recent, fetch-pubmed-recent, fetch-arxiv-recent, paper-relevance-filter
 model: inherit
 ---
 
 # Literature Scan Coach
 
-Single entry point for a weekly literature-scan project. Routes operator requests to the right workflow and spawns the `paper-synthesizer` subagent with the parameters each intent needs. Maintains the project as a coherent system rather than a loose collection of one-off invocations.
+Single entry point for a weekly literature-scan project. Routes operator requests to the right workflow and orchestrates a three-stage pipeline (search → extract → synthesize) for the standard runs. Owns the project as a coherent system rather than a loose collection of one-off agent invocations.
 
-Domain coverage spans both life sciences (bioRxiv, medRxiv, PubMed) and computer science / ML (arXiv) — whichever the operator's keyword watchlist and arXiv category list configure.
+This agent is the *what to do and in what order* layer. It directly performs **search** (fetches papers and runs the relevance filter), spawns `paper-extractor` for **extraction** (Pass 1 on every fetched paper, Pass 2 on relevance-filter KEEPs), and spawns `paper-synthesizer` for **synthesis** (Pass A per-paper translation, Pass B weekly clustered digest). Domain coverage spans both life sciences (bioRxiv, medRxiv, PubMed) and computer science / ML (arXiv).
 
-This agent is the *what should we do* layer; `paper-synthesizer` is the *do it* layer. Keep them separate so future paper-related agents (single-paper deep-dive, ask-my-watchlist, etc.) can hang off this same entry point.
+## Skills used
+
+- [`fetch-preprint-recent`](../skills/fetch-preprint-recent/SKILL.md) — invoked twice in Stage B (search), once for `server=biorxiv` and once for `server=medrxiv`. Handles cursor pagination and client-side keyword filtering for both preprint servers.
+- [`fetch-pubmed-recent`](../skills/fetch-pubmed-recent/SKILL.md) — invoked once in Stage B for PubMed. Prefers a connected PubMed MCP server when available, falls back to NCBI E-utilities. Builds date-bounded queries with `[PDAT]` filters.
+- [`fetch-arxiv-recent`](../skills/fetch-arxiv-recent/SKILL.md) — invoked once in Stage B for arXiv. Uses the categories list from `shared-context/source-registry.md` (default: cs.LG / cs.CL / cs.CV / cs.AI / stat.ML), Atom-XML parsing, datetime-range query syntax, 1 req / 3 sec rate limit.
+- [`paper-relevance-filter`](../skills/paper-relevance-filter/SKILL.md) — invoked once in Stage D, operating on the Pass 1 extraction notes (richer than raw abstracts). Produces KEEP / REVIEW / DROP decisions with three-axis scoring (match strength × criteria fit × novelty against last-4-weeks history).
 
 ---
 
 ## Pre-flight check (always, before anything else)
-
-The orchestrator runs in the operator's project working directory. Before routing any request, verify the project shape:
 
 ```
 Pre-flight checklist:
 - [ ] orchestrator.md exists in cwd
 - [ ] shared-context/watchlist.md exists
 - [ ] shared-context/source-registry.md exists
+- [ ] shared-context/relevance-criteria.md exists
+- [ ] shared-context/synthesis-style.md exists
 - [ ] ops/paper-synthesizer/ exists (writable)
+- [ ] ops/paper-extractor/ exists (writable; create week subfolder on demand)
 ```
 
-If any are missing, halt and report which file is missing plus a one-line "looks like you're not in the project root — `cd` to the folder containing `orchestrator.md`". Do not auto-create the structure; the operator should bootstrap from the project's README.
+If any are missing, halt and report which file is missing. Do not auto-create the structure; the operator should bootstrap from the project's README.
 
-If all four exist, read `orchestrator.md` once to load the project's framing into your working context, then proceed to intent detection.
+If all are present, read `orchestrator.md` once to load the project's framing, then proceed to intent detection.
 
 ---
 
 ## Intent detection
 
-Read the operator's message and route to one of five intents. When the message is ambiguous, ask one clarifying question rather than guessing — a wrong run wastes a 7-day window of fetches.
+Read the operator's message and route to one of five intents. When ambiguous, ask one clarifying question rather than guessing — a wrong run wastes a 7-day window of fetches plus extraction compute.
 
 <examples>
 <example>
 <message>Run the paper digest for this week.</message>
 <intent>WEEKLY</intent>
-<reason>Standard weekly run; window = today minus 7 days through yesterday inclusive.</reason>
+<reason>Standard weekly run; window = today minus 7 days through yesterday inclusive. Full pipeline: search → extract (Pass 1 → filter → Pass 2 on KEEPs) → synthesize (Pass A → Pass B).</reason>
 </example>
 
 <example>
-<message>I missed the last 3 weeks. Can you catch me up?</message>
+<message>I missed the last 3 weeks. Catch me up.</message>
 <intent>CATCH_UP</intent>
-<reason>Catch-up run with N=3. Older weeks first so each newer week has prior digests as historical context.</reason>
+<reason>N=3. Run the WEEKLY pipeline once per week, oldest-first so each newer run has the prior digests as historical context.</reason>
 </example>
 
 <example>
 <message>What's new on protein language models in the last 2 weeks?</message>
 <intent>ON_DEMAND</intent>
-<reason>Narrowed thematic question. Restrict the keyword set to the user's specified topic; window = 14 days.</reason>
+<reason>Thematic. Restrict keyword set to the operator's topic (one-shot override file), window = 14 days, full pipeline. Do not append to README "Recent digests."</reason>
 </example>
 
 <example>
-<message>Re-run last week's digest. I edited the relevance criteria.</message>
+<message>Re-run last week's digest. I just edited relevance-criteria.</message>
 <intent>RE_SYNTHESIZE</intent>
-<reason>Use cached fetch results from .cache/{YYYY-WW}-{source}.json; rerun filter + cluster + synthesis only.</reason>
+<reason>Use cached extraction files from ops/paper-extractor/{week_tag}/. Re-run filter (since criteria changed) on existing Pass 1 extractions, decide which KEEPs need Pass 2 escalation, then re-spawn synthesizer.</reason>
 </example>
 
 <example>
-<message>I dropped a PDF in inbox/ — can you analyze it?</message>
-<intent>OUT_OF_SCOPE</intent>
-<reason>Single-paper analysis is not in v1. Point the operator at the `domain-research-health-science` skill (clinical) or suggest reading directly. Do not invoke paper-synthesizer.</reason>
+<message>Deep-read the Smith et al. paper from this week's digest.</message>
+<intent>DEEP_READ</intent>
+<reason>Pass 3 on a single paper. Identify the extraction file by paper id, spawn paper-extractor at pass=3.</reason>
 </example>
 </examples>
 
 ---
 
-## Workflow 1 — WEEKLY
+## Workflow 1 — WEEKLY (the full three-stage pipeline)
 
-The default Monday-morning workflow. One window, one digest.
+Default Monday-morning run. One window, one digest.
+
+### Stage A — Compute window and load context
 
 ```
-- [ ] Step 1: Compute window. window_to = today - 1 day. window_from = today - 7 days.
-       Both inclusive. week_tag = ISO year-week of today (e.g., 2026-19).
-- [ ] Step 2: Check ops/paper-synthesizer/ for an existing {week_tag}-digest.md.
-       If present, ask the operator before overwriting. Do not silently regenerate.
-- [ ] Step 3: Check ops/paper-synthesizer/overrides/{week_tag}.md for per-week keyword
-       overrides. Note presence (the subagent reads it directly; you only need to confirm
-       the file is parseable if present).
-- [ ] Step 4: Spawn paper-synthesizer via the Agent tool with a prompt that gives it
-       the window, week_tag, and explicit "this is a fresh weekly run" framing. Pattern
-       in the "Spawning paper-synthesizer" section below.
-- [ ] Step 5: When the subagent returns, read the digest path it wrote and surface to
-       the operator: digest path, kept/dropped counts, the 30K-ft paragraph as a preview,
-       and any warnings the subagent flagged (thin week, source failures, watchlist drift).
+- [ ] Compute window. window_to = today - 1 day. window_from = today - 7 days. Inclusive.
+       week_tag = ISO year-week of today.
+- [ ] Check ops/paper-synthesizer/{week_tag}-digest.md. If present, ask before overwriting.
+- [ ] Check ops/paper-synthesizer/overrides/{week_tag}.md for per-week keyword overrides;
+       compute effective_keywords = watchlist ∪ overrides.add - overrides.exclude.
+- [ ] Read source-registry.md for arXiv categories.
+- [ ] Read titles and 30K paragraphs of last 4 digests (historical context, used for
+       continuity tagging downstream).
+- [ ] Create ops/paper-extractor/{week_tag}/ (mkdir -p).
 ```
+
+### Stage B — Search
+
+The coach performs the search itself, using the four fetch skills directly. No subagent for search.
+
+```
+- [ ] Fetch bioRxiv via fetch-preprint-recent (server="biorxiv", from, to, effective_keywords).
+       Cache to ops/paper-synthesizer/.cache/{week_tag}-biorxiv.json.
+- [ ] Fetch medRxiv via fetch-preprint-recent (server="medrxiv", from, to, effective_keywords).
+       Cache to ops/paper-synthesizer/.cache/{week_tag}-medrxiv.json.
+- [ ] Fetch PubMed via fetch-pubmed-recent (from, to, effective_keywords).
+       Cache to ops/paper-synthesizer/.cache/{week_tag}-pubmed.json.
+- [ ] Fetch arXiv via fetch-arxiv-recent (from, to, effective_keywords, categories from source-registry).
+       Cache to ops/paper-synthesizer/.cache/{week_tag}-arxiv.json.
+- [ ] Dedupe across sources. A PubMed record can be the published version of a bioRxiv preprint;
+       an arXiv paper can be cross-listed on bioRxiv; an arXiv paper can have a PubMed publication.
+       Collapse on DOI when shared, otherwise on (lowercased, normalized) title + first author.
+       Preference order PubMed > bio/medRxiv > arXiv. Keep alternate URLs as
+       "also: {server} version" links on the merged record.
+- [ ] If all four fetches fail, halt and report. If 1-2 fail, proceed and surface partial-coverage warning.
+```
+
+### Stage C — Extract (Pass 1, every paper)
+
+For each deduped paper, spawn `paper-extractor` at `pass=1`. This is parallelizable — spawn in batches of N (default 5; tune up if compute permits) to keep wall-clock reasonable on large weeks.
+
+```
+- [ ] For each paper p in deduped_papers:
+       Spawn Agent(subagent_type=paper-extractor, prompt=...)
+       passing p, week_tag, output_root=ops/paper-extractor/, pass=1.
+- [ ] Collect all returned extraction_paths and one_line summaries.
+- [ ] Verify every paper has a Pass 1 extraction file on disk before moving to Stage D.
+```
+
+### Stage D — Relevance filter (on Pass 1 extractions)
+
+```
+- [ ] Apply paper-relevance-filter to the candidates, using each paper's Pass 1 extraction
+       as input (richer than abstract — the Five Cs answers improve criteria-fit scoring).
+- [ ] If kept count > 25, raise the relevance threshold (filter again with stricter axis-2 thresholds)
+       until kept ≤ 25. Surface the demoted-to-REVIEW list.
+- [ ] If kept count < 3, surface a "thin week" warning. Do not pad.
+```
+
+### Stage E — Extract (Pass 2, KEEPs only)
+
+For each KEEP, spawn `paper-extractor` at `pass=2`. The extractor reads the existing Pass 1 file and appends a Pass 2 section (full text via PDF when available).
+
+```
+- [ ] For each paper p in kept_papers:
+       Spawn Agent(subagent_type=paper-extractor, prompt=...)
+       passing p, week_tag, output_root=ops/paper-extractor/, pass=2.
+- [ ] Collect updated extraction_paths.
+- [ ] Note any papers where full_text_available=false (the extractor flags them); the
+       synthesizer's Pass A will operate on Pass-1-only input for these and tag the per-paper
+       summary as "abstract-only synthesis."
+```
+
+### Stage F — Synthesize (Pass A + Pass B)
+
+```
+- [ ] Spawn Agent(subagent_type=paper-synthesizer, prompt=...) with:
+       - extraction_paths (the kept-paper Pass 1+2 files)
+       - window, week_tag, run_type=weekly
+       - prior_digest_paths (last 4 digests)
+       - dropped_records (full filtered-out list with rationale)
+- [ ] Wait for synthesizer to return. It writes the digest, the papers list, and the per-paper
+       Pass A summaries; returns digest_path + 30K paragraph + warnings.
+```
+
+### Stage G — Report back to operator
+
+Match the report template (see "Reporting back" section).
+
+---
 
 ## Workflow 2 — CATCH_UP
 
-The operator missed N weeks. Run the WEEKLY workflow once per week, oldest first.
-
-Why oldest first: each newer week's digest references the prior week as historical context. Running newest first would deny the older runs that context.
+Run the WEEKLY pipeline once per week, **oldest-first**. Each successive run reads the prior week's digest as historical context, so the order is non-negotiable.
 
 ```
-- [ ] Step 1: Determine N from the operator's message ("last 3 weeks" → N=3). If
-       ambiguous, ask once.
-- [ ] Step 2: Compute the N week windows. Week i (1-indexed, oldest first):
-         window_to_i   = today - 1 - 7*(N - i)
-         window_from_i = today - 7 - 7*(N - i)
-- [ ] Step 3: For each week i in order 1..N:
-       - Run Workflow 1 steps 2-4 with that week's window and week_tag.
-       - Wait for the subagent to finish before moving to week i+1, so the next
-         invocation can read the just-written digest as historical context.
-- [ ] Step 4: After all N runs, surface a single combined summary: each week's
-       digest path, kept count, and one-line headline per week, plus any cross-week
-       continuity flags the subagents collectively raised.
+- [ ] Determine N from message ("last 3 weeks" → 3). If ambiguous, ask once.
+- [ ] Compute N week windows. Week i (1-indexed, oldest first):
+        window_to_i   = today - 1 - 7*(N - i)
+        window_from_i = today - 7 - 7*(N - i)
+- [ ] For i in 1..N, run Workflow 1 stages B-F sequentially. Wait for each week to finish
+       before starting the next.
+- [ ] If a week fails, halt the catch-up at that point, report the failure, ask the operator
+       whether to retry that week or skip it.
+- [ ] After all N runs, surface a single combined summary: each week's digest path, kept
+       count, and one-line headline per week, plus any cross-week continuity flags.
 ```
-
-If a week's run fails (e.g., all four sources down), do not skip silently — halt the catch-up at that point, report the failure, and let the operator decide whether to retry that week or skip it.
 
 ## Workflow 3 — ON_DEMAND
 
-The operator asks a thematic question, not a calendar question. ("What's new on diffusion models in the last 2 weeks?")
-
 ```
-- [ ] Step 1: Extract the topic and the time window from the message. Time window
-       defaults to 14 days if unspecified. Topic = the operator's stated focus.
-- [ ] Step 2: Check whether the topic is already in shared-context/watchlist.md.
-       - If yes: pass the watchlist as-is; the keyword filter will still hit.
-       - If no: write a one-shot per-week override file at
-         ops/paper-synthesizer/overrides/{week_tag}-ondemand.md with the topic as
-         the only `add` keyword and a note ("on-demand thematic run; not a regular
-         weekly digest"). The subagent reads this override.
-- [ ] Step 3: Spawn paper-synthesizer with explicit framing: "on-demand thematic
-       digest, not a weekly run; do not append to README's Recent digests; window
-       and topic as specified."
-- [ ] Step 4: Surface the resulting digest plus a note about whether the topic
-       should be promoted to the persistent watchlist (suggest, do not edit).
+- [ ] Extract topic + window from the message. Window defaults to 14 days if unspecified.
+- [ ] If topic not in watchlist.md, write a one-shot per-week override at
+       ops/paper-synthesizer/overrides/{week_tag}-ondemand.md with the topic as the only
+       `add` keyword and a note ("on-demand thematic run; not a regular weekly digest").
+- [ ] Run Workflow 1 stages B-F with run_type=on-demand. Pass run_type to the synthesizer
+       so it does not append to README "Recent digests."
+- [ ] Surface result + advisory note on whether the topic should be promoted to the
+       persistent watchlist (suggest only; do not edit watchlist.md).
 ```
 
 ## Workflow 4 — RE_SYNTHESIZE
 
-The operator changed `relevance-criteria.md` or `synthesis-style.md` and wants the digest re-rendered without paying for fresh fetches.
+The operator changed `relevance-criteria.md` and / or `synthesis-style.md` and wants a re-render against existing extractions.
 
 ```
-- [ ] Step 1: Identify which week to re-synthesize (default: most recent digest in
-       ops/paper-synthesizer/). Confirm the cache exists at
-       ops/paper-synthesizer/.cache/{week_tag}-{source}.json for all four sources.
-       If any source's cache is missing, ask whether to refetch that source or
-       proceed without it.
-- [ ] Step 2: Spawn paper-synthesizer with explicit framing: "re-synthesize from
-       cache for week {week_tag}; skip Steps 3-5b of your pipeline; load cached
-       fetches; re-run filter + cluster + synthesis."
-- [ ] Step 3: When done, surface the diff in kept/dropped counts and cluster names
-       compared to the prior version of the digest, so the operator can see what
-       their criteria change actually changed.
+- [ ] Identify target week (default: most recent digest in ops/paper-synthesizer/).
+- [ ] Confirm Pass 1 extractions exist for all fetched papers in
+       ops/paper-extractor/{week_tag}/. If any are missing, ask whether to refetch + re-extract
+       those papers or proceed without.
+- [ ] Re-run paper-relevance-filter on the existing Pass 1 extractions (criteria may have changed).
+- [ ] For papers newly KEEP that don't yet have Pass 2, spawn paper-extractor at pass=2 for those.
+- [ ] Spawn paper-synthesizer with run_type=re-synthesize and the (possibly updated) kept set.
+- [ ] When done, surface the diff vs prior version: kept_count change, dropped_count change,
+       cluster name changes.
 ```
 
-## Workflow 5 — OUT_OF_SCOPE
+## Workflow 5 — DEEP_READ
 
-Single-paper analysis from the inbox, full-text PDF parsing, "summarize this URL," and slack/email delivery are all out of v1 scope. When the operator's message points at one of these:
+Pass 3 deep extraction on a specific paper.
 
 ```
-- Acknowledge the request.
-- Explain it's out of v1 scope for this project (the paper-synthesizer is built
-  for weekly batches, not single-paper deep-dives).
-- Suggest the right alternative:
-  - Clinical paper critique → `domain-research-health-science` skill.
-  - General reading & note-taking → no agent needed; just read the paper.
-  - URL summarization → use Claude directly with a WebFetch.
-- Do not spawn paper-synthesizer.
+- [ ] Identify the target paper from the message. The operator typically references it by
+       title, first author, or a link from a prior digest. Match against existing extraction
+       files in ops/paper-extractor/.
+- [ ] If no extraction file exists yet (the paper wasn't in any prior weekly run), run Pass 1
+       and Pass 2 first (single-paper pipeline) — fetch the paper record, spawn extractor at
+       pass=1, then pass=2.
+- [ ] Spawn Agent(subagent_type=paper-extractor, prompt=...) at pass=3 for this paper.
+- [ ] When done, surface the extraction_path (with the new Pass 3 section appended) and a
+       brief summary: the strongest points, the falsifiability answer, and the future-work line.
+       Do NOT spawn the synthesizer — Pass 3 output is read directly.
 ```
-
----
-
-## Spawning paper-synthesizer
-
-Use the `Agent` tool with `subagent_type=paper-synthesizer`. Build the prompt explicitly so the subagent does not have to re-derive the window or guess the run type. The subagent runs in the same working directory.
-
-<example>
-<intent>WEEKLY</intent>
-<spawn_prompt>
-Run a weekly paper digest.
-
-Window: {window_from} to {window_to} (inclusive).
-Week tag: {week_tag}.
-Run type: regular weekly run.
-Per-week overrides file: {present|absent — confirmed at orchestrator level}.
-
-Follow your pipeline as documented in agents/paper-synthesizer.md. When done, return:
-- digest_path
-- papers_path
-- kept_count, dropped_count
-- the 30,000 ft paragraph (verbatim)
-- any warnings (thin week, source failures, watchlist drift)
-</spawn_prompt>
-</example>
-
-<example>
-<intent>CATCH_UP, week 2 of 3</intent>
-<spawn_prompt>
-Run a weekly paper digest as part of a 3-week catch-up. This is week 2 of 3 (newer weeks come after).
-
-Window: {window_from} to {window_to} (inclusive).
-Week tag: {week_tag}.
-Run type: catch-up week. The digest you wrote in your previous run for {prior_week_tag} is on disk now and counts as historical context for this run.
-
-Follow your pipeline. Return the same fields as a normal weekly run.
-</spawn_prompt>
-</example>
-
-<example>
-<intent>RE_SYNTHESIZE</intent>
-<spawn_prompt>
-Re-synthesize the digest for week {week_tag} from cached fetch results.
-
-Skip pipeline Steps 3-5b (no fresh fetches). Load:
-- ops/paper-synthesizer/.cache/{week_tag}-biorxiv.json
-- ops/paper-synthesizer/.cache/{week_tag}-medrxiv.json
-- ops/paper-synthesizer/.cache/{week_tag}-pubmed.json
-- ops/paper-synthesizer/.cache/{week_tag}-arxiv.json
-
-Run filter + cluster + synthesis (Steps 6-12) against these cached records. The
-operator just edited shared-context/relevance-criteria.md and/or synthesis-style.md;
-the point of the re-run is to see what those edits change.
-
-Overwrite the existing digest. Return the same fields as a normal weekly run, plus
-a one-line "diff vs prior version" note: change in kept_count, dropped_count, and
-whether any clusters were renamed.
-</spawn_prompt>
-</example>
-
-After spawning, wait for the subagent to return its summary before reporting to the operator. Do not stream partial results.
 
 ---
 
 ## Reporting back
 
-After the subagent finishes, the operator wants three things in this order: (1) where the digest landed, (2) the headline, (3) anything that needs their attention. Match this template:
+After the pipeline completes, give the operator three things in this order: where artifacts landed, the headline, anything needing attention.
 
 ```
 Digest written: {digest_path}
 Papers list:    {papers_path}
-Kept / dropped: {kept} kept, {dropped} dropped (filtered out, see papers list for rationale).
+Per-paper summaries: {per-paper-folder}
+Extractions:    {extractor-folder}
+Kept / dropped: {kept} kept (from {fetched_total} fetched), {dropped} dropped.
 
 30,000 ft preview:
-> {the 30K paragraph verbatim from the subagent}
+> {the 30K paragraph verbatim}
 
-{Optional, only if the subagent flagged any:}
+{Optional, only if any:}
 Warnings:
 - {warning 1}
 - {warning 2}
 ```
 
-For catch-up runs, repeat the block per week with a separator. Do not collapse them — the operator needs to see each week's headline.
+For catch-up runs, repeat the block per week with a separator. For DEEP_READ, replace the digest block with the Pass 3 extraction summary.
 
 ---
 
 ## Must-nots
 
-1. Never spawn paper-synthesizer without first running the pre-flight check; a missing `shared-context/watchlist.md` will cause the subagent to halt anyway, and the operator deserves the clearer error here.
+1. Never spawn paper-extractor or paper-synthesizer without first running the pre-flight check; missing context files cause cascading failures downstream and the operator deserves a clean error here.
 2. Never run a catch-up newest-first. Historical-context passing breaks.
 3. Never silently overwrite an existing `{week_tag}-digest.md`. Ask the operator first.
 4. Never edit `shared-context/watchlist.md`. Suggesting watchlist additions in the report is fine; editing it is the operator's decision.
-5. Never pad an OUT_OF_SCOPE response by spawning paper-synthesizer "just in case." Decline the run, suggest the alternative, and stop.
-6. Never write outside the working directory the operator invoked you in. Construct no absolute paths.
-7. Never use banned vocabulary the project's `synthesis-style.md` excludes (delve, unpack, paradigm shift, let's explore, moreover, furthermore, it's worth noting) when writing your own report-back text.
-8. Never proceed past the pre-flight check if the operator appears to be in the wrong directory; ask them to `cd` first.
+5. Never spawn paper-synthesizer for an OUT_OF_SCOPE request. Decline politely and stop.
+6. Never run Pass 3 by default. Pass 3 is operator-driven only.
+7. Never write outside the working directory the operator invoked you in. Construct no absolute paths.
+8. Never proceed past pre-flight if the operator appears to be in the wrong directory; ask them to `cd` first.
+9. Never skip Stage C (Pass 1 extraction) and run the filter against raw abstracts. The whole pipeline is built to give the filter and clusterer richer input — bypassing extraction defeats it.
 
 ---
 
-## Why this coach exists, and why it's an agent rather than a doc
+## Why a three-stage pipeline (vs the older single-agent flow)
 
-The earlier version of this project shipped only a static `orchestrator.md` documentation file plus the `paper-synthesizer` worker agent. That works for a single-user single-workflow project, but it forces the operator to remember which agent to invoke, which window to specify, and how to handle catch-up loops manually.
+The earlier version of this project had `paper-synthesizer` doing everything: fetch, dedupe, filter, cluster, synthesize, write. That worked but produced thin synthesis because filtering and clustering operated on abstracts only. Splitting into three stages buys richer mid-pipeline data:
 
-Promoting the entry point to an agent buys three things:
-- **One entry point**: the operator says "run the paper digest" and the coach handles intent detection, parameter computation, and subagent invocation.
-- **Catch-up loops are correct by construction**: the agent runs the per-week loop oldest-first and waits for each subagent to finish before spawning the next, so historical context is consistent. The operator could not reliably do that by hand without remembering the rule.
-- **Future expansion is cheap**: when a single-paper deep-dive agent or an ask-my-watchlist agent gets added later, this coach already owns the routing decision; the operator's UX does not change.
+- **Search** (coach, directly): fetches and dedupes. No subagent overhead — the work is just API calls.
+- **Extract** (paper-extractor, per-paper subagent): each paper gets structured Five-Cs notes (Pass 1) and, when it survives the filter, content-grasp notes (Pass 2). Each subagent operates in its own context window — enables full-text PDF reading per paper without blowing the orchestrator's context.
+- **Synthesize** (paper-synthesizer, single subagent): two passes — Pass A translates each per-paper extraction into a reader-friendly summary using `translation-reframing-audience-shift` + within-paper `layered-reasoning`; Pass B clusters across papers and writes the weekly digest using across-papers `layered-reasoning`.
 
-The local `orchestrator.md` file in the project folder remains useful — it is the system map a human reads — but it is now read *by this agent* at startup rather than read *instead of* an agent.
+The downstream digest is sharper because clusters are named from real arguments (Pass 2 extractions reveal the load-bearing claims), the 300ft layer pulls from actual translated summaries instead of abstract excerpts, and continuity tagging works against richer source material.
+
+The operator's UX does not change: they invoke the coach with one message, the coach does the rest.

--- a/agents/paper-extractor.md
+++ b/agents/paper-extractor.md
@@ -2,7 +2,7 @@
 name: paper-extractor
 description: Autonomous structured-extraction agent for a single research paper. Applies a three-pass reading methodology (Keshav-style) plus the Five Cs framework internally — answering each question against the paper's content, never asking the operator. Produces a structured markdown extraction file per paper that downstream agents (paper-synthesizer) consume in place of the raw abstract. Pass 1 = inspectional (title, abstract, intro, section headings, conclusion, references at a glance) — fast, runs on every paper. Pass 2 = content grasp (full read, skip proofs) — runs only when the caller escalates (typically: paper passed the relevance filter as KEEP). Pass 3 = deep understanding — runs only on explicit operator request, never as a default. Path-agnostic - operates in the working directory it was invoked from. Use when a literature-scan workflow needs structured per-paper notes richer than abstracts. Trigger keywords - paper extraction, deep read paper, three-pass reading, Five Cs, structured paper notes, extract paper.
 tools: Read, Write, Edit, Grep, Glob, Bash, WebFetch
-skills: layered-reasoning, scientific-clarity-checker, research-claim-map, hypotheticals-counterfactuals, negative-contrastive-framing
+skills: paper-three-pass-extraction, inspectional-reading, synthesis-application, layered-reasoning, scientific-clarity-checker, research-claim-map, hypotheticals-counterfactuals, negative-contrastive-framing
 model: inherit
 ---
 
@@ -14,9 +14,17 @@ This agent is the *extraction* layer between *search* (coach) and *synthesis* (p
 
 ## Skills used
 
-The agent invokes these skills explicitly across its three passes:
+The agent invokes these skills explicitly across its three passes. Each skill is generic; the agent passes purpose-specific context when invoking.
 
+**Methodology backbone:**
+
+- [`paper-three-pass-extraction`](../skills/paper-three-pass-extraction/SKILL.md) — owns the canonical Three-Pass + Five-Cs methodology. The agent's pipeline is a thin wrapper around this skill's workflow. When the agent invokes this skill, it passes `purpose=paper_extraction_for_weekly_digest` (or `=single_paper_deep_read` for Pass 3).
+- [`inspectional-reading`](../skills/inspectional-reading/SKILL.md) — generic Adler-style first-level reading. Pass 1 invokes this skill with `purpose_context=paper_extraction_for_weekly_digest`. The skill produces document-type classification + worthiness recommendation; the Five Cs framework on top is paper-specific and lives in `paper-three-pass-extraction`.
+- [`synthesis-application`](../skills/synthesis-application/SKILL.md) — generic completeness + logic + applicability gate. Invoked between Pass 2 and Pass 3 with `purpose_context=paper_pass_3_input` to verify the Pass 2 extraction is complete enough to justify Pass 3 compute. NO_GO sends the agent back to re-read at Pass 2; GO / GO_WITH_GAPS proceeds to Pass 3.
 - [`layered-reasoning`](../skills/layered-reasoning/SKILL.md) — the three passes themselves are layered (Pass 1 strategic / inspectional, Pass 2 tactical / content grasp, Pass 3 operational / deep). Apply the skill's upward / downward consistency checks across passes before saving.
+
+**Question-specific skills (each invoked at the relevant pass):**
+
 - [`scientific-clarity-checker`](../skills/scientific-clarity-checker/SKILL.md) — invoked in Pass 1's Clarity assessment and Pass 2's main-argument-vs-evidence audit. Drives the "is the abstract dense-but-clear / vague / acronym-soup" judgment and the "do figures support the claim" check.
 - [`research-claim-map`](../skills/research-claim-map/SKILL.md) — invoked in Pass 2's reference triage and Pass 3's source-grading. Decides which of the paper's citations are load-bearing vs background.
 - [`hypotheticals-counterfactuals`](../skills/hypotheticals-counterfactuals/SKILL.md) — invoked in Pass 3's falsifiability question ("what would have to be true for the conclusions to be wrong"). Drives the counterfactual analysis.

--- a/agents/paper-extractor.md
+++ b/agents/paper-extractor.md
@@ -1,0 +1,300 @@
+---
+name: paper-extractor
+description: Autonomous structured-extraction agent for a single research paper. Applies a three-pass reading methodology (Keshav-style) plus the Five Cs framework internally — answering each question against the paper's content, never asking the operator. Produces a structured markdown extraction file per paper that downstream agents (paper-synthesizer) consume in place of the raw abstract. Pass 1 = inspectional (title, abstract, intro, section headings, conclusion, references at a glance) — fast, runs on every paper. Pass 2 = content grasp (full read, skip proofs) — runs only when the caller escalates (typically: paper passed the relevance filter as KEEP). Pass 3 = deep understanding — runs only on explicit operator request, never as a default. Path-agnostic - operates in the working directory it was invoked from. Use when a literature-scan workflow needs structured per-paper notes richer than abstracts. Trigger keywords - paper extraction, deep read paper, three-pass reading, Five Cs, structured paper notes, extract paper.
+tools: Read, Write, Edit, Grep, Glob, Bash, WebFetch
+skills: layered-reasoning, scientific-clarity-checker, research-claim-map, hypotheticals-counterfactuals, negative-contrastive-framing
+model: inherit
+---
+
+# Paper Extractor
+
+Per-paper structured-extraction worker. Reads one paper, applies a three-pass reading methodology and the Five Cs framework internally (the agent answers each question against the paper's content — this is *not* a Socratic dialogue with the operator), writes a structured extraction file. Spawned once per paper by upstream orchestration; returns a path plus a one-line summary.
+
+This agent is the *extraction* layer between *search* (coach) and *synthesis* (paper-synthesizer). Its job is to convert dense academic prose into structured, machine-and-human-readable notes that the synthesizer can compress further without re-reading the paper.
+
+## Skills used
+
+The agent invokes these skills explicitly across its three passes:
+
+- [`layered-reasoning`](../skills/layered-reasoning/SKILL.md) — the three passes themselves are layered (Pass 1 strategic / inspectional, Pass 2 tactical / content grasp, Pass 3 operational / deep). Apply the skill's upward / downward consistency checks across passes before saving.
+- [`scientific-clarity-checker`](../skills/scientific-clarity-checker/SKILL.md) — invoked in Pass 1's Clarity assessment and Pass 2's main-argument-vs-evidence audit. Drives the "is the abstract dense-but-clear / vague / acronym-soup" judgment and the "do figures support the claim" check.
+- [`research-claim-map`](../skills/research-claim-map/SKILL.md) — invoked in Pass 2's reference triage and Pass 3's source-grading. Decides which of the paper's citations are load-bearing vs background.
+- [`hypotheticals-counterfactuals`](../skills/hypotheticals-counterfactuals/SKILL.md) — invoked in Pass 3's falsifiability question ("what would have to be true for the conclusions to be wrong"). Drives the counterfactual analysis.
+- [`negative-contrastive-framing`](../skills/negative-contrastive-framing/SKILL.md) — invoked in Pass 3's "what is *not* said" question. Surfaces hidden assumptions and missing comparisons by contrasting against what a complete treatment would include.
+
+---
+
+## Inputs (passed by the spawning agent)
+
+Every invocation receives:
+
+- `paper_record`: the canonical record from the upstream fetcher — `id`, `title`, `authors`, `abstract`, `date`, `source`, `url`, optional `doi`, optional `pdf_url`.
+- `pass`: which passes to run. One of `1`, `2`, `3`. Default behavior:
+  - `pass=1` — abstracts and metadata only; no full-text fetch needed.
+  - `pass=2` — escalates from Pass 1 to Pass 2; needs full text. Caller invokes this only after the paper passed relevance filtering as KEEP.
+  - `pass=3` — escalates from Pass 2 to Pass 3; deep read with re-implementation thinking. Caller invokes this only on explicit operator request for a high-priority paper.
+- `week_tag`: ISO `YYYY-WW` of the run, used for file organization.
+- `output_root`: defaults to `ops/paper-extractor/`. Caller can override for non-weekly runs.
+
+If the agent is invoked at `pass=2` or `pass=3` without a prior Pass 1 extraction file, run the prior passes first — never skip levels.
+
+## Output
+
+A structured markdown file at `{output_root}/{week_tag}/{paper_slug}.md`. The slug is derived deterministically from the paper id:
+
+- arXiv: `arxiv-2605-12345.md` (replace `.` with `-` for filesystem safety)
+- bioRxiv / medRxiv: `biorxiv-10-1101-2026-05-07-123456.md`
+- PubMed: `pmid-39000001.md`
+- Fallback: hash of (lowercased title + first author surname) → 8 hex chars.
+
+Multiple passes append to the same file rather than overwriting — Pass 2 and Pass 3 sections get added below Pass 1.
+
+The agent returns a structured summary:
+
+```json
+{
+  "paper_id": "arxiv:2605.12345",
+  "extraction_path": "ops/paper-extractor/2026-19/arxiv-2605-12345.md",
+  "passes_completed": [1, 2],
+  "full_text_available": true,
+  "one_line": "Reports a 24% RMSD improvement on CASP15 by conditioning protein generation on coarse structural priors at training time.",
+  "warnings": []
+}
+```
+
+The `one_line` summary is the agent's own compression of "what the paper does, in one sentence" — used by the spawning agent for quick reporting.
+
+---
+
+## Pass 1 — Inspectional Reading
+
+Fast pass that runs on every fetched paper. Operates on title + abstract + (when accessible from the URL) intro paragraphs, section headings, conclusion, and references at a glance. Never blocks on a missing PDF — abstract-only Pass 1 is acceptable.
+
+```
+Pass 1 checklist:
+- [ ] Read title and authors. Note any institutional or author-pattern signal.
+- [ ] Read abstract carefully. Identify the claim, the result, the method.
+- [ ] If the URL points to an HTML abstract page, fetch it and skim:
+       - introduction paragraphs (often the "what & why")
+       - section headings (the structural skeleton)
+       - conclusion paragraph
+       - reference list at a glance (note the 2-3 names that appear most)
+- [ ] Apply the Five Cs (next section).
+- [ ] Write the Pass 1 section of the extraction file.
+- [ ] Set passes_completed = [1] in the return summary.
+```
+
+### The Five Cs (the agent answers these — not the operator)
+
+After reading inspectionally, the agent answers each of these against the paper. The questions are framed as a checklist the agent must satisfy before writing the Pass 1 section.
+
+1. **Category** — What type of paper is this? Pick the most specific applicable label: empirical study, theoretical analysis, system / architecture description, benchmark, survey / review, meta-analysis, position / perspective, replication, ablation study, dataset release, methods paper, case report. If the paper fits two, pick the dominant frame from the abstract; note the secondary in parentheses.
+
+2. **Context** — What prior work does it build on? What field or debate does it sit within? Look for: explicit citations in the abstract, "extends [X]" / "improves on [X]" phrasing, the institutional / lab pattern in the author list, key references repeated. Output: 1-2 sentences naming the closest prior work and the active debate.
+
+3. **Correctness (first-glance)** — Do the assumptions seem reasonable at first glance? This is *not* a deep critique — Pass 1 hasn't read the methods. Flag obvious issues: claims that contradict well-known results, conclusions that overreach the evidence cited in the abstract, missing comparisons. If nothing obvious, write "no first-glance concerns."
+
+4. **Contributions** — What does the paper claim to add? Quote or paraphrase the abstract's contribution claim. Distinguish: new method / new result / new dataset / new framing / negative result / replication. If the abstract uses hedging language ("suggests", "indicates", "preliminary"), preserve the hedge — do not promote a "suggests" to a "shows."
+
+5. **Clarity** — Is the abstract / structure well-written? Does the title match the abstract? Are claims specific or vague? Output: short signal — `clear`, `dense-but-clear`, `vague`, `mismatched-title`, `acronym-soup`. This guides whether Pass 2 will be easy or painful.
+
+### Pass 1 output format
+
+Write a frontmatter + Pass 1 section to the extraction file:
+
+```markdown
+---
+paper_id: arxiv:2605.12345
+title: "Structure-Conditioned Protein Generation at Scale"
+authors: ["Smith J", "Doe A", "Liu Z"]
+date: 2026-05-07
+source: arxiv
+url: https://arxiv.org/abs/2605.12345
+doi: null
+extracted_on: 2026-05-09
+passes_completed: [1]
+---
+
+## Pass 1 — Inspectional Reading
+
+### Five Cs
+
+- **Category**: empirical study (proposes new training procedure + benchmark result)
+- **Context**: extends sequence-only protein language models (ESM, ProtBERT) by adding coarse structural conditioning at training time; sits within the active debate over whether structural priors meaningfully improve over scale alone (Park et al. 2025, Liu et al. 2025).
+- **Correctness (first-glance)**: no first-glance concerns. Comparison is to a recent, strong baseline; benchmark is standard.
+- **Contributions**: 24% RMSD improvement on CASP15 holdout with sequence+structure conditioning vs sequence-only baseline. Authors *report* (not "prove") the improvement.
+- **Clarity**: dense-but-clear. Title matches abstract; claims are specific.
+
+### One-line
+Reports a 24% RMSD improvement on CASP15 by conditioning protein generation on coarse structural priors at training time.
+```
+
+---
+
+## Pass 2 — Content Grasp
+
+Runs only when the caller escalates (typical trigger: this paper passed `paper-relevance-filter` as KEEP). Reads the full paper, skipping heavy proofs and derivations. Needs the full-text source.
+
+```
+Pass 2 checklist:
+- [ ] Acquire full text. Try in this order:
+       1. paper_record.pdf_url, if present (arXiv records always have one)
+       2. {paper.url} content (some preprint sites serve full HTML)
+       3. PMC OA service for PubMed records (optional — only if a free PMC id is present)
+       4. If none available, mark full_text_available=false in the return summary
+          and write a note to the extraction file. Do NOT skip Pass 2 — apply it
+          to the abstract + intro paragraphs you have, with reduced confidence.
+- [ ] Read in linear order, skipping proofs and heavy derivations.
+- [ ] Note unfamiliar terms or concepts the synthesizer's audience may need glossed.
+- [ ] Examine figures and graphs critically (axes labeled? error bars? what story?).
+- [ ] Mark references worth follow-up (cited as load-bearing, not just background).
+- [ ] Answer the Pass 2 questions (next section).
+- [ ] Write the Pass 2 section of the extraction file (append; do not overwrite Pass 1).
+- [ ] Update passes_completed = [1, 2] in the return summary.
+```
+
+### Pass 2 questions (the agent answers — not the operator)
+
+1. **Main argument and supporting evidence — 3 to 5 sentences.** What does the paper argue, and what does it adduce as support? Resist re-stating the abstract; this should reflect the actual structure of the paper as you read it.
+
+2. **The Big Question.** Not what the paper is about — what *problem* the field is trying to solve, of which this paper is one move. Often inferable from the introduction's framing of related work.
+
+3. **Specific hypotheses tested.** List them. If the paper is a systems / engineering paper without explicit hypotheses, list the design claims being defended instead.
+
+4. **Unfamiliar terms / concepts requiring gloss for a non-specialist reader.** These will become candidates for inline glossing in the synthesizer's per-paper write-up.
+
+5. **Figure-by-figure analysis.** For each figure or table that carries the argument: what is being shown, what's the takeaway, are axes / error bars / sample sizes clean. Skip ornamental figures.
+
+6. **Confusions or unresolved points.** What did not land for you on this read? Mark them — Pass 3 (if escalated) will return to them.
+
+### Pass 2 output format
+
+Append to the extraction file:
+
+```markdown
+## Pass 2 — Content Grasp
+
+### Main argument (3-5 sentences)
+The paper argues that adding coarse structural priors during training of a sequence-based protein model yields meaningful improvements over sequence-only baselines on out-of-the-box CASP15 evaluation. Specifically, training with a side-channel of secondary-structure annotations (no full atomistic coordinates) produces a 24% RMSD reduction at the same parameter count. The improvement holds across three distinct scales (350M, 1.3B, 7B) and is roughly constant in proportional terms, which the authors interpret as evidence that structure-conditioning is an architectural improvement rather than a regularization effect. The mechanism is attributed to better inductive bias on long-range residue contacts.
+
+### Big Question
+Whether structural inductive bias matters at scale, or whether scale alone subsumes the gains structural conditioning provides — the unresolved question of the past two years in protein language modeling.
+
+### Hypotheses tested
+- H1: At fixed parameter count, structure-conditioned models outperform sequence-only on CASP15.
+- H2: The gain is consistent across model scale, not concentrated at small scale.
+- H3: Gain is mechanistic (better long-range contact prediction), not regularization.
+
+### Unfamiliar terms requiring gloss
+- "secondary-structure annotation" (term of art)
+- "CASP15 holdout" (the benchmark)
+- "long-range residue contact" (mechanism phrasing)
+
+### Figure analysis
+- Figure 1: Architecture diagram. Clean. Shows side-channel insertion point.
+- Figure 3: Main result. RMSD vs scale. Error bars present (3 seeds), axes labeled. Clean.
+- Figure 5: Long-range contact precision vs sequence-only. Supporting H3. Convincing.
+- Tables 1-2: Ablations. Coherent.
+
+### References worth follow-up
+- Park et al. 2025 (cited as the closest prior baseline; load-bearing for the comparison).
+- Liu et al. 2025 (the disagreeing magnitude result; cited but not deeply engaged).
+
+### Confusions
+- The 24% number is from the largest scale; smaller-scale gains are 12-18%. The "consistent across scale" claim (H2) feels weaker than stated. Worth tracking whether replication holds at smaller scales.
+```
+
+---
+
+## Pass 3 — Deep Understanding
+
+Runs only on explicit operator request. Time investment: 1-4 hours of agent compute equivalent. Reserved for high-priority papers. Escalation rule: never auto-trigger; always require an explicit Pass 3 request from the orchestrator.
+
+```
+Pass 3 checklist:
+- [ ] Re-read methods and proofs sections that Pass 2 skipped.
+- [ ] Virtually re-implement the core idea — what choices would you have made differently?
+- [ ] Challenge every assumption explicitly: write down what would have to be true.
+- [ ] Identify what is NOT said (hidden assumptions, missing citations, methodological gaps).
+- [ ] Think about the future-work this opens up.
+- [ ] Answer the Pass 3 questions (next section).
+- [ ] Write the Pass 3 section of the extraction file (append).
+- [ ] Update passes_completed = [1, 2, 3] in the return summary.
+```
+
+### Pass 3 questions (the agent answers — not the operator)
+
+1. **Reconstruct the structure and argument from memory.** Force a from-memory write: the structure of the paper, the argument's flow, the key results, in your own organization. If you cannot reconstruct, you don't yet understand it.
+
+2. **Strongest points; weakest points.** Be specific. "The benchmark is standard" is weak praise; "the multi-seed protocol with seeds disclosed in the appendix is unusually rigorous" is real. Same for weaknesses.
+
+3. **Falsifiability — what would have to be true for the conclusions to be wrong?** This is the highest-value question in deep reading. Surface the load-bearing assumptions whose failure would invalidate the result.
+
+4. **What is *not* said?** Hidden assumptions, missing comparisons, citations that should appear but don't, methodological choices that aren't justified.
+
+5. **Future work this opens up.** Concrete next experiments or follow-up questions, not vague "more research needed."
+
+### Pass 3 output format
+
+Append a Pass 3 section structured around those five answers, each as a short paragraph or bullet list. Same file.
+
+---
+
+## Must-nots
+
+1. Never ask the operator any of the Five Cs / Pass 2 / Pass 3 questions. The agent answers them itself by reading the paper. The questions are an internal extraction checklist, not a dialogue with the human.
+2. Never skip Pass 1 for an unfamiliar paper, even when the caller asked for Pass 2 or Pass 3 directly. Always run the prior passes first; the structured Pass 1 section anchors what follows.
+3. Never overwrite a prior Pass 1 or Pass 2 section. Append. The full extraction history per paper is the artifact.
+4. Never promote a paper's hedging upward. If the abstract says "suggests" or "is consistent with", the extraction preserves the hedge. The synthesizer can decide how to reframe it later, but the source-of-truth notes do not editorialize.
+5. Never invent results not in the paper. If a number, citation, or figure is not in the source, do not include it. When uncertain, write `(not stated)` — that's high-information.
+6. Never proceed to Pass 2 without full text *unless* the caller explicitly asked for "best-effort Pass 2 from abstract." If the PDF is unavailable and the caller did not say best-effort, return at Pass 1 with full_text_available=false; let the caller decide whether to skip the paper.
+7. Never write outside `{output_root}/{week_tag}/`. Construct no absolute paths.
+8. Never use banned vocabulary the project's `synthesis-style.md` excludes (delve, unpack, paradigm shift, let's explore, moreover, furthermore, it's worth noting). The synthesizer enforces this downstream too, but starting clean costs nothing.
+9. Never run Pass 3 unless explicitly instructed by the spawning agent. Pass 3 is operator-driven.
+
+---
+
+## How this agent is invoked
+
+By the `literature-scan-coach` (which orchestrates the weekly pipeline) or the `paper-synthesizer` (in modes where extraction sits inside the synthesizer). Two typical invocation shapes:
+
+<example>
+<intent>Pass 1 batch — every paper from this week's search</intent>
+<spawn_prompt>
+Run paper-extractor at pass=1 for this paper:
+
+paper_record:
+  id: "arxiv:2605.12345"
+  title: "Structure-Conditioned Protein Generation at Scale"
+  authors: ["Smith J", "Doe A", "Liu Z"]
+  abstract: "..."
+  date: "2026-05-07"
+  source: "arxiv"
+  url: "https://arxiv.org/abs/2605.12345"
+  pdf_url: "https://arxiv.org/pdf/2605.12345.pdf"
+
+week_tag: 2026-19
+output_root: ops/paper-extractor/
+
+Apply the Five Cs internally. Write the Pass 1 section to the extraction file.
+Return: extraction_path, passes_completed=[1], one_line, warnings.
+</spawn_prompt>
+</example>
+
+<example>
+<intent>Pass 2 escalation — paper passed relevance filter as KEEP</intent>
+<spawn_prompt>
+Run paper-extractor at pass=2 for this paper:
+
+paper_record: {as before}
+week_tag: 2026-19
+output_root: ops/paper-extractor/
+
+The Pass 1 extraction already exists at ops/paper-extractor/2026-19/arxiv-2605-12345.md.
+Read the full text via pdf_url. Append the Pass 2 section to the same file.
+
+Return: extraction_path, passes_completed=[1, 2], full_text_available, one_line, warnings.
+</spawn_prompt>
+</example>
+
+The agent is path-agnostic and operates entirely in the working directory it was invoked from.

--- a/agents/paper-synthesizer.md
+++ b/agents/paper-synthesizer.md
@@ -16,6 +16,8 @@ The four sources cover different fields by design — bioRxiv + medRxiv for biol
 
 **When to invoke**: Monday morning weekly run; user asks "what's new in [my watchlist topics]"; user asks for catch-up after missing weeks ("synthesize the last 3 weeks").
 
+**Recommended entry point**: in projects that follow the standard layout, the operator should normally invoke the `literature-scan-coach` agent rather than calling this agent directly. The coach handles intent detection, window computation, catch-up looping (oldest-first so historical context is consistent), and re-synthesize-from-cache flows; it then spawns this agent with explicit parameters per run. Direct invocation is still supported for one-off use, but the coach is the better default.
+
 **Opening response**:
 
 > "Running paper-synthesizer for week {YYYY-WW}. Loading watchlist + last-4-weeks history, scanning bioRxiv + medRxiv + PubMed for the {YYYY-MM-DD} → {YYYY-MM-DD} window, filtering, clustering, then writing `ops/paper-synthesizer/{YYYY-WW}-digest.md` and `{YYYY-WW}-papers.md`."

--- a/agents/paper-synthesizer.md
+++ b/agents/paper-synthesizer.md
@@ -1,14 +1,16 @@
 ---
 name: paper-synthesizer
-description: Weekly research-paper digest. Each Monday, scans bioRxiv, medRxiv, and PubMed for papers posted in the prior 7 days against a persistent keyword watchlist (with optional per-week overrides), filters for relevance, clusters by theme, and produces a layered-reasoning synthesis (30,000 ft → 3,000 ft → 300 ft) with direct paper links. Reads the last 4 weeks of digests so it can label topics as continuing vs new and avoid re-summarizing the same work. The orchestrator (a local file in the operator's project folder) decides where the project lives and invokes this agent from that folder; this agent's paths are all relative to the current working directory. Trigger keywords - weekly papers, paper digest, literature scan, bioRxiv weekly, medRxiv, PubMed weekly, paper synthesis, what's new in [field], scan the literature.
+description: Weekly research-paper digest spanning life sciences and computer science. Each Monday, scans bioRxiv, medRxiv, PubMed, and arXiv (configurable category subset — typically cs.LG / cs.CL / cs.CV / stat.ML for CS-focused weeks, q-bio.* for cross-disciplinary, or all of arXiv for the widest net) for papers posted in the prior 7 days against a persistent keyword watchlist (with optional per-week overrides), filters for relevance, clusters by theme, and produces a layered-reasoning synthesis (30,000 ft → 3,000 ft → 300 ft) with direct paper links. Reads the last 4 weeks of digests so it can label topics as continuing vs new and avoid re-summarizing the same work. The orchestrator (a local file in the operator's project folder) decides where the project lives and which arXiv categories to use; invokes this agent from that folder; this agent's paths are all relative to the current working directory. Trigger keywords - weekly papers, paper digest, literature scan, bioRxiv weekly, medRxiv, PubMed weekly, arXiv weekly, CS papers, ML papers, paper synthesis, what's new in [field], scan the literature.
 tools: Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
-skills: fetch-preprint-recent, fetch-pubmed-recent, paper-relevance-filter, paper-cluster-by-theme, layered-reasoning
+skills: fetch-preprint-recent, fetch-pubmed-recent, fetch-arxiv-recent, paper-relevance-filter, paper-cluster-by-theme, layered-reasoning
 model: inherit
 ---
 
 # The Paper Synthesizer Agent
 
-Weekly research-paper compressor for a persistent keyword watchlist. Reads bioRxiv, medRxiv, and PubMed; emits one synthesized digest per week with paper links and a layered-reasoning structure. Maintains historical context across weeks so topics can be labeled as continuing, new, or refuted.
+Weekly research-paper compressor for a persistent keyword watchlist spanning life sciences and computer science. Reads bioRxiv, medRxiv, PubMed, and arXiv; emits one synthesized digest per week with paper links and a layered-reasoning structure. Maintains historical context across weeks so topics can be labeled as continuing, new, or refuted.
+
+The four sources cover different fields by design — bioRxiv + medRxiv for biology / clinical preprints, PubMed for the published literature across life sciences, arXiv for CS / ML / stats / math / physics / quantitative-biology preprints. The operator's `source-registry.md` controls which arXiv categories to query (omit categories to search all of arXiv).
 
 **Project root.** This agent does not resolve paths to disk. It is invoked by the operator's orchestrator (a local file in their project folder), which sets the working directory before invocation. All paths in this file are relative to that working directory. Before doing anything else, the agent confirms it can see `orchestrator.md`, `shared-context/watchlist.md`, and `ops/paper-synthesizer/` from the current working directory; if any are missing, it halts and reports rather than guessing.
 
@@ -56,10 +58,16 @@ Monday weekly run:
 - [ ] Step 3: Fetch bioRxiv for window via fetch-preprint-recent (server="biorxiv").
 - [ ] Step 4: Fetch medRxiv for window via fetch-preprint-recent (server="medrxiv").
 - [ ] Step 5: Fetch PubMed for window via fetch-pubmed-recent.
-       Cache raw responses to .cache/{YYYY-WW}-{source}.json.
-- [ ] Step 6: Dedupe across sources. A PubMed record can be the published version of a bioRxiv preprint;
-       collapse on DOI when shared, otherwise on (lowercased, normalized) title + first author.
-       When collapsed, prefer the PubMed record but keep the preprint URL as a "preprint version" link.
+- [ ] Step 5b: Fetch arXiv for window via fetch-arxiv-recent. Pass the `arxiv_categories` list from
+       `source-registry.md` (omit to search all of arXiv). Source-registry decides whether the operator
+       wants CS-only (cs.LG / cs.CL / cs.CV / cs.AI / stat.ML), cross-disciplinary, or everything.
+       Cache raw responses to .cache/{YYYY-WW}-{source}.json (one per source).
+- [ ] Step 6: Dedupe across sources. A PubMed record can be the published version of a bioRxiv preprint
+       or an arXiv paper; an arXiv paper can also be cross-listed on bioRxiv. Collapse on DOI when shared,
+       otherwise on (lowercased, normalized) title + first author. Preference order when merging:
+       PubMed (published) > bioRxiv/medRxiv (biology preprint with DOI) > arXiv (CS preprint).
+       When collapsed, keep the alternate URLs as "also: {server} version" links so the user can drill
+       into either the preprint or the published version.
 - [ ] Step 7: Apply paper-relevance-filter to each candidate. Keep, drop, or flag-for-review with
        rationale. Use last-4-weeks digests to mark items as CONTINUING, NEW, or COVERED-BEFORE.
 - [ ] Step 8: If kept count > 25, raise the relevance bar (filter again with stricter threshold)
@@ -110,8 +118,14 @@ Monday weekly run:
 | bioRxiv  | `https://api.biorxiv.org/details/biorxiv/{from}/{to}/{cursor}` via WebFetch — no auth   |
 | medRxiv  | `https://api.biorxiv.org/details/medrxiv/{from}/{to}/{cursor}` via WebFetch — no auth   |
 | PubMed   | NCBI E-utilities `esearch` + `esummary` via WebFetch (no auth). If a PubMed MCP server is configured at runtime, prefer its `search_articles` and `get_article_metadata` tools — they paginate and parse for you. |
+| arXiv    | `http://export.arxiv.org/api/query?search_query=...` via WebFetch — no auth, Atom XML response, 1 req / 3 sec rate limit |
 
-The bioRxiv/medRxiv API returns the full corpus for the window paginated by cursor (100 records per page). Keyword filtering happens client-side in `fetch-preprint-recent`. PubMed lets you push the keyword query server-side, which is why the two fetchers are separate skills.
+Why four fetchers, not one? The four sources have meaningfully different APIs:
+- bioRxiv / medRxiv: same JSON endpoint, cursor pagination, no server-side keyword filter, share one skill.
+- PubMed: server-side keyword + date filter via E-utilities (or a PubMed MCP). Different transport.
+- arXiv: Atom XML, datetime-range query syntax, hard rate limit, different category taxonomy. Different transport.
+
+Each fetcher returns the same canonical record shape so cross-source dedupe works against the union.
 
 ---
 
@@ -134,7 +148,7 @@ Before synthesizing, read titles + cluster names + the 30K paragraph from the pr
 ---
 week: 2026-19
 window: 2026-05-04 to 2026-05-10
-sources_hit: [biorxiv, medrxiv, pubmed]
+sources_hit: [biorxiv, medrxiv, pubmed, arxiv]
 fetched_total: 412
 kept_total: 17
 dropped_total: 395
@@ -196,7 +210,7 @@ A flat table or list. Every kept paper with: title, authors (et al. after 3), so
 8. Never run a digest without reading the last 4 weeks first. Historical context is non-negotiable.
 9. Never use banned vocabulary: delve, unpack, paradigm shift, let's explore, moreover, furthermore, it's worth noting.
 10. Never claim a paper "shows X" when its abstract only "suggests X" or "is consistent with X" — preserve the paper's own hedging in the 300 ft layer.
-11. Never proceed if all three sources fail to return results. Halt, report which fetches failed, ask the user.
+11. Never proceed if all four sources fail to return results. Halt, report which fetches failed, ask the user. If 1-2 sources fail but the others returned, proceed and surface the partial coverage prominently in the digest's "Notes for next week" line.
 12. Never assume two papers with the same title are the same record without matching DOI or first author — different research groups release similarly-titled work.
 
 ---

--- a/agents/paper-synthesizer.md
+++ b/agents/paper-synthesizer.md
@@ -1,150 +1,168 @@
 ---
 name: paper-synthesizer
-description: Weekly research-paper digest spanning life sciences and computer science. Each Monday, scans bioRxiv, medRxiv, PubMed, and arXiv (configurable category subset — typically cs.LG / cs.CL / cs.CV / stat.ML for CS-focused weeks, q-bio.* for cross-disciplinary, or all of arXiv for the widest net) for papers posted in the prior 7 days against a persistent keyword watchlist (with optional per-week overrides), filters for relevance, clusters by theme, and produces a layered-reasoning synthesis (30,000 ft → 3,000 ft → 300 ft) with direct paper links. Reads the last 4 weeks of digests so it can label topics as continuing vs new and avoid re-summarizing the same work. The orchestrator (a local file in the operator's project folder) decides where the project lives and which arXiv categories to use; invokes this agent from that folder; this agent's paths are all relative to the current working directory. Trigger keywords - weekly papers, paper digest, literature scan, bioRxiv weekly, medRxiv, PubMed weekly, arXiv weekly, CS papers, ML papers, paper synthesis, what's new in [field], scan the literature.
-tools: Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
-skills: fetch-preprint-recent, fetch-pubmed-recent, fetch-arxiv-recent, paper-relevance-filter, paper-cluster-by-theme, layered-reasoning
+description: Two-pass synthesis worker. Takes a list of structured paper extractions (produced upstream by the paper-extractor agent) and produces a weekly literature-scan digest. Pass A operates per-paper - translates each extraction into a reader-friendly summary using layered-reasoning + translation-reframing-audience-shift to lighten cognitive load without dampening the paper's own language. Pass B operates across papers - clusters the per-paper summaries by theme, then writes the final layered digest (30,000 ft / 3,000 ft / 300 ft). Reads the last 4 weeks of digests for continuity tagging. Path-agnostic - operates in the working directory it was invoked from. Spawned by the literature-scan-coach in the standard pipeline; direct invocation is supported when extractions already exist on disk. Trigger keywords - paper synthesis, weekly digest, synthesize papers, write digest, layered paper report.
+tools: Read, Write, Edit, Grep, Glob
+skills: paper-cluster-by-theme, layered-reasoning, translation-reframing-audience-shift
 model: inherit
 ---
 
-# The Paper Synthesizer Agent
+# The Paper Synthesizer
 
-Weekly research-paper compressor for a persistent keyword watchlist spanning life sciences and computer science. Reads bioRxiv, medRxiv, PubMed, and arXiv; emits one synthesized digest per week with paper links and a layered-reasoning structure. Maintains historical context across weeks so topics can be labeled as continuing, new, or refuted.
+Two-pass synthesis worker. Consumes structured paper extractions (one per paper, written upstream by `paper-extractor`) and produces a weekly literature-scan digest with the layered-reasoning structure (30K / 3K / 300ft).
 
-The four sources cover different fields by design — bioRxiv + medRxiv for biology / clinical preprints, PubMed for the published literature across life sciences, arXiv for CS / ML / stats / math / physics / quantitative-biology preprints. The operator's `source-registry.md` controls which arXiv categories to query (omit categories to search all of arXiv).
+This agent no longer fetches papers or runs the relevance filter — those stages are upstream now (`literature-scan-coach` does fetch + dedupe + filter; `paper-extractor` does per-paper extraction). The synthesizer's job is purely **translation + clustering + report writing**.
 
-**Project root.** This agent does not resolve paths to disk. It is invoked by the operator's orchestrator (a local file in their project folder), which sets the working directory before invocation. All paths in this file are relative to that working directory. Before doing anything else, the agent confirms it can see `orchestrator.md`, `shared-context/watchlist.md`, and `ops/paper-synthesizer/` from the current working directory; if any are missing, it halts and reports rather than guessing.
+## Skills used
 
-**When to invoke**: Monday morning weekly run; user asks "what's new in [my watchlist topics]"; user asks for catch-up after missing weeks ("synthesize the last 3 weeks").
-
-**Recommended entry point**: in projects that follow the standard layout, the operator should normally invoke the `literature-scan-coach` agent rather than calling this agent directly. The coach handles intent detection, window computation, catch-up looping (oldest-first so historical context is consistent), and re-synthesize-from-cache flows; it then spawns this agent with explicit parameters per run. Direct invocation is still supported for one-off use, but the coach is the better default.
-
-**Opening response**:
-
-> "Running paper-synthesizer for week {YYYY-WW}. Loading watchlist + last-4-weeks history, scanning bioRxiv + medRxiv + PubMed for the {YYYY-MM-DD} → {YYYY-MM-DD} window, filtering, clustering, then writing `ops/paper-synthesizer/{YYYY-WW}-digest.md` and `{YYYY-WW}-papers.md`."
+- [`paper-cluster-by-theme`](../skills/paper-cluster-by-theme/SKILL.md) — clusters the kept papers into 2-5 argument-shaped groups before Pass B, using the per-paper Pass A summaries as input (richer than abstracts).
+- [`layered-reasoning`](../skills/layered-reasoning/SKILL.md) — applied at two scales. Pass A applies it within each paper (30K = paper's core claim, 3K = argument + evidence, 300ft = specifics). Pass B applies it across papers (30K = the week's through-line, 3K = clusters, 300ft = per-paper bullets). The skill's upward / downward / lateral consistency checks gate the digest before it's written to disk.
+- [`translation-reframing-audience-shift`](../skills/translation-reframing-audience-shift/SKILL.md) — the engine of Pass A. Translates dense academic phrasing into reader-friendly prose without dampening the paper's own language. Target audience = "smart non-specialist who reads weekly digests." Preserves hedging, specificity, and named methods; strips acronym-soup and excessive nominalizations.
 
 ---
 
+## Inputs (passed by the spawning agent)
+
+- `extraction_paths`: list of paths to extraction files written by `paper-extractor`. Each file contains Pass 1 + (when escalated) Pass 2 sections per paper. Order is the relevance-filter KEEP order; the synthesizer should preserve it within clusters.
+- `window`: `YYYY-MM-DD/YYYY-MM-DD`.
+- `week_tag`: ISO `YYYY-WW`.
+- `run_type`: one of `weekly`, `catchup`, `on-demand`, `re-synthesize`.
+- `prior_digest_paths`: paths to the last 4 weekly digests (already on disk), used for continuity tagging.
+- `dropped_records`: list of records the relevance filter rejected, with rationale per record. Synthesizer surfaces these in `{week_tag}-papers.md` so the operator can audit the filter.
+
 ## Paths
 
-All paths below are relative to the working directory the orchestrator invokes the agent in. Never construct absolute paths in this agent.
+All relative to the working directory the spawning agent invoked from.
 
-**Reads (always, in order):**
-1. `orchestrator.md` — system map
-2. `shared-context/watchlist.md` — persistent keywords
-3. `shared-context/source-registry.md` — endpoints + query templates
-4. `shared-context/relevance-criteria.md` — keep/drop rules
-5. `shared-context/synthesis-style.md` — layered-reasoning rendering rules
-6. `ops/paper-synthesizer/overrides/{YYYY-WW}.md` (if exists) — per-week additions/exclusions
-7. The last 4 weekly digests in `ops/paper-synthesizer/*-digest.md` (sorted desc, take 4) — historical context
+**Reads:**
+- `shared-context/synthesis-style.md` — Pass A and Pass B style rules
+- `shared-context/relevance-criteria.md` — for context on what was filtered (don't re-filter)
+- The extraction files at `ops/paper-extractor/{week_tag}/*.md`
+- The last 4 weekly digests in `ops/paper-synthesizer/*-digest.md`
 
 **Writes:**
-- `ops/paper-synthesizer/{YYYY-WW}-digest.md` — synthesized layered report (the thing the user reads)
-- `ops/paper-synthesizer/{YYYY-WW}-papers.md` — full filtered paper list with title, authors, source, date, link, abstract excerpt, relevance rationale
-- `ops/paper-synthesizer/.cache/{YYYY-WW}-{source}.json` — raw fetch results (for debugging + re-synthesis without re-fetching)
+- `ops/paper-synthesizer/{week_tag}-digest.md` — the final weekly digest (Pass B output)
+- `ops/paper-synthesizer/{week_tag}-papers.md` — full filtered paper list with rationale + per-paper summary
+- `ops/paper-synthesizer/{week_tag}/per-paper/{slug}.md` — Pass A per-paper translated summaries (one file per kept paper)
 
-**Never writes:** `shared-context/watchlist.md` (user owns), `archive/` (manual move only), and never anything outside `{PROJECT_ROOT}`.
+**Never writes:** anything outside `ops/paper-synthesizer/`. Never edits the extraction files (read-only input from the upstream extractor).
 
 ---
 
 ## Pipeline
 
 ```
-Monday weekly run:
-- [ ] Step 0: Compute window. Today is Monday {YYYY-MM-DD}. Window = [today - 7 days, today - 1 day] inclusive.
-       Week tag = ISO year-week of "today" formatted YYYY-WW (e.g., 2026-19).
-- [ ] Step 1: Load context. Read orchestrator, watchlist, source-registry, relevance-criteria,
-       synthesis-style, this-week's overrides (if any), and titles+themes of the last 4 digests.
-- [ ] Step 2: Build effective keyword set = watchlist ∪ overrides.add - overrides.exclude.
-       Note any keyword groups (e.g., "protein-design", "single-cell"); treat them separately
-       only if multiple groups are explicitly defined. Otherwise treat as one flat set.
-- [ ] Step 3: Fetch bioRxiv for window via fetch-preprint-recent (server="biorxiv").
-- [ ] Step 4: Fetch medRxiv for window via fetch-preprint-recent (server="medrxiv").
-- [ ] Step 5: Fetch PubMed for window via fetch-pubmed-recent.
-- [ ] Step 5b: Fetch arXiv for window via fetch-arxiv-recent. Pass the `arxiv_categories` list from
-       `source-registry.md` (omit to search all of arXiv). Source-registry decides whether the operator
-       wants CS-only (cs.LG / cs.CL / cs.CV / cs.AI / stat.ML), cross-disciplinary, or everything.
-       Cache raw responses to .cache/{YYYY-WW}-{source}.json (one per source).
-- [ ] Step 6: Dedupe across sources. A PubMed record can be the published version of a bioRxiv preprint
-       or an arXiv paper; an arXiv paper can also be cross-listed on bioRxiv. Collapse on DOI when shared,
-       otherwise on (lowercased, normalized) title + first author. Preference order when merging:
-       PubMed (published) > bioRxiv/medRxiv (biology preprint with DOI) > arXiv (CS preprint).
-       When collapsed, keep the alternate URLs as "also: {server} version" links so the user can drill
-       into either the preprint or the published version.
-- [ ] Step 7: Apply paper-relevance-filter to each candidate. Keep, drop, or flag-for-review with
-       rationale. Use last-4-weeks digests to mark items as CONTINUING, NEW, or COVERED-BEFORE.
-- [ ] Step 8: If kept count > 25, raise the relevance bar (filter again with stricter threshold)
-       until ≤ 25. If kept count < 3, surface this as a "thin week" warning rather than padding.
-- [ ] Step 9: Apply paper-cluster-by-theme to the kept set. Produce 2-5 thematic clusters
-       plus an "outliers / single-paper-themes" bucket if needed.
-- [ ] Step 10: Synthesize top-down via layered-reasoning. Read synthesis-style.md for the
-       full rules; the short version is:
-
-       The reader has three different questions. Each layer answers one, in this order:
-         - 30,000 ft  → "What did you find across ALL the papers this week?"
-                        One paragraph. The through-line. What changed, what did NOT change,
-                        what's continuing from prior weeks, what's the disagreement if any.
-                        NOT a list of cluster names. NOT a list of papers. The compressed
-                        intersection of the kept set. If the week is genuinely scattered,
-                        say so — don't fake a through-line.
-         - 3,000 ft   → "What were the themes? Tell me by topic."
-                        One short paragraph per cluster (from paper-cluster-by-theme).
-                        State what the cluster collectively argues. Cite the strongest 1-2
-                        papers inline. Surface the tension if the cluster has one.
-                        Tag continuity in the cluster header: [continuing from YYYY-WW].
-         - 300 ft     → "Show me the actual papers."
-                        One bullet per paper, in cluster order. Title — first author et al.,
-                        source, date. One sentence on what the paper does and why it belongs
-                        in this cluster. Preserve the paper's own hedging (suggests vs shows).
-                        Direct link.
-
-       Write top-down: 30K first (this is the hardest and forces you to actually synthesize),
-       then 3K per cluster, then 300 ft per paper. Lower layers must be consistent with the
-       upper layer — don't let a cluster paragraph or paper line contradict the 30K headline.
-
-       Before saving, run the three consistency checks from synthesis-style.md (upward,
-       downward, lateral). If any fails, fix before writing.
-- [ ] Step 11: Write {YYYY-WW}-papers.md (full list, not synthesized — for user to drill in).
-- [ ] Step 12: Write {YYYY-WW}-digest.md with frontmatter (week, window, sources_hit, kept_count,
-       dropped_count, prior_weeks_referenced) followed by the synthesized report.
-- [ ] Step 13: Append a one-line entry to README.md "Recent digests" section (top of list).
-- [ ] Step 14: Report to user: digest path, kept/dropped counts, top-3 highlights, any warnings
-       (thin week, source fetch failures, watchlist drift suggestion).
+- [ ] Step 1: Load synthesis-style.md and the last 4 prior digests' headers + 30K paragraphs.
+- [ ] Step 2: Load all extraction files passed via extraction_paths.
+- [ ] Step 3: Run Pass A — per-paper translation/reframing. (See "Pass A" section.)
+       Output: ops/paper-synthesizer/{week_tag}/per-paper/{slug}.md per paper.
+- [ ] Step 4: Apply paper-cluster-by-theme to the kept set, using each paper's Pass A
+       summary as input (richer than abstracts — clustering quality improves).
+       Output: 2-5 argument-shaped clusters + an outliers bucket if needed.
+- [ ] Step 5: Run Pass B — across-papers synthesis. (See "Pass B" section.)
+       Output: ops/paper-synthesizer/{week_tag}-digest.md.
+- [ ] Step 6: Write {week_tag}-papers.md with the full filtered list, including dropped
+       records with rationale.
+- [ ] Step 7: Run cross-layer consistency checks (in synthesis-style.md). Fix before saving.
+- [ ] Step 8: Append a one-line entry to the project README's "Recent digests" section
+       (top of list) — only for run_type=weekly. Skip for on-demand.
+- [ ] Step 9: Return summary: digest_path, papers_path, kept_count, cluster_count, the
+       30K paragraph verbatim, and any warnings.
 ```
 
 ---
 
-## Connectors
+## Pass A — Per-paper translation
 
-| Source   | How                                                                                     |
-| -------- | --------------------------------------------------------------------------------------- |
-| bioRxiv  | `https://api.biorxiv.org/details/biorxiv/{from}/{to}/{cursor}` via WebFetch — no auth   |
-| medRxiv  | `https://api.biorxiv.org/details/medrxiv/{from}/{to}/{cursor}` via WebFetch — no auth   |
-| PubMed   | NCBI E-utilities `esearch` + `esummary` via WebFetch (no auth). If a PubMed MCP server is configured at runtime, prefer its `search_articles` and `get_article_metadata` tools — they paginate and parse for you. |
-| arXiv    | `http://export.arxiv.org/api/query?search_query=...` via WebFetch — no auth, Atom XML response, 1 req / 3 sec rate limit |
+For each kept paper's extraction, produce a reader-friendly per-paper summary. The point is to **lighten cognitive load on the operator without dampening the paper's language**:
 
-Why four fetchers, not one? The four sources have meaningfully different APIs:
-- bioRxiv / medRxiv: same JSON endpoint, cursor pagination, no server-side keyword filter, share one skill.
-- PubMed: server-side keyword + date filter via E-utilities (or a PubMed MCP). Different transport.
-- arXiv: Atom XML, datetime-range query syntax, hard rate limit, different category taxonomy. Different transport.
+- Translate dense academic phrasing into plainer, direct prose.
+- Preserve specificity — keep numbers, comparisons, named methods.
+- Preserve hedging — if the extraction says "suggests" or "is consistent with", the summary keeps the hedge. Do not promote.
+- Inline-gloss unfamiliar terms the extraction's "Unfamiliar terms" section flagged. Brief parenthetical or footnote-style.
 
-Each fetcher returns the same canonical record shape so cross-source dedupe works against the union.
+The per-paper summary uses **within-paper layered reasoning** — three layers describing this single paper:
+
+| Layer        | The reader's question for this one paper                                | Source from extraction                       |
+| ------------ | ----------------------------------------------------------------------- | -------------------------------------------- |
+| 30,000 ft    | "What is this paper's core claim, in one sentence?"                     | Pass 1 one-line + Pass 2 main argument       |
+| 3,000 ft     | "What is the argument and the evidence — 2-3 sentences?"                | Pass 2 main argument + figure analysis       |
+| 300 ft       | "What did the authors specifically test, find, and hedge?"              | Pass 2 hypotheses + confusions; preserve hedge |
+
+The skill `translation-reframing-audience-shift` provides the translation pattern. Apply it with target audience = "smart non-specialist who reads weekly digests" — assume the reader is technically literate but not a domain expert in this paper's subfield.
+
+### Pass A output format (per paper)
+
+Write to `ops/paper-synthesizer/{week_tag}/per-paper/{slug}.md`:
+
+```markdown
+---
+paper_id: arxiv:2605.12345
+title: "Structure-Conditioned Protein Generation at Scale"
+authors: ["Smith J", "Doe A", "Liu Z"]
+date: 2026-05-07
+source: arxiv
+url: https://arxiv.org/abs/2605.12345
+extraction_path: ops/paper-extractor/2026-19/arxiv-2605-12345.md
+synthesized_on: 2026-05-09
+---
+
+## 30,000 ft (one sentence)
+This paper reports that adding coarse structural priors during training of a sequence-based
+protein language model produces a 24% RMSD improvement on a standard benchmark, and argues
+the gain is mechanistic rather than a regularization side-effect.
+
+## 3,000 ft (argument + evidence, 2-3 sentences)
+The authors compare three model scales (350M / 1.3B / 7B parameters) trained either on
+sequences alone or on sequences plus a side-channel of secondary-structure annotations, and
+report consistent ~24% RMSD reduction on CASP15 holdout in favor of the structure-conditioned
+variant. They also report that long-range residue contact precision (a known mechanism for
+structural prediction) improves correspondingly, which they offer as evidence the gain is
+mechanistic rather than incidental. The proportional gain is roughly stable across scale,
+which they treat as additional support — though that consistency is weaker at smaller scales
+than the headline number implies.
+
+## 300 ft (specifics, hypotheses, hedges preserved)
+- The 24% headline is the largest-scale result; gains at smaller scales are 12-18%, so the
+  "consistent across scale" claim is *suggestive* (their word) rather than tight.
+- Three hypotheses tested: (H1) structure-conditioned beats sequence-only at fixed parameters,
+  (H2) gain is consistent across scale, (H3) gain is mechanistic via long-range contact prediction.
+- Multi-seed protocol with seeds disclosed in the appendix. Standard CASP15 holdout.
+- "Secondary-structure annotation" is the side-channel input; not full atomistic coordinates.
+
+## Why this matters in this week's context
+{Optional 1-sentence framing — only when the cluster needs it. Otherwise omit.}
+```
+
+The "Why this matters" line is filled in by Pass B, not Pass A — Pass A doesn't yet know cluster context. Leave as a placeholder Pass B can fill.
+
+### Pass A guardrails
+
+- Length: per-paper summary should be ~150-300 words total. If you are over 400, you are re-stating the extraction, not translating it.
+- Don't add information the extraction doesn't carry. If the extraction says `(not stated)`, the summary says "not stated."
+- Don't strip caveats. The extraction's hedging IS the precision.
+- Banned vocabulary: delve, unpack, paradigm shift, let's explore, moreover, furthermore, it's worth noting.
 
 ---
 
-## Historical context — how to use the last 4 digests
+## Pass B — Across-papers synthesis (the weekly digest)
 
-Before synthesizing, read titles + cluster names + the 30K paragraph from the prior 4 weekly digests. Use them to:
+Pass B explicitly invokes the `layered-reasoning` skill, applied at the across-papers scale. The skill is the engine of this pass — top-down decomposition (30K → 3K → 300ft), upward / downward / lateral consistency checks, and the discipline of writing the strategic layer first to force actual synthesis rather than listing.
 
-1. **Tag continuing topics**: if a cluster name from this week appeared in any of the last 4 weeks, tag the cluster header as `[continuing from YYYY-WW]`. Tells the user "this isn't a new front."
-2. **Detect resurfacing of same paper**: a preprint posted 5 weeks ago that just hit PubMed is the *same paper*. Mark it `[journal version of preprint covered YYYY-WW]` and do not let it dominate the digest.
-3. **Spot watchlist drift**: if 3+ weeks running you're keeping <3 papers per week, the watchlist is too narrow. Surface this in the closing "Notes for next week" line. Do not silently widen the watchlist.
-4. **Spot keyword bloat**: if the same kept-but-low-relevance theme keeps appearing, suggest tightening that keyword. Suggestion only — user owns the watchlist.
+This pass operates on Pass A's richer input (per-paper translated summaries) instead of raw abstracts. Same three-layer structure, same operator-question framing — see `shared-context/synthesis-style.md` for the project-specific style rules and `skills/layered-reasoning/SKILL.md` for the methodology.
 
----
+The reader has three different questions across papers; each layer answers one:
 
-## Output format
+| Layer       | The reader's question across papers              | Unit of writing       | Pulls from                                    |
+| ----------- | ------------------------------------------------ | --------------------- | --------------------------------------------- |
+| 30,000 ft   | "What did you find across all papers this week?" | The week              | Pass A summaries' 30K lines, integrated       |
+| 3,000 ft    | "What were the themes? Tell me by topic."        | The cluster           | Pass A summaries inside each cluster          |
+| 300 ft      | "Show me the actual papers."                     | One paper per bullet  | Pass A summaries' 30K + a link to the per-paper file |
 
-### `{YYYY-WW}-digest.md`
+Write top-down per the `layered-reasoning` skill: 30K first (this is the strategic layer; writing it first forces actual synthesis rather than listing), then 3K per cluster (tactical), then 300ft per paper (operational). The lower layers must be consistent with the upper layer — the skill's upward / downward / lateral consistency checks (Step 5 of its workflow) are non-negotiable here. Run them before saving; if any fails, fix before writing the digest to disk.
+
+### Pass B output format
+
+Write to `ops/paper-synthesizer/{week_tag}-digest.md`:
 
 ```markdown
 ---
@@ -162,16 +180,17 @@ generated: 2026-05-11
 # Week 2026-19 Paper Digest
 
 ## 30,000 ft — What changed in the field this week
-[3-5 sentence synthesis. What is the headline. What new mechanism / dataset / result actually moved.
-What did NOT change. Optional: one-line link to a continuation from last week.]
+[3-5 sentence synthesis. The through-line. What changed, what did NOT change, what's continuing
+from prior weeks, what's the disagreement if any. NOT a list of clusters. NOT a list of papers.
+The compressed intersection of the kept set.]
 
 ## 3,000 ft — By theme
 
-### Cluster 1: {Theme name} [continuing from 2026-17]
-[2-3 sentence summary of what the cluster collectively argues, with the key disagreement or
-convergence between papers in it. Link the 1-2 most important papers inline.]
+### Cluster 1: {Argument-shaped name} [continuing from 2026-17]
+[2-3 sentences on what the cluster collectively argues. Cite the strongest 1-2 papers inline.
+Surface the tension if the cluster has one. The argument-shape comes from paper-cluster-by-theme.]
 
-### Cluster 2: {Theme name}
+### Cluster 2: {Argument-shaped name}
 ...
 
 ### Outliers
@@ -179,48 +198,95 @@ convergence between papers in it. Link the 1-2 most important papers inline.]
 
 ## 300 ft — Papers, by cluster
 
-### Cluster 1: {Theme name}
-- **{Title}** — {first author et al.}, {source}, {YYYY-MM-DD}. {one sentence on what it does and why it
-  belongs in this cluster.} → [link]({url})
+### Cluster 1: {Argument-shaped name}
+- **{Title}** — {first author et al.}, {source}, {date}. {one sentence pulled from the
+  per-paper Pass A summary, framed for why this paper sits in this cluster.}
+  → [paper]({url}) · [extracted notes](ops/paper-synthesizer/2026-19/per-paper/{slug}.md)
 - ...
 
-### Cluster 2: {Theme name}
+### Cluster 2: {Argument-shaped name}
 - ...
 
 ## Notes for next week
-- Any thin-week warnings, watchlist drift signals, or papers worth re-checking when journal versions land.
+- Any thin-week warnings, watchlist drift signals, or papers worth re-checking.
+- Any 1-2 source-failure notes (partial coverage warnings).
 
 ## Full list
-See `2026-19-papers.md` for the unsynthesized table of every kept paper plus the dropped-with-rationale entries.
+See `2026-19-papers.md` for the unsynthesized table of every kept paper plus the
+dropped-with-rationale entries. Each kept paper also has a Pass A per-paper summary at
+`ops/paper-synthesizer/2026-19/per-paper/{slug}.md` and the underlying extraction at
+`ops/paper-extractor/2026-19/{slug}.md`.
 ```
 
-### `{YYYY-WW}-papers.md`
+After writing the digest, **go back and fill in the "Why this matters in this week's context" line** in each Pass A per-paper file, since Pass B now knows the cluster framing. One sentence per file.
 
-A flat table or list. Every kept paper with: title, authors (et al. after 3), source, date, DOI / URL, one-sentence abstract excerpt, relevance score, cluster assignment. Then a collapsed `<details>` with dropped papers and one-line rationale each (so the user can challenge the filter).
+### Pass B guardrails
+
+The full rules live in `shared-context/synthesis-style.md`. The agent reads that file at startup. Highlights:
+
+- 30K is one paragraph (3-5 sentences). Not a list of cluster names. Not a list of papers. The compressed intersection.
+- 3K paragraph per cluster, 2-3 sentences. State what the cluster collectively argues. Tag continuity.
+- 300ft is one bullet per paper. Title — first author et al., source, date. One sentence. Direct link.
+- Cluster names must be argument-shaped, not topic-shaped. ("Protein design moves toward sequence+structure conditioning" — not "Protein design.")
+- Cross-layer consistency: upward (do clusters support 30K?), downward (do papers support clusters?), lateral (do clusters contradict?).
 
 ---
+
+## Cap and thin-week handling
+
+- If the kept count exceeds the cap (default 25), the upstream filter has already raised the threshold; the synthesizer trusts the input. Do not re-filter.
+- If the kept count is below 3, surface a "thin week" warning in the digest's "Notes for next week" line. Do not pad the digest with marginal papers.
+
+## Re-synthesize-from-cache mode
+
+When `run_type=re-synthesize`, the synthesizer is invoked because the operator edited `relevance-criteria.md` or `synthesis-style.md`. The pipeline simplifies:
+
+- Skip Pass A if it was already run for this week and the underlying extractions haven't changed (caller decides; check via file timestamps if uncertain).
+- Re-run paper-cluster-by-theme on the existing Pass A summaries.
+- Re-run Pass B writing the digest.
+- In the return summary, include a one-line "diff vs prior version": kept-count delta, cluster-name changes.
 
 ## Must-nots
 
-1. Never invent or guess a paper. Every entry must come from a real fetch result; cross-reference against the cached raw JSON if unsure.
-2. Never include a paper without its source URL or DOI. If the URL extraction failed, flag it and do not include the paper.
-3. Never re-summarize a paper already in any of the last 4 digests' kept lists unless its journal version just appeared — and even then, label it as such, do not give it a fresh write-up.
-4. Never silently widen the watchlist. Suggestions go in "Notes for next week"; only the user edits `watchlist.md`.
-5. Never drop the dropped-papers section. If filter rejected something, the rationale lives in `{YYYY-WW}-papers.md` so the user can audit.
-6. Never exceed 25 kept papers per week. If the field is genuinely that busy, raise the relevance threshold rather than diluting the digest.
-7. Never write outside `ops/paper-synthesizer/` or `archive/` (relative to the invocation working directory; `archive/` only on explicit user request). Never construct an absolute path.
-8. Never run a digest without reading the last 4 weeks first. Historical context is non-negotiable.
-9. Never use banned vocabulary: delve, unpack, paradigm shift, let's explore, moreover, furthermore, it's worth noting.
-10. Never claim a paper "shows X" when its abstract only "suggests X" or "is consistent with X" — preserve the paper's own hedging in the 300 ft layer.
-11. Never proceed if all four sources fail to return results. Halt, report which fetches failed, ask the user. If 1-2 sources fail but the others returned, proceed and surface the partial coverage prominently in the digest's "Notes for next week" line.
-12. Never assume two papers with the same title are the same record without matching DOI or first author — different research groups release similarly-titled work.
+1. Never re-fetch papers. Fetch is upstream (the coach). The synthesizer reads extraction files only.
+2. Never re-run the relevance filter. Filtering is upstream. If you think a kept paper shouldn't have been kept, surface it as a "filter likely loose on this paper" warning — but do not drop it.
+3. Never edit the extraction files. They are the upstream artifact; the synthesizer is read-only on them.
+4. Never collapse the 300ft layer to a paper count. Every kept paper gets a bullet with title, authors, source, date, sentence, and link.
+5. Never let Pass B contradict Pass A. If you find yourself wanting to claim something at the cluster level the per-paper summaries don't support, fix the cluster claim — do not editorialize past the source.
+6. Never use banned vocabulary: delve, unpack, paradigm shift, let's explore, moreover, furthermore, it's worth noting.
+7. Never write outside `ops/paper-synthesizer/`.
+8. Never proceed without `synthesis-style.md`. If the file is missing, halt and report.
 
 ---
 
-## Cadence
+## How this agent is invoked
 
-**Monday morning, weekly.** Lookback = prior 7 days (Monday-of-this-week minus 7 → Sunday-of-prior-week, inclusive). The orchestrator file is the source of truth for the window definition; if the user runs the agent on a non-Monday, treat invocation date as the window endpoint and compute window = [invocation - 7d, invocation - 1d].
+By the `literature-scan-coach`, after the coach has searched + extracted (Pass 1 + Pass 2) + filtered. Typical spawn:
 
-**Catch-up runs** (user missed weeks): the user says "synthesize the last N weeks." Run N independent weekly passes, oldest first, so each newer pass has the prior digests as historical context.
+<example>
+<intent>WEEKLY synthesis</intent>
+<spawn_prompt>
+Run paper-synthesizer for the weekly digest.
 
-**On-demand single-paper analysis** (papers dropped in `inbox/`): out of scope for this agent in v1. If the user drops a PDF or URL there, surface it but do not parse — point them at the existing `domain-research-health-science` skill for clinical critique.
+window: 2026-05-04/2026-05-10
+week_tag: 2026-19
+run_type: weekly
+
+extraction_paths:
+- ops/paper-extractor/2026-19/arxiv-2605-12345.md
+- ops/paper-extractor/2026-19/biorxiv-10-1101-2026-05-07-654321.md
+- ops/paper-extractor/2026-19/pmid-39000001.md
+- ... (one per kept paper, 17 total)
+
+prior_digest_paths:
+- ops/paper-synthesizer/2026-18-digest.md
+- ops/paper-synthesizer/2026-17-digest.md
+- ops/paper-synthesizer/2026-16-digest.md
+- ops/paper-synthesizer/2026-15-digest.md
+
+dropped_records: {as JSON list with reason per record}
+
+Follow your two-pass pipeline. Return digest_path, papers_path, kept_count, cluster_count,
+the 30K paragraph verbatim, warnings.
+</spawn_prompt>
+</example>

--- a/skills/fetch-arxiv-recent/SKILL.md
+++ b/skills/fetch-arxiv-recent/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: fetch-arxiv-recent
+description: Fetches arXiv papers submitted within a given date window matching a keyword set, with optional restriction to one or more arXiv categories (e.g. cs.LG, cs.CL, cs.CV, stat.ML, math.ST, q-bio.QM). Wraps the public `export.arxiv.org/api/query` endpoint, parses Atom XML, handles pagination, and normalizes records to the same canonical shape as `fetch-preprint-recent` and `fetch-pubmed-recent` so a calling agent can dedupe across sources. Domain-neutral — usable for any literature scan that crosses CS, ML, statistics, math, physics, or quantitative biology. Use when user mentions arXiv, cs.LG, ML papers, NeurIPS-adjacent preprints, weekly arXiv scan, or when a literature-scan agent needs arXiv records alongside bioRxiv / medRxiv / PubMed.
+---
+
+# fetch-arxiv-recent
+
+Fetch arXiv papers submitted within a date window, optionally restricted to specific arXiv categories, and keyword-filter the results. Returns records in the same canonical shape as the other three literature fetchers.
+
+## Workflow
+
+```
+- [ ] Step 1: Validate inputs (from, to, keywords, optional categories)
+- [ ] Step 2: Build the search_query string with date range + categories + keywords
+- [ ] Step 3: Page through the API until results exhausted or window endpoint passed
+- [ ] Step 4: Parse Atom XML; normalize each entry
+- [ ] Step 5: Dedupe by arXiv ID (keep latest version)
+- [ ] Step 6: Return matched records + summary
+```
+
+**Step 1 — Validate inputs**
+
+Required:
+- `from`: `YYYY-MM-DD`, inclusive
+- `to`: `YYYY-MM-DD`, inclusive, `to >= from`
+- `keywords`: list of strings (case-insensitive substring match against title + abstract)
+
+Optional:
+- `categories`: list of arXiv category codes — e.g. `["cs.LG", "cs.CL", "stat.ML"]`. If omitted, search all of arXiv. Common groupings the caller may want to expose:
+  - **CS / ML**: `cs.LG, cs.CL, cs.CV, cs.AI, cs.NE, stat.ML`
+  - **Math / stats**: `math.ST, math.PR, math.OC, stat.ME, stat.AP`
+  - **Quantitative biology**: `q-bio.QM, q-bio.GN, q-bio.MN, q-bio.NC`
+  - **Physics-adjacent**: `physics.data-an, cond-mat.stat-mech`
+
+  The skill itself does not hard-code these groupings; it accepts whatever categories the caller passes. The orchestrator's `source-registry.md` can document the groupings the operator cares about.
+
+Reject if window > 31 days (same rule as `fetch-preprint-recent` — wider windows almost always indicate a misuse).
+
+**Step 2 — Build the query string**
+
+The arXiv search API accepts a query language with fielded search. Compose:
+
+```
+search_query = (date_clause) AND (category_clause)? AND (keyword_clause)
+```
+
+- **Date clause** (always include — without it you'll get the whole arXiv history):
+  ```
+  submittedDate:[YYYYMMDDHHMM TO YYYYMMDDHHMM]
+  ```
+  Use `from + 0000` and `to + 2359` so the window is fully inclusive of both days.
+
+- **Category clause** (optional): join categories with OR.
+  ```
+  (cat:cs.LG OR cat:cs.CL OR cat:stat.ML)
+  ```
+
+- **Keyword clause**: join with OR. Use `all:` for full-record search (covers title + abstract + authors, which is what we want for a wide-net keyword scan):
+  ```
+  (all:"protein language model" OR all:"diffusion model" OR all:gnn)
+  ```
+  Multi-word phrases must be double-quoted. Single words don't need quotes.
+
+Final assembled example:
+```
+submittedDate:[202605040000 TO 202605102359]
+  AND (cat:cs.LG OR cat:cs.CL OR cat:stat.ML)
+  AND (all:"protein language model" OR all:"diffusion model" OR all:transformer)
+```
+
+URL-encode and pass as `search_query` to:
+
+```
+http://export.arxiv.org/api/query?search_query={URL_ENCODED}&sortBy=submittedDate&sortOrder=descending&start={offset}&max_results=200
+```
+
+`sortBy=submittedDate&sortOrder=descending` is important — it lets you stop paginating as soon as the result dates fall before `from`, instead of having to walk the whole result set.
+
+**Step 3 — Pagination**
+
+arXiv returns 200 records per page (max). After each page:
+- If response has 0 entries, stop.
+- If the *last* entry's `published` date is older than `from`, stop (the rest are out of window).
+- Otherwise, increment `start` by 200, request again.
+- Cap at 10 pages (2,000 records). If hit, surface "window may be over-broad" and return what you have.
+
+Rate limit: arXiv asks for **1 request every 3 seconds**. Sleep between paginated requests. Don't hammer.
+
+**Step 4 — Parse Atom XML**
+
+The API returns an Atom feed. Each `<entry>` has:
+- `<id>`: full URL like `http://arxiv.org/abs/2605.12345v1` — the canonical paper ID is the trailing `2605.12345` (post-2007 format) or `arxiv.org/abs/cs.LG/0301001` (legacy format)
+- `<title>`: paper title (may have newlines + indentation; collapse whitespace)
+- `<summary>`: abstract (same whitespace caveat)
+- `<author><name>`: one per author; preserve order
+- `<published>`: ISO timestamp of v1 submission (use this as `date`)
+- `<updated>`: ISO timestamp of latest version (different if revised)
+- `<arxiv:primary_category term="cs.LG">`: primary category
+- `<category term="..."/>`: list of all categories
+- `<link rel="alternate" type="text/html" href="..."/>`: abstract page URL
+- `<link title="pdf" rel="related" type="application/pdf" href="..."/>`: PDF URL
+- `<arxiv:doi>`: optional, present once paper is published in a journal
+
+If the Atom parser fails, retry the request once with a 5-second backoff. On second failure, log the error to `fetch_errors` and skip the page.
+
+**Step 5 — Dedupe by arXiv ID**
+
+The paginated results may include the same paper twice if a v2 was submitted within the window. Keep the highest version per ID.
+
+The arXiv ID alone (e.g. `2605.12345`) is the canonical key — strip the `v1`/`v2` suffix from the URL and use that.
+
+**Step 6 — Normalize and return**
+
+Same canonical record shape as the other fetchers:
+
+```json
+{
+  "id": "arxiv:2605.12345",                                   // arxiv-prefixed for source clarity
+  "title": "...",
+  "authors": ["Smith J", "Doe A", ...],
+  "abstract": "...",
+  "date": "2026-05-07",                                       // YYYY-MM-DD parsed from <published>
+  "server": "arxiv",
+  "primary_category": "cs.LG",
+  "categories": ["cs.LG", "stat.ML"],
+  "version": 2,
+  "doi": "10.1145/...",                                       // if present, otherwise null
+  "url": "https://arxiv.org/abs/2605.12345",                  // abstract page (preferred for digest links)
+  "pdf_url": "https://arxiv.org/pdf/2605.12345.pdf",
+  "matched_keywords": ["protein language model"]
+}
+```
+
+Apply the keyword filter client-side (the API's `all:` is full-record OR but doesn't preserve the match-keyword info). For each record, check title + abstract against the keyword list, populate `matched_keywords`, and drop records that match none (the API's recall is broader than the operator's intent — the skill must filter).
+
+Return summary:
+
+```json
+{
+  "server": "arxiv",
+  "window": "2026-05-04/2026-05-10",
+  "categories": ["cs.LG", "cs.CL", "stat.ML"],
+  "query": "(...full search_query...)",
+  "fetched_total": 1240,
+  "matched_total": 18,
+  "pages_fetched": 7,
+  "fetch_errors": [],
+  "records": [ ... ]
+}
+```
+
+Cache the raw Atom XML responses (one per page) to `.cache/{YYYY-WW}-arxiv-{page}.xml`.
+
+## Common Patterns
+
+**Pattern A — CS-only weekly scan**: `categories=["cs.LG", "cs.CL", "cs.CV", "cs.AI", "stat.ML"]`. The default for an ML/CS-leaning watchlist.
+
+**Pattern B — Cross-disciplinary scan (CS + quant-bio)**: `categories=["cs.LG", "stat.ML", "q-bio.QM", "q-bio.GN"]`. When the operator wants computational-biology preprints from arXiv that bioRxiv may miss.
+
+**Pattern C — All of arXiv**: `categories=None`. Maximum recall, maximum noise. Only useful when the keyword filter is very tight.
+
+**Pattern D — Track a specific arXiv account**: outside this skill's default scope. Add `(au:"Smith, J" OR au:"Doe, A")` to the search_query as an additional AND clause.
+
+## Guardrails
+
+1. **Always include the date clause.** Without `submittedDate:[... TO ...]` arXiv returns the entire history of the matching query — millions of records. This is the single most common arXiv-API mistake.
+2. **Sort by submittedDate descending.** Otherwise you cannot bail out of pagination early when the dates fall out of window — you'd have to walk the whole result set.
+3. **Respect the 3-second rate limit.** arXiv enforces it loosely but consistent abuse triggers IP-level throttling. Sleep 3s between paginated requests.
+4. **Don't trust the `<title>` and `<summary>` whitespace.** Atom feeds often contain literal `\n` plus 6 spaces of indentation. Collapse all internal whitespace runs to single spaces before storing.
+5. **Don't conflate the `id` URL with the canonical ID.** `<id>http://arxiv.org/abs/2605.12345v2</id>` — the canonical ID is `2605.12345`. The `v2` is the version suffix; strip it for dedupe.
+6. **Don't drop the legacy ID format silently.** Pre-2007 arXiv IDs look like `cs.LG/0301001`. The skill should accept both formats, never assert the modern one. Match `^[a-z-]+\.[A-Z]+/\d+$|^\d{4}\.\d{4,5}$` to validate.
+7. **Don't dedupe across sources here.** A paper on arXiv may also be on bioRxiv (for cross-listing) or have a PubMed publication — that's the calling agent's job, not this skill's.
+8. **Don't expand keywords automatically.** arXiv's full-record `all:` search is already broad; further synonym expansion silently widens the net. The watchlist is the gate.
+
+## Quick Reference
+
+| Field          | Source                                                       | Notes                                                         |
+| -------------- | ------------------------------------------------------------ | ------------------------------------------------------------- |
+| Endpoint       | `http://export.arxiv.org/api/query?search_query={q}&...`     | HTTPS works too but the docs use HTTP                         |
+| Auth           | None                                                         | Public API. Use a User-Agent header if WebFetch lets you set one. |
+| Page size      | 200 max (`max_results=200`)                                  |                                                               |
+| Rate limit     | 1 request / 3 seconds                                        | Sleep between paginated requests                              |
+| Window cap     | 31 days (soft); 7 days for weekly digests                    |                                                               |
+| Date format    | `YYYYMMDDHHMM` (no dashes, no colons)                        | Use `0000` for `from`, `2359` for `to`                        |
+| ID format      | `2605.12345` (post-2007), `cs.LG/0301001` (legacy)           | Strip `vN` suffix from the URL; canonical ID excludes version |
+| Canonical URL  | `https://arxiv.org/abs/{id}`                                 | Abstract page; preferred for digest links                     |
+| PDF URL        | `https://arxiv.org/pdf/{id}.pdf`                             | Optional secondary link                                       |
+| Sort           | `sortBy=submittedDate&sortOrder=descending`                  | Required for early-bail pagination                            |
+| Common cats    | `cs.LG, cs.CL, cs.CV, cs.AI, stat.ML, math.ST, q-bio.QM`     | Operator decides; skill takes any list                        |

--- a/skills/inspectional-reading/SKILL.md
+++ b/skills/inspectional-reading/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: inspectional-reading
+description: Domain-neutral methodology for the first level of Adler-style reading - systematic skimming to determine what kind of document this is, what it's about as a whole, and whether deeper engagement is worth the time investment. Read title, metadata, table of contents or section headings, abstract or introduction, conclusion, and end-material at a glance. Classify document type (methodology, framework, tool, theoretical, reference, or hybrid). Decide whether to escalate to deeper reading. Reusable across any artifact-from-document workflow - paper extraction, skill creation from a methodology document, literature triage, reading-list pruning. Use when an agent needs to convert "I have a document, what is it" into structured downstream-actionable input. Trigger keywords - inspectional reading, systematic skimming, document classification, Adler reading, skim before reading, skill-worthiness check, paper triage, reading triage.
+---
+
+# inspectional-reading
+
+The first level of Adler's "How to Read a Book" methodology, applied as a reusable skill. Answers two questions before any deeper reading happens: **What kind of document is this?** and **Is it worth reading carefully?**
+
+The skill is invoked autonomously by an agent — it reads the document and produces structured output. It does not host a dialogue with the operator.
+
+## Workflow
+
+```
+- [ ] Step 1: Read the metadata (title, authors, date, source, length)
+- [ ] Step 2: Read the abstract / introduction completely
+- [ ] Step 3: Examine table of contents or section headings
+- [ ] Step 4: Skim the conclusion and any end-material at a glance
+- [ ] Step 5: Classify the document type
+- [ ] Step 6: Assess worthiness for the calling agent's purpose
+- [ ] Step 7: Output structured findings
+```
+
+Time budget: 10-15 minutes for a typical paper / chapter / methodology document. If a document needs more, you've drifted into the next level of reading — stop and produce the inspectional output you have.
+
+## Inputs
+
+The calling agent passes:
+- `source`: the document to read (path or URL or text)
+- `purpose_context`: a short string describing what this document is being read *for*. The classification and worthiness check both depend on this — reading a paper for synthesis vs reading a methodology document for skill extraction yield different worthiness criteria. Examples:
+  - `purpose=paper_extraction_for_weekly_digest` — caller is paper-synthesizer's pipeline
+  - `purpose=skill_extraction_from_methodology` — caller is the skill-creator agent
+  - `purpose=reading_list_triage` — caller wants to rank a backlog
+- `domain_hint`: optional. The field the document is in (life sciences, ML, philosophy, etc.) — improves classification.
+
+## Output structure
+
+```markdown
+## Inspectional Reading Output
+
+### Metadata
+- Source: {path or URL}
+- Title: {title}
+- Authors / origin: {names or affiliation}
+- Length: {pages, sections, or word count}
+- Date / version: {date}
+
+### Document type
+Primary: {methodology | framework | tool/template | theoretical | reference/catalog | hybrid}
+Secondary aspects (if hybrid): {list}
+
+### Stated purpose and audience
+{1-2 sentences from the abstract / intro}
+
+### Structural skeleton
+{TOC or section headings, in order, as a bullet list}
+
+### Worthiness assessment (for purpose={purpose_context})
+- Reusable across multiple contexts: {yes|no|partial} — {one-line rationale}
+- Teachable as steps or principles: {yes|no|partial} — {rationale}
+- Non-obvious (provides value beyond common sense): {yes|no} — {rationale}
+- Complete enough to be actionable: {yes|no|partial} — {rationale}
+Recommendation: {ESCALATE to deeper reading | STOP — not worth it | PROCEED with caveats}
+
+### One-line summary
+{single sentence, ≤30 words, what this document is}
+```
+
+## Document types — quick reference
+
+The classification drives what the calling agent does next. Use the most specific applicable label.
+
+| Type                | Characteristics                                        | Extraction focus                                          | Skill-worthy default                |
+| ------------------- | ------------------------------------------------------ | --------------------------------------------------------- | ----------------------------------- |
+| Methodology / process | Sequential steps or phases; "first do X, then Y"      | Steps, sequence, inputs/outputs, decision criteria         | Yes — linear workflow              |
+| Framework / model   | Dimensions, axes, principles, matrices                 | Dimensions, categories, when-to-apply, interpretation       | Yes — framework with decision logic |
+| Tool / template     | Fill-in-the-blank, templates, checklists               | Template structure, what goes where, usage guidelines      | Yes — template with completion docs |
+| Theoretical / concept | Explains "why", research findings, principles        | Core concepts, implications, application mappings           | Needs synthesis to be actionable    |
+| Reference / catalog | Lists, encyclopedia-like, lookup-oriented              | Usually skip — but extract decision-frameworks if present | Usually NOT skill-worthy            |
+| Hybrid              | Combines multiple types                                | Identify boundaries; extract each part by its type         | Yes — partitioned                  |
+
+## Common patterns
+
+### Pattern A — Paper extraction (call from a paper-reading workflow)
+
+`purpose=paper_extraction_for_weekly_digest`. The caller wants to know enough to decide whether to invest deeper-reading compute. Worthiness criteria emphasize: relevance to the watchlist, novelty vs prior weeks, whether the abstract claims something specific or vague. Paper papers fall mostly into "theoretical / empirical study" — apply the next level of reading (content grasp) only when the worthiness check passes.
+
+### Pattern B — Skill extraction (call from skill-creator)
+
+`purpose=skill_extraction_from_methodology`. The caller wants to know whether this document is worth extracting into a SKILL.md. Worthiness criteria emphasize: is the methodology *actionable* (can it be turned into steps a different agent could follow), is it *non-obvious* (does it teach something the model doesn't already know), is it *complete enough* (or are there gaps that would need filling). Reference/catalog documents almost always fail; methodology / framework documents almost always pass.
+
+### Pattern C — Reading-list triage
+
+`purpose=reading_list_triage`. The caller has a backlog of N documents and wants to rank them. Output focuses on the worthiness assessment + one-line summary; classification is secondary.
+
+## Guardrails
+
+1. **Never read past the inspectional level.** If you find yourself reading the methods section in detail, you've drifted into the next reading level — stop.
+2. **Always classify against the specific purpose_context.** A document that's gold for paper extraction may fail for skill extraction (or vice versa). The caller's purpose is the lens.
+3. **Worthiness has gradations.** ESCALATE / STOP / PROCEED-WITH-CAVEATS — do not collapse to a binary unless the caller explicitly asks for one.
+4. **Don't claim a type you can't justify from the structure.** If the TOC has both numbered steps AND framework dimensions, classify hybrid — not "methodology" with hand-waving.
+5. **Don't fabricate metadata.** If date or authors aren't visible at the inspectional level, write `(not visible at this level)` rather than guessing.
+
+## Related
+
+- [`paper-three-pass-extraction`](../paper-three-pass-extraction/SKILL.md) — wraps this skill as Pass 1 plus the paper-specific Five Cs framework, then escalates to Pass 2 / Pass 3 for content grasp + deep reading.
+- [`structural-analysis`](../structural-analysis/SKILL.md) — the *next* level of reading; called by `paper-three-pass-extraction` Pass 2 and by `skill-creator` Step 2 when this skill recommends ESCALATE.
+- [`synthesis-application`](../synthesis-application/SKILL.md) — the completeness-and-logic check that runs in deeper reading levels after this one.
+- The skill-creator skill at `skills/skill-creator/SKILL.md` invokes this skill as its Step 1.

--- a/skills/paper-three-pass-extraction/SKILL.md
+++ b/skills/paper-three-pass-extraction/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: paper-three-pass-extraction
+description: Domain-neutral methodology for autonomously extracting structured notes from a single academic paper via three escalating passes. Pass 1 (inspectional, ~10-15 min) reads title, abstract, intro, section headings, conclusion, references at a glance, then applies the Five Cs framework (Category, Context, Correctness, Contributions, Clarity). Pass 2 (content grasp, ~30-60 min) reads the full paper skipping proofs, answers main-argument / Big-Question / hypotheses / figure-by-figure / references / confusions. Pass 3 (deep understanding, ~1-4 hours, reserved for important papers) virtually re-implements, challenges every assumption, identifies what is NOT said, asks the falsifiability question. The methodology is internal to the agent applying it - questions are answered against the paper's content, never asked of the operator. Inspired by Keshav 2007 ("How to Read a Paper") and Adler-style inspectional reading. Use when an extraction agent needs to convert dense academic prose into structured machine-and-human-readable notes - bio papers, CS papers, ML papers, statistics, math, any field.
+---
+
+# paper-three-pass-extraction
+
+Three-pass methodology for extracting structured notes from a single academic paper. Each pass escalates from cheap-and-shallow to expensive-and-deep; downstream agents trigger Pass 2 only for relevant papers and Pass 3 only on explicit operator request.
+
+The **central principle**: every question in this methodology is answered *by the agent reading the paper*, against the paper's content. Never ask the operator the questions. Never have a Socratic dialogue. The questions are an internal extraction checklist whose purpose is to produce structured output — not user-facing prompts.
+
+## Workflow
+
+```
+- [ ] Pass 1: Inspectional reading (always run)
+       - Read title, abstract, intro paragraphs, section headings, conclusion, references at a glance
+       - Apply the Five Cs framework
+       - Produce Pass 1 extraction output
+- [ ] Pass 2: Content grasp (run when escalated, e.g., paper passed relevance filter)
+       - Acquire full text (PDF or HTML); flag if unavailable
+       - Read linearly, skipping proofs and heavy derivations
+       - Answer the Pass 2 question set
+       - Append Pass 2 extraction output
+- [ ] Pass 3: Deep understanding (run only on operator request)
+       - Re-read methods + proofs that Pass 2 skipped
+       - Virtually re-implement the core idea
+       - Answer the Pass 3 question set
+       - Append Pass 3 extraction output
+```
+
+## Pass 1 — Inspectional Reading
+
+Operates on title, abstract, intro paragraphs, section headings, conclusion, and references at a glance. Never blocks on a missing PDF — abstract-only Pass 1 is acceptable.
+
+### The Five Cs (the agent answers each — not the operator)
+
+1. **Category** — What type of paper is this? Pick the most specific applicable label: empirical study, theoretical analysis, system / architecture description, benchmark, survey / review, meta-analysis, position / perspective, replication, ablation study, dataset release, methods paper, case report. If the paper fits two, pick the dominant frame from the abstract; note the secondary in parentheses.
+
+2. **Context** — What prior work does it build on? What field or debate does it sit within? Look for: explicit citations in the abstract, "extends [X]" / "improves on [X]" phrasing, the institutional / lab pattern in the author list, key references repeated. Output: 1-2 sentences naming the closest prior work and the active debate.
+
+3. **Correctness (first-glance)** — Do the assumptions seem reasonable at first glance? This is *not* a deep critique — Pass 1 hasn't read the methods. Flag obvious issues: claims that contradict well-known results, conclusions that overreach the evidence cited in the abstract, missing comparisons. If nothing obvious, write "no first-glance concerns."
+
+4. **Contributions** — What does the paper claim to add? Quote or paraphrase the abstract's contribution claim. Distinguish: new method / new result / new dataset / new framing / negative result / replication. **Preserve hedging**: if the abstract says "suggests" or "is consistent with," the extraction says the same. Never promote a "suggests" to a "shows."
+
+5. **Clarity** — Is the abstract / structure well-written? Does the title match the abstract? Are claims specific or vague? Output: short signal — `clear`, `dense-but-clear`, `vague`, `mismatched-title`, `acronym-soup`. This guides whether Pass 2 will be easy or painful.
+
+### Pass 1 also produces a `one_line` summary
+
+A single-sentence compression of "what the paper does." Used by upstream callers for quick reporting. Shouldn't exceed ~30 words.
+
+## Pass 2 — Content Grasp
+
+Runs when the caller escalates (typical trigger: paper passed a relevance filter as KEEP). Reads the full paper, skipping proofs and heavy derivations. Needs the full-text source.
+
+### Pass 2 question set (the agent answers — not the operator)
+
+1. **Main argument and supporting evidence — 3 to 5 sentences.** What does the paper argue, and what does it adduce as support? Resist re-stating the abstract; this should reflect the actual structure of the paper as you read it.
+
+2. **The Big Question.** Not what the paper is about — what *problem* the field is trying to solve, of which this paper is one move. Often inferable from the introduction's framing of related work.
+
+3. **Specific hypotheses tested.** List them. If the paper is a systems / engineering paper without explicit hypotheses, list the design claims being defended instead.
+
+4. **Unfamiliar terms / concepts requiring gloss for a non-specialist reader.** These will become candidates for inline glossing in any downstream summary.
+
+5. **Figure-by-figure analysis.** For each figure or table that carries the argument: what is being shown, what's the takeaway, are axes / error bars / sample sizes clean. Skip ornamental figures.
+
+6. **References worth follow-up.** Distinguish *load-bearing* references (the result depends on them) from background citations.
+
+7. **Confusions or unresolved points.** What did not land for you on this read? Mark them — Pass 3 (if escalated) will return to them.
+
+### Pass 2 acquisition order
+
+When fetching full text, try in this order:
+1. The paper record's PDF URL (arXiv records always carry one).
+2. The paper's URL content (some preprint sites serve full HTML).
+3. PMC OA service for PubMed records (only when a free PMC id exists).
+4. If none of the above, mark `full_text_available=false` and apply Pass 2 to the abstract + intro you have, with reduced confidence. Do not skip Pass 2 — degraded Pass 2 still beats no Pass 2 for downstream synthesis.
+
+## Pass 3 — Deep Understanding
+
+Runs only on explicit operator request. Time investment: 1-4 hours of agent compute equivalent. Reserved for high-priority papers. **Never auto-trigger.**
+
+### Pass 3 question set
+
+1. **Reconstruct the structure and argument from memory.** Force a from-memory write: the structure of the paper, the argument's flow, the key results, in your own organization. If you cannot reconstruct, you don't yet understand it — return to Pass 2.
+
+2. **Strongest points; weakest points.** Be specific. "The benchmark is standard" is weak praise; "the multi-seed protocol with seeds disclosed in the appendix is unusually rigorous" is real. Same for weaknesses.
+
+3. **Falsifiability — what would have to be true for the conclusions to be wrong?** This is the highest-value question in deep reading. Surface the load-bearing assumptions whose failure would invalidate the result.
+
+4. **What is *not* said?** Hidden assumptions, missing comparisons, citations that should appear but don't, methodological choices that aren't justified.
+
+5. **Future work this opens up.** Concrete next experiments or follow-up questions, not vague "more research needed."
+
+## Common patterns
+
+### Pattern A — Weekly batch literature scan
+
+Pass 1 on every fetched paper (cheap; runs in parallel as subagent batch). Apply the relevance filter on the Pass 1 outputs (richer signal than abstracts alone — the Five Cs answers improve criteria-fit scoring). Pass 2 on the KEEPs. Pass 3 only when the operator points at a specific paper from the digest.
+
+### Pattern B — Single-paper deep read
+
+Operator drops a paper into a focused-review workflow. Run all three passes sequentially, returning each pass's output. Pass 3 is on the table because there's only one paper to invest in.
+
+### Pattern C — Reading-list triage
+
+Operator has 50 papers in a backlog. Pass 1 on all 50 (fast); rank by Pass 1 signals (Category fit, hedging strength, Clarity); recommend top-N for Pass 2.
+
+### Pattern D — Replication / disagreement check
+
+Two papers claim contradictory results. Pass 2 on both with explicit attention to: methodology differences in question 1, hypothesis-testing protocol in question 3, figure protocol differences in question 5. Pass 3 on whichever is the higher-priority claim.
+
+## Guardrails
+
+1. **Never ask the operator any of the methodology questions.** Five Cs, Pass 2 questions, Pass 3 questions — all are answered by the agent against the paper. The questions are an internal extraction checklist, not a dialogue.
+2. **Never skip Pass 1 for an unfamiliar paper, even when the caller asked for Pass 2 or Pass 3 directly.** Always run prior passes first; Pass 1's structured frame anchors what follows.
+3. **Always preserve hedging.** If a paper says "suggests" or "is consistent with," the extraction says the same. Never promote.
+4. **Never invent results not in the paper.** If a number, citation, or figure isn't in the source, don't include it. Write `(not stated)` when uncertain — that's high-information.
+5. **Never auto-trigger Pass 3.** Pass 3 is operator-driven. Pass 2 may auto-escalate based on filter results; Pass 3 must not.
+6. **Pass 2 without full text is degraded, not skipped.** Mark the file as such and reduce downstream confidence; don't refuse the pass.
+7. **Pass 1 stays cheap.** If you're reading the methods section in Pass 1, you've drifted into Pass 2. Stop.
+
+## Quick reference
+
+| Pass | Time      | Trigger                                | Input                                    | Output                                          |
+| ---- | --------- | -------------------------------------- | ---------------------------------------- | ----------------------------------------------- |
+| 1    | ~10-15min | Always (every paper)                   | Title, abstract, intro, headings, conclusion | Five Cs answers + one_line summary              |
+| 2    | ~30-60min | Caller escalates (filter KEEP)         | Full paper text (PDF or HTML), skip proofs | Pass 2 question-set answers, figure analysis    |
+| 3    | ~1-4h     | Operator request only — never auto      | Full paper including methods + proofs    | Reconstruction, strongest/weakest, falsifiability, what-is-not-said, future work |
+
+## Related skills
+
+- [`layered-reasoning`](../layered-reasoning/SKILL.md) — the three passes are themselves a layered structure (inspectional / content / deep). Apply layered-reasoning's consistency checks across passes.
+- [`scientific-clarity-checker`](../scientific-clarity-checker/SKILL.md) — directly applicable to Pass 1's Clarity assessment and Pass 2's main-argument-vs-evidence check.
+- [`research-claim-map`](../research-claim-map/SKILL.md) — applicable to Pass 2's reference triage (load-bearing vs background) and Pass 3's source grading.
+- [`hypotheticals-counterfactuals`](../hypotheticals-counterfactuals/SKILL.md) — drives Pass 3's falsifiability question.
+- [`negative-contrastive-framing`](../negative-contrastive-framing/SKILL.md) — drives Pass 3's "what is *not* said."
+- [`skill-creator/resources/inspectional-reading.md`](../skill-creator/resources/inspectional-reading.md) — the kindred-spirit predecessor scoped to skill creation; same Adler-style reading discipline applied to a different artifact (source documents for skill extraction rather than research papers).
+- [`skill-creator/resources/synthesis-application.md`](../skill-creator/resources/synthesis-application.md) — same lineage; provides the completeness-and-logic check pattern that Pass 3's "what is not said" extends.
+
+## Inputs required
+
+- A paper record (id, title, authors, abstract, date, source URL, optional DOI, optional PDF URL)
+- The pass to run (1, 2, or 3) — caller's escalation choice
+- An output location for the extraction file (path-agnostic; caller decides)
+
+## Outputs produced
+
+A structured markdown file accumulating each pass's output. Multiple passes append; never overwrite a prior pass section. The file is the artifact downstream agents (synthesizer, archiver, search) consume.

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -19,6 +19,13 @@ description: Transforms documents containing theoretical knowledge or frameworks
 
 This skill applies Mortimer Adler's systematic reading methodology ("How to Read a Book") through a six-step progressive approach: inspectional reading, structural analysis, component extraction, synthesis, skill construction, and validation. The process is collaborative -- at decision points, options and trade-offs are presented for the user to choose.
 
+**Methodology composition.** Two of the steps are now backed by domain-neutral standalone skills, reusable beyond skill creation:
+
+- Step 1 (Inspectional Reading) — see [`inspectional-reading`](../inspectional-reading/SKILL.md). Invoke with `purpose_context=skill_extraction_from_methodology`. The local resource at `resources/inspectional-reading.md` documents the skill-creation-specific session-initialization and `$SESSION_DIR` mechanics that the generic skill does not own.
+- Step 4 (Synthesis and Application) — see [`synthesis-application`](../synthesis-application/SKILL.md). Invoke with `purpose_context=skill_construction`. The local resource at `resources/synthesis-application.md` documents the skill-creation-specific completeness inventory (terms / propositions / arguments / solutions / decision-criteria / triggers) that the generic skill defers to its caller.
+
+The remaining steps (structural analysis, component extraction, skill construction, validation) are still documented inline via local resources only — promote to standalone skills if and when other agents need them.
+
 ---
 
 ## Workflow

--- a/skills/synthesis-application/SKILL.md
+++ b/skills/synthesis-application/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: synthesis-application
+description: Domain-neutral methodology for evaluating completeness and logical soundness of an extracted set of components, then transforming them into actionable guidance. Runs the "is it true / is it complete / what of it" critical evaluation pass before any final artifact is built. Checks for completeness gaps, logical consistency, contradictions, and practical applicability. Reusable across any extraction workflow - skill creation (evaluating extracted components before building SKILL.md), paper extraction (evaluating Pass 2 extraction notes before deep reading), report writing (evaluating gathered evidence before synthesis). Use when an agent has extracted structured components from a source and needs to gate-check before downstream commitment. Trigger keywords - synthesis evaluation, completeness check, logic check, critical evaluation, fact-check before synthesis, gap analysis, what is not said.
+---
+
+# synthesis-application
+
+Critical-evaluation gate that runs after component extraction and before final artifact construction. Asks Adler's third-level questions: **"Is it true? What of it?"** Catches logical gaps, missing pieces, contradictions, and practical-applicability issues before they propagate into a downstream artifact.
+
+The skill is invoked autonomously by an agent on a structured set of extracted components. It does not host a dialogue with the operator.
+
+## Workflow
+
+```
+- [ ] Step 1: Completeness check — are all major component types present?
+- [ ] Step 2: Logic check — do the parts cohere? Any contradictions?
+- [ ] Step 3: Applicability check — can this actually be applied?
+- [ ] Step 4: Gap-fill recommendations — what would the calling agent need to fill?
+- [ ] Step 5: Output structured findings + a single GO / GO-WITH-GAPS / NO-GO verdict
+```
+
+## Inputs
+
+The calling agent passes:
+- `extracted_components`: a structured payload of what was extracted (terms, propositions, arguments, solutions, hypotheses, etc.). Format depends on caller.
+- `purpose_context`: what this is being extracted *for*. The completeness criteria depend on it. Examples:
+  - `purpose=skill_construction` — caller is about to build a SKILL.md from these components
+  - `purpose=paper_pass_3_input` — caller is about to do a Pass 3 deep read on these components
+  - `purpose=evidence_synthesis` — caller is about to write a report from these components
+- `domain_hint`: optional, the field the source is in.
+
+## Output structure
+
+```markdown
+## Synthesis-and-Application Output
+
+### Completeness check
+For each major component type expected for purpose={purpose_context}:
+- {Component type}: {present | partial | missing} — {one-line rationale}
+- ...
+
+### Logic check
+- Gaps: {list of "the artifact jumps from A to C without explaining B" issues, or "none found"}
+- Contradictions: {list of "section X contradicts section Y" issues, or "none found"}
+- Hidden assumptions: {assumptions stated implicitly that should be made explicit, or "none flagged"}
+- Unsupported claims: {claims without evidence or reasoning, or "none flagged"}
+
+### Applicability check
+- Concrete enough to act on: {yes | partial | no} — {rationale}
+- Decision criteria specified where needed: {yes | partial | no} — {rationale}
+- Edge cases covered: {yes | partial | no} — {which edges are unaddressed}
+
+### Gap-fill recommendations
+- {Specific item the caller should add or seek before downstream commitment}
+- ...
+
+### Verdict
+{GO | GO_WITH_GAPS | NO_GO}
+
+Rationale: {2-3 sentences}
+```
+
+## Component types by purpose_context
+
+Different downstream artifacts need different inventories of components. The completeness check uses the relevant inventory.
+
+### purpose = skill_construction
+
+A SKILL.md needs:
+- **Terms**: key concepts defined unambiguously
+- **Propositions**: claims supported by evidence or reasoning
+- **Arguments**: complete logical sequences from premise to conclusion
+- **Solutions**: concrete examples or templates that demonstrate application
+- **Decision criteria**: how to choose between alternatives where the methodology branches
+- **Triggers**: when this skill should be invoked
+
+### purpose = paper_pass_3_input
+
+A deep-read needs:
+- **Main argument**: the through-line, in 3-5 sentences
+- **Big Question**: the field-level problem
+- **Hypotheses**: specific claims being tested
+- **Evidence inventory**: figures, tables, references that carry the argument
+- **Confusions**: what didn't land in Pass 2 — the agenda for Pass 3
+
+### purpose = evidence_synthesis
+
+A report needs:
+- **Claims**: structured propositions
+- **Sources**: provenance for each claim
+- **Source quality**: assessment per source
+- **Conflicting evidence**: where sources disagree
+- **Confidence ratings**: per-claim
+
+For other `purpose_context` values, the calling agent should specify expected component types in the input — this skill does not silently extend the inventory.
+
+## Logic checks — what to look for
+
+**Gaps** — premises missing between conclusions:
+- "The document jumps from A to C without explaining B."
+- "Step 5 references something Step 4 doesn't establish."
+
+**Contradictions** — internal conflicts:
+- "Proposition 2 says X, but Proposition 7 says not-X."
+- "The framework's Dimension 1 and Dimension 3 overlap in unstated ways."
+
+**Hidden assumptions** — load-bearing premises that aren't surfaced:
+- "The methodology assumes the user has access to PHI without saying so."
+- "The framework only works at scale > 10K users — never stated."
+
+**Unsupported claims** — assertions without backing:
+- "Claims X works 80% of the time but cites no source."
+
+The output is the list. The skill does not fix gaps — it surfaces them and recommends action.
+
+## Applicability checks — what to look for
+
+- **Concrete enough to act on**: an extracted "principle" like "always be data-driven" is too vague. Concrete would be "before each sprint, pull last month's metric trend and identify one delta to investigate."
+- **Decision criteria specified**: when the methodology branches ("if X, do A; if Y, do B"), is X-vs-Y specified clearly enough that a different agent could follow it?
+- **Edge cases covered**: what happens at the boundaries — empty input, conflicting input, error states? If silent on edges, flag.
+
+## Common patterns
+
+### Pattern A — Skill creation gate
+
+`purpose=skill_construction`. Run after Step 3 (component extraction) and before Step 5 (skill construction) in a skill-creation workflow. The verdict gates whether the agent proceeds to build SKILL.md or returns to the source for more extraction.
+
+### Pattern B — Paper Pass 3 readiness
+
+`purpose=paper_pass_3_input`. Run after Pass 2 (content grasp) on a paper extraction. The verdict gates whether Pass 3 is worth running or whether the paper needs re-reading at Pass 2 first.
+
+### Pattern C — Pre-synthesis evidence audit
+
+`purpose=evidence_synthesis`. Run on a research-claim-map output before writing the synthesis report. Catches "the gathered evidence doesn't actually support the conclusion you're about to write."
+
+## Guardrails
+
+1. **Don't fix gaps; surface them.** This skill produces a structured list of issues and a verdict. It does not modify the extracted components. The calling agent decides what to do.
+2. **Don't lower the bar on completeness when components are sparse.** GO_WITH_GAPS means "you can proceed but here's what's missing" — not "this is fine because we don't have more."
+3. **Verdict matters — don't soften it.** GO / GO_WITH_GAPS / NO_GO is a discrete signal. If you mean NO_GO, write NO_GO. The calling agent's pipeline depends on it.
+4. **Don't import information from outside the source.** Completeness is judged against what was extracted, not what the model knows about the topic.
+
+## Related
+
+- [`inspectional-reading`](../inspectional-reading/SKILL.md) — the first reading level, run before extraction begins.
+- [`structural-analysis`](../structural-analysis/SKILL.md) — the second level, runs between inspectional and component extraction.
+- [`research-claim-map`](../research-claim-map/SKILL.md) — for the evidence-synthesis purpose, the upstream skill that produces the structured claim-source-quality payload this skill evaluates.
+- [`negative-contrastive-framing`](../negative-contrastive-framing/SKILL.md) — pairs naturally with the "what is not said" portion of the logic check.
+- The skill-creator skill at `skills/skill-creator/SKILL.md` invokes this skill as its Step 4.
+- [`paper-three-pass-extraction`](../paper-three-pass-extraction/SKILL.md) invokes this skill before Pass 3 to gate whether a deep read is worth it.


### PR DESCRIPTION
**Stacks on #54** (`lyndonkl/literature-scan-coach`). Once #54 merges, this PR's diff will rebase to show only the four new commits below.

## Summary

Promotes the paper-synthesis project to a true three-stage pipeline coordinated by `literature-scan-coach`: **search → extract → synthesize**. The relevance filter and clusterer now operate on structured per-paper extraction notes rather than raw abstracts, sharpening both. Adds two reusable Adler-style reading skills (lifted from `skill-creator/resources/`) so paper-extractor and other agents can share the methodology.

## Commits

### 1. `c0687bb` — Three-stage pipeline: paper-extractor + synthesizer/coach refactor

**New agent `paper-extractor`** — autonomous structured-extraction worker, spawned per paper.

- Applies a three-pass reading methodology + Five Cs framework **internally** (questions answered against the paper, never asked of the operator).
- Pass 1 inspectional (every paper). Pass 2 content grasp (relevance-filter KEEPs). Pass 3 deep understanding (operator request only).
- Each pass appends to the same per-paper extraction file.

**New skill `paper-three-pass-extraction`** — domain-neutral methodology owning the Three Pass + Five Cs framework. Inspired by Keshav 2007 + Adler. Hard guardrail: questions are an internal extraction checklist, NOT a Socratic dialogue.

**Refactored `paper-synthesizer`** — now two-pass.
- Pass A: per-paper translation using `layered-reasoning` + `translation-reframing-audience-shift` to lighten cognitive load without dampening the paper's language. Preserves hedging, specificity, named methods.
- Pass B: across-papers clustered weekly digest using `paper-cluster-by-theme` + `layered-reasoning` at across-papers scale. The skill's upward / downward / lateral consistency checks gate the digest before save.
- No longer fetches or runs the relevance filter — those are upstream now.

**Refactored `literature-scan-coach`** — now a true full-pipeline orchestrator.
- Stage A: load context. Stage B: search (coach calls fetch-* skills directly, dedupes across sources). Stage C: spawn paper-extractor at pass=1 for every paper. Stage D: apply paper-relevance-filter on Pass 1 notes. Stage E: spawn paper-extractor at pass=2 for KEEPs. Stage F: spawn paper-synthesizer with extraction paths.
- Adds DEEP_READ as a fifth intent (Pass 3 on a specific paper, no synthesizer).
- Catch-up still oldest-first; full pipeline B-F runs per week.

All three agents now have explicit `skills:` field in YAML frontmatter and a "Skills used" body section with markdown links to each skill's SKILL.md, explaining how the skill maps to specific stages/passes — per Anthropic's agent skills authoring best practices.

### 2. `07cd5f1` — Promote inspectional-reading + synthesis-application to top-level skills

The Adler-style reading methodology buried in `skills/skill-creator/resources/` is genuinely domain-neutral. Both apply equally to "what skill should I extract from this methodology document" and "what should I extract from this academic paper." Promoting them to top-level skills lets `paper-extractor` and (in future) other agents reuse them without copy-paste.

- **`inspectional-reading`** — Adler Level 1. Systematic skim, document-type classification, worthiness assessment for the calling agent's purpose. Caller passes `purpose_context` (e.g., `paper_extraction_for_weekly_digest`, `skill_extraction_from_methodology`, `reading_list_triage`).
- **`synthesis-application`** — Adler's "Is it true? What of it?" pass. Completeness + logic + applicability gate, produces GO / GO_WITH_GAPS / NO_GO verdict on a structured set of extracted components. Caller passes `purpose_context` (e.g., `skill_construction`, `paper_pass_3_input`, `evidence_synthesis`) which drives the completeness inventory.

`skills/skill-creator/SKILL.md` updated with explicit pointers to both new top-level skills for Steps 1 and 4, plus a note on what the local resources still own (session mechanics, skill-construction-specific completeness inventory).

## Counts in this PR

- README: skills 209 → 213, agents 38 → 40 (combined with #54).
- Research & Evidence index gains a "Reading methodology" subsection.

## Phase 2b (deferred)

Extracting `structural-analysis`, `component-extraction`, `skill-construction` into top-level skills + creating `agents/skill-creator.md` to fully promote the skill-creator skill to an orchestrator agent. Ship-able as a follow-up; this PR is coherent on its own.

## Test plan

- [ ] All three agents (`literature-scan-coach`, `paper-extractor`, `paper-synthesizer`) load with valid YAML frontmatter, including `skills:` field
- [ ] Three new skills (`paper-three-pass-extraction`, `inspectional-reading`, `synthesis-application`) load with valid frontmatter
- [ ] Coach pre-flight check halts cleanly when invoked outside a project root
- [ ] WEEKLY workflow executes Stages A → F end-to-end on a real 7-day window
- [ ] paper-extractor at pass=1 produces structured Five Cs output for every fetched paper
- [ ] Relevance filter scores improve when operating on Pass 1 extractions vs raw abstracts (qualitative)
- [ ] paper-extractor at pass=2 produces content-grasp output for a KEEP paper
- [ ] paper-synthesizer Pass A produces per-paper translated summaries
- [ ] paper-synthesizer Pass B produces a layered digest with argument-shaped clusters
- [ ] DEEP_READ intent runs paper-extractor at pass=3 without spawning synthesizer
- [ ] Cross-source dedupe across bioRxiv / medRxiv / PubMed / arXiv still works post-refactor
- [ ] Mermaid diagram renders correctly with `LSC` node

🤖 Generated with [Claude Code](https://claude.com/claude-code)