### PR TITLE
paper-extractor Pass 2: explicit PDF-fetch recipe (fixes thin extractions)

### DIFF
--- a/agents/paper-extractor.md
+++ b/agents/paper-extractor.md
@@ -143,25 +143,81 @@ Reports a 24% RMSD improvement on CASP15 by conditioning protein generation on c
 
 ## Pass 2 — Content Grasp
 
-Runs only when the caller escalates (typical trigger: this paper passed `paper-relevance-filter` as KEEP). Reads the full paper, skipping heavy proofs and derivations. Needs the full-text source.
+Runs only when the caller escalates (typical trigger: this paper passed `paper-relevance-filter` as KEEP). Reads the full paper, skipping heavy proofs and derivations. Needs the full-text source — and you have to actually fetch it. WebFetch does not handle PDFs; use Bash to download to disk, then the Read tool to ingest.
+
+### Full-text acquisition recipe (this is the part the agent gets wrong if not spelled out)
 
 ```
 Pass 2 checklist:
-- [ ] Acquire full text. Try in this order:
-       1. paper_record.pdf_url, if present (arXiv records always have one)
-       2. {paper.url} content (some preprint sites serve full HTML)
-       3. PMC OA service for PubMed records (optional — only if a free PMC id is present)
-       4. If none available, mark full_text_available=false in the return summary
-          and write a note to the extraction file. Do NOT skip Pass 2 — apply it
-          to the abstract + intro paragraphs you have, with reduced confidence.
+- [ ] Determine paper_slug from the paper id (same slug rule as Pass 1's extraction
+       filename — strip dots/colons in the id, hash if needed).
+- [ ] Construct the cache path:
+       pdf_cache = ops/paper-synthesizer/.cache/pdfs/{paper_slug}.pdf
+       (the .cache/ directory is gitignored; safe to leave PDFs there)
+- [ ] Ensure the cache directory exists:
+       Bash: `mkdir -p ops/paper-synthesizer/.cache/pdfs`
+- [ ] Try sources in order. STOP at the first one that succeeds.
+
+       Source 1 (preferred) — direct PDF download via Bash + curl.
+         Applies when paper_record.pdf_url is set (arXiv always; bioRxiv / medRxiv
+         always; PubMed only when a PMC OA full-text URL is present in the record).
+         Bash: `curl -L --max-time 60 --fail -sS -o {pdf_cache} "{pdf_url}"`
+         Check exit code. Non-zero → curl failed (404, network, redirect loop).
+         Move to Source 2. Zero → continue to Read step below.
+
+       Source 2 (fallback for HTML-only abstract pages) — WebFetch on paper.url.
+         Some preprint sites serve usable full text as HTML. WebFetch returns
+         markdown. If the result is genuinely the full text (length > ~5K chars,
+         contains methods + results sections), proceed with it as full_text. If
+         it's just the abstract page (length < 2K chars; only abstract content),
+         move to Source 3.
+
+       Source 3 (PubMed records only) — PMC Open Access service.
+         If paper_record.source == "pubmed" and a PMC id is present, construct:
+           https://www.ncbi.nlm.nih.gov/pmc/articles/PMC{pmc_id}/
+         and try Source 1's curl recipe against the PMC PDF endpoint:
+           https://www.ncbi.nlm.nih.gov/pmc/articles/PMC{pmc_id}/pdf/
+         Many PubMed records have no PMC id (paywalled). That's expected.
+
+       If all three sources fail:
+         Set full_text_available=false in the return summary. Write a note to
+         the extraction file. Do NOT skip Pass 2 — apply it to the abstract +
+         intro you have at reduced confidence, and explicitly tag any answer
+         that relied on a missing section as "(abstract-only; full text unavailable)".
+
+- [ ] Read the cached PDF using the Read tool with the pages parameter.
+       The Read tool caps at 20 pages per call. Most papers fit in one call.
+       For papers > 20 pages:
+         First call: Read({file_path: pdf_cache, pages: "1-20"})
+         If you have not yet seen the references section or appendix, continue:
+           Read({file_path: pdf_cache, pages: "21-40"})
+         And so on. Stop when you reach the references / appendix or the file ends.
+       For HTML full text from Source 2, just use the WebFetch result directly.
+
 - [ ] Read in linear order, skipping proofs and heavy derivations.
 - [ ] Note unfamiliar terms or concepts the synthesizer's audience may need glossed.
 - [ ] Examine figures and graphs critically (axes labeled? error bars? what story?).
+       Figures are visible to you when reading a PDF — actually look at them, don't
+       just summarize the caption.
 - [ ] Mark references worth follow-up (cited as load-bearing, not just background).
 - [ ] Answer the Pass 2 questions (next section).
 - [ ] Write the Pass 2 section of the extraction file (append; do not overwrite Pass 1).
-- [ ] Update passes_completed = [1, 2] in the return summary.
+- [ ] Update passes_completed = [1, 2] in the return summary. Set full_text_available
+       to true if any of Source 1 / 2 / 3 succeeded; false only if all three failed.
+- [ ] Leave the cached PDF in place. Re-runs (RE_SYNTHESIZE intent, Pass 3 escalation)
+       skip the download step when the cache is already populated.
 ```
+
+### Pass 2 reduced-confidence mode
+
+When `full_text_available=false`, you operate on abstract + (when accessible) the HTML abstract page's intro paragraphs only. In this mode:
+
+- Answer Pass 2 questions with the material you have, and tag each affected answer with `(abstract-only; full text unavailable)`.
+- Skip the figure-by-figure question entirely — write `(skipped; full text unavailable)`.
+- The references-worth-follow-up list shrinks to "those named in the abstract" only.
+- Set the per-paper one-liner with reduced specificity; do not invent details the abstract didn't carry.
+
+Reduced-confidence Pass 2 still beats no Pass 2 for downstream synthesis. The synthesizer's Pass A will see the tags and lower the per-paper summary's specificity correspondingly.
 
 ### Pass 2 questions (the agent answers — not the operator)
 
@@ -222,6 +278,10 @@ Runs only on explicit operator request. Time investment: 1-4 hours of agent comp
 
 ```
 Pass 3 checklist:
+- [ ] Re-use the cached PDF from Pass 2 at ops/paper-synthesizer/.cache/pdfs/{slug}.pdf.
+       If it's missing (Pass 2 ran in reduced-confidence mode, or the cache was cleared),
+       re-run the full-text acquisition recipe from Pass 2 first. Pass 3 against an
+       abstract-only source is not meaningful — halt and report instead.
 - [ ] Re-read methods and proofs sections that Pass 2 skipped.
 - [ ] Virtually re-implement the core idea — what choices would you have made differently?
 - [ ] Challenge every assumption explicitly: write down what would have to be true.
@@ -257,7 +317,7 @@ Append a Pass 3 section structured around those five answers, each as a short pa
 3. Never overwrite a prior Pass 1 or Pass 2 section. Append. The full extraction history per paper is the artifact.
 4. Never promote a paper's hedging upward. If the abstract says "suggests" or "is consistent with", the extraction preserves the hedge. The synthesizer can decide how to reframe it later, but the source-of-truth notes do not editorialize.
 5. Never invent results not in the paper. If a number, citation, or figure is not in the source, do not include it. When uncertain, write `(not stated)` — that's high-information.
-6. Never proceed to Pass 2 without full text *unless* the caller explicitly asked for "best-effort Pass 2 from abstract." If the PDF is unavailable and the caller did not say best-effort, return at Pass 1 with full_text_available=false; let the caller decide whether to skip the paper.
+6. Never set `full_text_available=false` without first attempting the full-text acquisition recipe end-to-end (Source 1 curl + Source 2 WebFetch fallback + Source 3 PMC fallback for PubMed). WebFetch alone on a `.pdf` URL does not count as "tried" — that always fails because WebFetch is HTML-only. The Bash + curl + Read sequence is required. If the recipe genuinely fails on all three sources, then proceed in reduced-confidence mode (abstract-only Pass 2, with explicit tags) — do not skip Pass 2 entirely.
 7. Never write outside `{output_root}/{week_tag}/`. Construct no absolute paths.
 8. Never use banned vocabulary the project's `synthesis-style.md` excludes (delve, unpack, paradigm shift, let's explore, moreover, furthermore, it's worth noting). The synthesizer enforces this downstream too, but starting clean costs nothing.
 9. Never run Pass 3 unless explicitly instructed by the spawning agent. Pass 3 is operator-driven.

--- a/skills/paper-three-pass-extraction/SKILL.md
+++ b/skills/paper-three-pass-extraction/SKILL.md
@@ -68,13 +68,55 @@ Runs when the caller escalates (typical trigger: paper passed a relevance filter
 
 7. **Confusions or unresolved points.** What did not land for you on this read? Mark them — Pass 3 (if escalated) will return to them.
 
-### Pass 2 acquisition order
+### Pass 2 acquisition recipe
 
-When fetching full text, try in this order:
-1. The paper record's PDF URL (arXiv records always carry one).
-2. The paper's URL content (some preprint sites serve full HTML).
-3. PMC OA service for PubMed records (only when a free PMC id exists).
-4. If none of the above, mark `full_text_available=false` and apply Pass 2 to the abstract + intro you have, with reduced confidence. Do not skip Pass 2 — degraded Pass 2 still beats no Pass 2 for downstream synthesis.
+The agent has to actually fetch the full text — not just say it tried. WebFetch is HTML→markdown only; it does not handle PDFs. The reliable recipe uses the calling agent's Bash and Read tools together: `curl` the PDF to a local cache path, then read it with the Read tool's `pages` parameter (max 20 pages per call).
+
+```
+1. Construct a local cache path:
+   pdf_cache = {output_root}/.cache/pdfs/{paper_slug}.pdf
+   (or whatever cache convention the calling workflow uses; the cache should
+    be gitignored so PDFs don't get committed)
+
+2. Ensure the cache directory exists:
+   Bash: `mkdir -p {output_root}/.cache/pdfs`
+
+3. Try sources in order. STOP at the first one that succeeds.
+
+   Source 1 (preferred) — direct PDF download via Bash + curl:
+     `curl -L --max-time 60 --fail -sS -o {pdf_cache} "{pdf_url}"`
+     Non-zero exit code → curl failed (404, network, redirect loop). Move on.
+     Zero exit → continue to step 4.
+
+   Source 2 (HTML fallback) — WebFetch on the abstract page URL:
+     WebFetch returns markdown. Accept only if length > ~5K chars and the
+     result clearly contains methods + results sections (not just the abstract).
+     Otherwise treat as "abstract page only" and move on.
+
+   Source 3 (PubMed PMC OA fallback):
+     Only attempts when source == "pubmed" and a PMC id is present in the
+     paper_record. Apply Source 1's curl recipe to the PMC PDF URL:
+       https://www.ncbi.nlm.nih.gov/pmc/articles/PMC{pmc_id}/pdf/
+
+4. Read the full text:
+   For PDF cache files, use Read({file_path: pdf_cache, pages: "1-20"}).
+     Continue with pages "21-40", "41-60" etc. until you reach the references
+     or the file ends. Most papers fit in one call.
+   For Source 2 HTML, use the WebFetch result directly.
+
+5. Failure mode — if all three sources fail:
+   Mark full_text_available=false and proceed in reduced-confidence mode.
+   Pass 2 still runs on abstract + (when accessible) intro paragraphs, but
+   each affected answer is tagged "(abstract-only; full text unavailable)"
+   and the figure-by-figure question is skipped entirely. Degraded Pass 2
+   still beats no Pass 2 for downstream synthesis.
+```
+
+The calling agent's required tools for this recipe: `Bash` (for `mkdir -p` and `curl`), `Read` (for PDF ingestion with the `pages` parameter), and `WebFetch` (for the HTML fallback). Skill callers without one of these cannot execute the recipe and should fall back to abstract-only mode explicitly.
+
+### When `full_text_available=false` is the honest answer
+
+Most PubMed records are paywalled outside PMC OA. arXiv, bioRxiv, and medRxiv all serve open PDFs. If a calling workflow is reporting `full_text_available=false` for arXiv or preprint records, something is wrong — verify the recipe was actually run (curl exit code observed; Read attempted on the cached file) before accepting the false flag.
 
 ## Pass 3 — Deep Understanding
 


### PR DESCRIPTION
## Why

Pass 2 of `paper-extractor` was producing thin abstract-only extractions for almost every arXiv / bioRxiv / medRxiv paper, even though those sources all serve open PDFs. Downstream the synthesizer's Pass A summaries and Pass B clusters had nothing to chew on, so the weekly digest was thin too.

Root cause is purely instructional. The agent's tools are sufficient — `Bash` + `Read` (Read handles `.pdf` files with a `pages` parameter, max 20 pages per call) — but Pass 2 told the agent to "try `paper_record.pdf_url`" without spelling out the mechanics. The agent kept reaching for `WebFetch` (the implicit fetch tool), which is HTML→markdown only and silently fails on `.pdf` URLs. The agent then fell through to `full_text_available=false` and ran Pass 2 on the abstract alone.

## The recipe

Both `agents/paper-extractor.md` Pass 2 section and `skills/paper-three-pass-extraction/SKILL.md` Pass 2 section now spell out:

1. Construct cache path: `ops/paper-synthesizer/.cache/pdfs/{slug}.pdf` (`.cache/` is already gitignored)
2. `mkdir -p` the cache dir via Bash
3. Try sources in order, stopping at first success:
   - **Source 1**: \`curl -L --max-time 60 --fail -sS -o {cache} "{pdf_url}"\`
   - **Source 2**: WebFetch on the HTML abstract page (only accept if it's genuinely full text — methods + results, > 5K chars)
   - **Source 3**: PMC OA PDF endpoint for PubMed records with PMC ids
4. \`Read({file_path: cache, pages: "1-20"})\` for the cached PDF. Continue with "21-40", "41-60" etc. until references reached.
5. If all three sources fail → `full_text_available=false` and proceed in reduced-confidence mode (each affected answer tagged `(abstract-only; full text unavailable)`; figure-by-figure skipped).

**Must-not #6 updated**: never set `full_text_available=false` without first attempting the Bash + curl + Read sequence end-to-end. WebFetch alone on a `.pdf` URL doesn't count as "tried" because it always fails.

**Pass 3 checklist updated**: reuse the cached PDF from Pass 2 rather than re-downloading.

## Tool audit (no changes needed elsewhere)

While here, audited every agent in the pipeline for missing tools:

| Agent | Tools | Verdict |
|---|---|---|
| `papersynthesis-orchestrator` (downstream repo) | Read, Write, Edit, Grep, Glob, Bash, Agent | Sufficient — delegates network work to literature-scan-coach |
| `literature-scan-coach` | + WebSearch, WebFetch | Sufficient |
| `paper-extractor` | + Bash, WebFetch | **Sufficient — recipe just needed documenting** |
| `paper-synthesizer` | Read, Write, Edit, Grep, Glob | Sufficient (file-only work) |

One borderline case flagged for a follow-up PR (not blocking anything): `skill-creator` lacks `WebFetch`, so "create a skill from this URL" doesn't work today. File-based source docs are unaffected.

## Test plan

- [ ] paper-extractor at pass=2 on an arXiv paper successfully downloads the PDF and reads it (verify cached file exists at `ops/paper-synthesizer/.cache/pdfs/{slug}.pdf`)
- [ ] Pass 2 output for an arXiv paper has populated answers for the figure-by-figure question and the references-worth-follow-up list (these were always empty before)
- [ ] paper-extractor on a paywalled PubMed record (no PMC id) gracefully falls back to reduced-confidence mode and tags affected answers correctly
- [ ] paper-extractor on a bioRxiv preprint downloads via Source 1 (no fallback needed)
- [ ] Re-run on the same paper reuses the cached PDF (no second curl call observed)
- [ ] Pass 3 escalation reuses the Pass 2 cache without re-downloading

🤖 Generated with [Claude Code](https://claude.com/claude-code)