### PR TITLE
README: document optional native dependencies for markdown-to-pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A production-ready library of **218 skills** and **43 orchestrating agents** for
 /plugin install thinking-frameworks-skills
 ```
 
+> **Note:** A small number of skills wrap native CLI tools (currently only [`markdown-to-pdf`](skills/markdown-to-pdf/SKILL.md), which needs `pandoc` and a LaTeX engine). Those tools must be installed separately. See [Optional native dependencies](#optional-native-dependencies) below. **All other skills work out of the box.**
+
 ---
 
 ## I want to…
@@ -107,6 +109,30 @@ Agents detect your need and route to the right skills. Each agent's page documen
 | [**technical-reviewer**](agents/technical-reviewer.md) | Pre-publish claim check — simplified / wrong / contested / overclaim classification with primary sources |
 | [**curator**](agents/curator.md) | Every 4-6 weeks: section map maintenance; active + reactive; handles per-section voice overlays |
 | [**growth-strategist**](agents/growth-strategist.md) | Quarterly (rolling 13-week) strategic zoomout with uncomfortable questions and kill list |
+
+---
+
+## Optional native dependencies
+
+A small number of skills wrap native command-line tools and only work if those tools are installed on the user's machine. **All such skills are optional.** If a required tool is missing, the skill exits immediately with the exact install commands; nothing breaks silently and the rest of the library continues to work normally.
+
+If you do not want to install the tools below, simply do not invoke the skills that need them. Every other skill in this repository, and every agent that does not include one of these skills in its pipeline, works without any additional native dependencies.
+
+### Skills with native dependencies
+
+| Skill | Native dependency | Why it's needed | Install (macOS) | Install (Linux / Debian) |
+|---|---|---|---|---|
+| [`markdown-to-pdf`](skills/markdown-to-pdf/SKILL.md) | `pandoc` and a LaTeX engine (`xelatex`) | Renders a finished markdown report to an analyst-style PDF. The LaTeX engine produces the typography. Without these tools the skill cannot run; it has no fallback rendering path. | `brew install pandoc basictex`<br/>`sudo tlmgr update --self`<br/>`sudo tlmgr install xetex` | `sudo apt install pandoc texlive-xetex texlive-fonts-recommended` |
+
+`basictex` on macOS is about 90 MB. Do not install `mactex` unless you specifically need the full LaTeX stack (~5 GB).
+
+### Agents that invoke these skills
+
+Currently only one agent pipeline includes a dependency-requiring skill:
+
+- [`product-strategist`](agents/product-strategist.md) calls `markdown-to-pdf` in its final step to render the finished strategist report.
+
+If you run `product-strategist` without `pandoc` or `xelatex` installed, the agent still produces its primary markdown report; only the PDF rendering step is affected, and the agent will surface the install instructions in that case. You can install the tools later and re-render any past markdown report on demand.
 
 ---
 
@@ -220,7 +246,7 @@ Domain-neutral primitives for any weekly paper-digest workflow. Powers the `lite
 - **[translation-reframing-audience-shift](skills/translation-reframing-audience-shift/SKILL.md)** — Adapt content for a new audience without losing accuracy.
 - **[one-pager-prd](skills/one-pager-prd/SKILL.md)** — Write concise one-pagers and PRDs for stakeholder alignment.
 - **[strategist-voice](skills/strategist-voice/SKILL.md)** — Apply the analyst-grade house style for long-form strategist reports: no em dashes, footnoted citations, opinion via phrasing.
-- **[markdown-to-pdf](skills/markdown-to-pdf/SKILL.md)** — Render a finished markdown report to PDF via pandoc and xelatex with analyst-style typography.
+- **[markdown-to-pdf](skills/markdown-to-pdf/SKILL.md)** — Render a finished markdown report to PDF via pandoc and xelatex with analyst-style typography. *Requires `pandoc` and a LaTeX engine installed locally — see [Optional native dependencies](#optional-native-dependencies).*
 
 ### Scientific & academic writing
 


### PR DESCRIPTION
## Summary

Makes the pandoc + xelatex dependency for the `markdown-to-pdf` skill clearly visible to anyone browsing the repository, in three places:

1. **One-line callout in the install block** — points to the new dependencies section so users see the dependency notice during install.

2. **New top-level section: Optional native dependencies** — explains the contract clearly:
   - Skills with native dependencies are optional
   - If the tool is missing, the skill exits with exact install commands
   - Nothing breaks silently
   - The rest of the library continues to work normally
   - Lists the current single skill (`markdown-to-pdf`) with macOS and Linux install commands side by side
   - Names the agents that include it (`product-strategist` only)
   - Notes that even without the dependency, the agent still produces its primary markdown output

3. **Inline italic note on the `markdown-to-pdf` entry in the skills index** — pointing back to the dependencies section.

## Why this matters

The user noticed that the prior PR (#62) added the `markdown-to-pdf` skill without making the native-tool dependency clear at the README level. Without this, a user could install the plugin, hit the agent pipeline, and only discover the dependency at runtime. This PR puts the dependency where users actually look: at install time, in a dedicated section, and inline next to the skill.

The framing is explicitly *optional* — users who do not want to install pandoc and a LaTeX engine can simply not invoke the skill. The rest of the library is unaffected.

## Test plan

- [ ] Verify the new section renders cleanly on GitHub (table with side-by-side macOS / Linux install commands)
- [ ] Verify the inline link from the skills index anchor resolves to the new section
- [ ] Verify the install-block callout reads naturally and does not over-emphasize a 1-of-218 dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)