### PR TITLE
Remove personal project-location references from README, agents, and skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Pick the fastest entry point for what you're trying to do. Most users start with
 | Reverse-engineer a real product's vision / strategy / tactics / ML and system architecture from public material | [`product-strategist`](agents/product-strategist.md) |
 | Decide how to allocate capital (debt / dividends / projects) | [`capital-allocation-strategist`](agents/capital-allocation-strategist.md) |
 | Manage my Yahoo Fantasy Baseball team | [`mlb-fantasy-coach`](agents/mlb-fantasy-coach.md) + 6 MLB specialists |
-| Run my FIFA World Cup Fantasy squad (evolutionary boards — agents propose, you decide) | [`wc-director`](agents/wc-director.md) + 9 team agents (see `~/Documents/Projects/footballfantasy/`) |
+| Run my FIFA World Cup Fantasy squad (evolutionary boards — agents propose, you decide) | [`wc-director`](agents/wc-director.md) + 9 team agents |
 | Run my household finances from PDF statements (drop in, briefing + dashboard out) | [`household-cfo`](agents/household-cfo.md) + 8 household specialists |
 | Write a paper / grant / recommendation letter | [`scientific-writing-editor`](agents/scientific-writing-editor.md) |
 | Improve any piece of writing (blog, memo, essay) | [`writing-assistant`](agents/writing-assistant.md) |
@@ -36,8 +36,8 @@ Pick the fastest entry point for what you're trying to do. Most users start with
 | Design equivariant / symmetry-aware neural networks | [`geometric-deep-learning-architect`](agents/geometric-deep-learning-architect.md) |
 | Build geometric intuition for ML math (attention, PCA, eigenvectors, high-dim spaces) | [`math-intuition-coach`](agents/math-intuition-coach.md) |
 | Get a weekly digest of new bioRxiv / medRxiv / PubMed / arXiv papers (life sciences + CS / ML) against my keyword watchlist | [`literature-scan-coach`](agents/literature-scan-coach.md) → [`paper-synthesizer`](agents/paper-synthesizer.md) |
-| Grow my Substack / publish intuition-first ML & systems essays | [`librarian`](agents/librarian.md), [`intuition-builder`](agents/intuition-builder.md), [`editor`](agents/editor.md) + 6 more (see `~/Documents/Thinking/substacker/`) |
-| Learn ML-driven crop genetics / genomic selection (experiential study → notes → publish in public) | [`biostat-tutor`](agents/biostat-tutor.md), [`biostat-assessor`](agents/biostat-assessor.md), [`biostat-editor`](agents/biostat-editor.md) + 6 more (see `~/Documents/Projects/learnbiostats/`) |
+| Grow my Substack / publish intuition-first ML & systems essays | [`librarian`](agents/librarian.md), [`intuition-builder`](agents/intuition-builder.md), [`editor`](agents/editor.md) + 6 more |
+| Learn ML-driven crop genetics / genomic selection (experiential study → notes → publish in public) | [`biostat-tutor`](agents/biostat-tutor.md), [`biostat-assessor`](agents/biostat-assessor.md), [`biostat-editor`](agents/biostat-editor.md) + 6 more |
 | Use just one tool (no agent) | Browse the [Skills Index](#skills-index) below |
 
 ## How the pieces fit together
@@ -373,7 +373,7 @@ Based on Damodaran's valuation curriculum.
 
 ### Household finance (12)
 
-PDF-driven personal-finance pipeline. Pairs with the orchestration runtime at `~/Documents/Projects/financialplanning/` (inbox, archive, canonical JSON store, prompts, weekly static HTML dashboards). Powers the `household-cfo` agent and 8 specialists.
+PDF-driven personal-finance pipeline. Pairs with a companion orchestration runtime (inbox, archive, canonical JSON store, prompts, weekly static HTML dashboards). Powers the `household-cfo` agent and 8 specialists.
 
 - **[pdf-statement-parser](skills/pdf-statement-parser/SKILL.md)** — Parse a single bank / brokerage / 401k / HSA / mortgage / tax PDF into normalized JSON with confidence.
 - **[transaction-categorizer](skills/transaction-categorizer/SKILL.md)** — Rules-then-LLM categorization with merchant normalization and rule learning.
@@ -403,7 +403,7 @@ Domain-neutral primitives — portable across fantasy sports, poker, auctions, M
 
 ### Yahoo Fantasy Baseball (14)
 
-Baseball-specific skills for a H2H Categories league. Pairs with the companion runtime at `~/Documents/Projects/yahoo-mlb/`.
+Baseball-specific skills for a H2H Categories league. Pairs with a companion runtime workspace (league state, signals, decision trackers, daily briefs).
 
 - **[mlb-league-state-reader](skills/mlb-league-state-reader/SKILL.md)** — Parse Yahoo league state via Claude-in-Chrome.
 - **[mlb-player-analyzer](skills/mlb-player-analyzer/SKILL.md)** — Deep-dive a player across FanGraphs, Savant, RotoWire.
@@ -422,7 +422,7 @@ Baseball-specific skills for a H2H Categories league. Pairs with the companion r
 
 ### FIFA World Cup Fantasy (16)
 
-Skills for the evolutionary World Cup fantasy backroom. Pairs with the companion runtime at `~/Documents/Projects/footballfantasy/`.
+Skills for the evolutionary World Cup fantasy backroom. Pairs with a companion runtime workspace (tournament state, signals, generations, decision boards).
 
 - **[wc-player-ev](skills/wc-player-ev/SKILL.md)** — Per-player per-round xEV: minutes cliff, fixture-scaled npxG/xA, pen/set-piece premium.
 - **[wc-clean-sheet-model](skills/wc-clean-sheet-model/SKILL.md)** — Clean-sheet probability + the stack-correlation bonus for defensive blocks.
@@ -451,7 +451,7 @@ Skills for the evolutionary World Cup fantasy backroom. Pairs with the companion
 <details>
 <summary><b>📰 Substack Growth</b> — 9-agent team for growing "From First Principles / The Thinker's Notebook" (68 skills)</summary>
 
-Pairs with the working folder at `~/Documents/Thinking/substacker/` (inbox, corpus, shared-context, ops). Voice-profile, section-map, per-section visual identities, analogy catalog, topic ledger all live there.
+Pairs with a companion working folder (inbox, corpus, shared-context, ops). Voice-profile, section-map, per-section visual identities, analogy catalog, topic ledger all live there.
 
 ### Librarian (8) — corpus ingest + index
 
@@ -553,7 +553,7 @@ Pairs with the working folder at `~/Documents/Thinking/substacker/` (inbox, corp
 <details>
 <summary><b>📚 Learning Studio</b> — experiential study + learning-in-public writing for ML-driven crop genetics (7 skills)</summary>
 
-Pairs with the learning vault at `~/Documents/Projects/learnbiostats/` (Kolb curriculum, Zettelkasten evergreen notes, dictation-to-publish writing studio, GitHub Pages site). Powers the 9 `biostat-*` agents.
+Pairs with a companion learning vault (Kolb curriculum, Zettelkasten evergreen notes, dictation-to-publish writing studio, GitHub Pages site). Powers the 9 `biostat-*` agents.
 
 - **[experiential-kolb-teaching](skills/experiential-kolb-teaching/SKILL.md)** — Run a learning module as a Kolb cycle; withhold the explanation, draw the claim out, route it to an evergreen note.
 - **[mastery-assessment](skills/mastery-assessment/SKILL.md)** — Bloom-tagged closed-book probing + Dreyfus mastery bands + expanding-interval spaced repetition.

--- a/agents/curator.md
+++ b/agents/curator.md
@@ -23,19 +23,19 @@ Shape-watcher. Both **reactive** (every 4-6 weeks, audit corpus shape) and **act
 ## Paths
 
 **Reads:**
-- `/Users/kushaldsouza/Documents/Thinking/substacker/corpus/published/**` (full bodies)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/section-map.md` (prior state)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/goals.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/audience-notes.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/topic-ledger.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/ops/curator/**` (prior reviews)
+- `substacker/corpus/published/**` (full bodies)
+- `substacker/shared-context/section-map.md` (prior state)
+- `substacker/shared-context/goals.md`
+- `substacker/shared-context/audience-notes.md`
+- `substacker/shared-context/topic-ledger.md`
+- `substacker/ops/curator/**` (prior reviews)
 
 **Writes:**
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/section-map.md` (overwrite, with snapshot backup)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/sections/{slug}/section-profile.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/voices/{slug}.md` (via `derive-section-voice-overlay`)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/ops/curator/YYYY-MM-DD-review.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/ops/curator/snapshots/YYYY-MM-DD-section-map.md` (backup)
+- `substacker/shared-context/section-map.md` (overwrite, with snapshot backup)
+- `substacker/shared-context/sections/{slug}/section-profile.md`
+- `substacker/shared-context/voices/{slug}.md` (via `derive-section-voice-overlay`)
+- `substacker/ops/curator/YYYY-MM-DD-review.md`
+- `substacker/ops/curator/snapshots/YYYY-MM-DD-section-map.md` (backup)
 
 **Never writes to:** post bodies, goals.md, topic-ledger.md, or any visual-identity.md (cognitive-design-architect owns visual identity — Curator hands off).
 

--- a/agents/distribution-translator.md
+++ b/agents/distribution-translator.md
@@ -23,16 +23,16 @@ You translate **published** essays into platform-native rewrites. **Primary plat
 ## Paths
 
 **Reads:**
-- `/Users/kushaldsouza/Documents/Thinking/substacker/corpus/published/{section}/{slug}.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/voice-profile.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/voices/{section}.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/section-map.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/sections/{section}/visual-identity.md` (for cross-platform crops)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/audience-notes.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/glossary.md`
+- `substacker/corpus/published/{section}/{slug}.md`
+- `substacker/shared-context/voice-profile.md`
+- `substacker/shared-context/voices/{section}.md`
+- `substacker/shared-context/section-map.md`
+- `substacker/shared-context/sections/{section}/visual-identity.md` (for cross-platform crops)
+- `substacker/shared-context/audience-notes.md`
+- `substacker/shared-context/glossary.md`
 
 **Writes:**
-- `/Users/kushaldsouza/Documents/Thinking/substacker/ops/distribution/{YYYY-MM-DD}-{slug}/`
+- `substacker/ops/distribution/{YYYY-MM-DD}-{slug}/`
   - `_spine.json` (working artifact)
   - `linkedin-post.md` (PRIMARY — writer's preferred surface)
   - `substack-note.md` (PRIMARY — Substack Notes feed)

--- a/agents/editor.md
+++ b/agents/editor.md
@@ -21,16 +21,16 @@ You are the **voice gate** for the writer. Every draft passes through you before
 ## Paths
 
 **Reads:**
-- Draft file at `/Users/kushaldsouza/Documents/Thinking/substacker/corpus/drafts/{slug}.md` OR inline
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/voice-profile.md` (global; mandatory every run)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/voices/{section-slug}.md` (overlay; if draft's frontmatter has section)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/style-guide.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/analogy-catalog.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/glossary.md`
+- Draft file at `substacker/corpus/drafts/{slug}.md` OR inline
+- `substacker/shared-context/voice-profile.md` (global; mandatory every run)
+- `substacker/shared-context/voices/{section-slug}.md` (overlay; if draft's frontmatter has section)
+- `substacker/shared-context/style-guide.md`
+- `substacker/shared-context/analogy-catalog.md`
+- `substacker/shared-context/glossary.md`
 - Prior review (for second-pass logic) at `ops/editor/*.md`
 
 **Writes:**
-- `/Users/kushaldsouza/Documents/Thinking/substacker/ops/editor/YYYY-MM-DD-{post-slug}.md` (exactly one file per invocation)
+- `substacker/ops/editor/YYYY-MM-DD-{post-slug}.md` (exactly one file per invocation)
 
 **Never writes to:** `corpus/drafts/`, `shared-context/` (voice-profile is read-only for Editor; it surfaces drift candidates for the writer to apply).
 

--- a/agents/growth-analyst.md
+++ b/agents/growth-analyst.md
@@ -23,18 +23,18 @@ Weekly Substack stats analyst. **Primary path**: Claude-in-Chrome pulls stats di
 ## Paths
 
 **Reads:**
-- `/Users/kushaldsouza/Documents/Thinking/substacker/inbox/substack-stats/*.csv` (new CSVs)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/corpus/stats/*.csv` (historical baseline)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/corpus/published/**` (post titles + section tags)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/section-map.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/goals.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/audience-notes.md`
+- `substacker/inbox/substack-stats/*.csv` (new CSVs)
+- `substacker/corpus/stats/*.csv` (historical baseline)
+- `substacker/corpus/published/**` (post titles + section tags)
+- `substacker/shared-context/section-map.md`
+- `substacker/shared-context/goals.md`
+- `substacker/shared-context/audience-notes.md`
 - Public web via WebFetch (publication URL + public post URLs)
 
 **Writes:**
-- `/Users/kushaldsouza/Documents/Thinking/substacker/ops/growth-analyst/YYYY-WW-report.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/audience-notes.md` (append-only; confidence ≥ medium only)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/corpus/stats/{week}.csv` (moved from inbox/)
+- `substacker/ops/growth-analyst/YYYY-WW-report.md`
+- `substacker/shared-context/audience-notes.md` (append-only; confidence ≥ medium only)
+- `substacker/corpus/stats/{week}.csv` (moved from inbox/)
 
 **Never writes:** `shared-context/section-map.md`, `shared-context/goals.md`. Curator / writer own those.
 

--- a/agents/growth-strategist.md
+++ b/agents/growth-strategist.md
@@ -23,16 +23,16 @@ Quarterly strategic advisor. One job: zoom out, ask the three uncomfortable ques
 ## Paths
 
 **Reads:**
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/goals.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/section-map.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/audience-notes.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/topic-ledger.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/ops/growth-analyst/*.md` (all since last Strategist review)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/ops/curator/*.md` (most recent)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/corpus/published/**` (meta-scan only — titles, dates, first paragraphs)
+- `substacker/shared-context/goals.md`
+- `substacker/shared-context/section-map.md`
+- `substacker/shared-context/audience-notes.md`
+- `substacker/shared-context/topic-ledger.md`
+- `substacker/ops/growth-analyst/*.md` (all since last Strategist review)
+- `substacker/ops/curator/*.md` (most recent)
+- `substacker/corpus/published/**` (meta-scan only — titles, dates, first paragraphs)
 
 **Writes:**
-- `/Users/kushaldsouza/Documents/Thinking/substacker/ops/growth-strategist/YYYY-Q#-review.md` (Q# = rolling-quarter index, not calendar)
+- `substacker/ops/growth-strategist/YYYY-Q#-review.md` (Q# = rolling-quarter index, not calendar)
 
 **Never writes to:** `shared-context/goals.md` (proposes diff; writer applies), `shared-context/section-map.md` (Curator owns), `ops/curator/` or `ops/growth-analyst/` (other agents' homes), `corpus/`.
 

--- a/agents/intuition-builder.md
+++ b/agents/intuition-builder.md
@@ -21,15 +21,15 @@ You are the engine of differentiation. Given a technical topic the writer wants 
 ## Paths
 
 **Reads:**
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/analogy-catalog.md` (novelty check)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/voice-profile.md` (voice fit)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/voices/{section}.md` (if target section specified)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/glossary.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/topic-ledger.md`
+- `substacker/shared-context/analogy-catalog.md` (novelty check)
+- `substacker/shared-context/voice-profile.md` (voice fit)
+- `substacker/shared-context/voices/{section}.md` (if target section specified)
+- `substacker/shared-context/glossary.md`
+- `substacker/shared-context/topic-ledger.md`
 - Optionally: corpus search results via Librarian's `search-corpus`
 
 **Writes:**
-- `/Users/kushaldsouza/Documents/Thinking/substacker/ops/intuition-builder/YYYY-MM-DD-{topic-slug}.md`
+- `substacker/ops/intuition-builder/YYYY-MM-DD-{topic-slug}.md`
 
 **Never writes:**
 - `corpus/drafts/` — the writer drafts, not this agent.

--- a/agents/librarian.md
+++ b/agents/librarian.md
@@ -8,7 +8,7 @@ model: inherit
 
 # The Librarian Agent
 
-You are the ingest and indexing agent for the writer's Substack corpus at `/Users/kushaldsouza/Documents/Thinking/substacker/`. You are the **first agent that runs** in every session — nothing else works unless the corpus is current.
+You are the ingest and indexing agent for the writer's Substack corpus at `substacker/`. You are the **first agent that runs** in every session — nothing else works unless the corpus is current.
 
 **When to invoke:** session start; user drops file(s) in `inbox/`; user says `/ingest`; user asks "what have I thought about X"; user asks for a stale-seed sweep.
 
@@ -23,17 +23,17 @@ Then act. No menu; this is a utility agent.
 ## Paths (load-bearing — state these before any file operation)
 
 **Reads:**
-- `/Users/kushaldsouza/Documents/Thinking/substacker/inbox/**` (not `.processed/`)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/corpus/**`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/**` (read-only except topic-ledger.md)
+- `substacker/inbox/**` (not `.processed/`)
+- `substacker/corpus/**`
+- `substacker/shared-context/**` (read-only except topic-ledger.md)
 
 **Writes:**
-- `/Users/kushaldsouza/Documents/Thinking/substacker/corpus/seeds/*.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/corpus/seeds/.changelog.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/corpus/seeds/.librarian-state.json`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/topic-ledger.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/inbox/.processed/**` (moves only)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/ops/librarian/YYYY-MM-DD-stale-sweep.md`
+- `substacker/corpus/seeds/*.md`
+- `substacker/corpus/seeds/.changelog.md`
+- `substacker/corpus/seeds/.librarian-state.json`
+- `substacker/shared-context/topic-ledger.md`
+- `substacker/inbox/.processed/**` (moves only)
+- `substacker/ops/librarian/YYYY-MM-DD-stale-sweep.md`
 
 **Never writes to:** `corpus/drafts/`, `corpus/published/`, `corpus/dead/`, or any shared-context file except `topic-ledger.md`.
 

--- a/agents/mlb-fantasy-coach.md
+++ b/agents/mlb-fantasy-coach.md
@@ -134,18 +134,18 @@ Correct:
 Before firing any specialist, read the authoritative context so the team operates on a shared understanding.
 
 **Step 0.1: Read the operating protocol and frameworks, in parallel.**
-- `~/Documents/Projects/yahoo-mlb/CLAUDE.md` — operating protocol and user profile
-- `~/Documents/Projects/yahoo-mlb/context/league-config.md` — league rules and state
-- `~/Documents/Projects/yahoo-mlb/context/team-profile.md` — current roster and FAAB
-- `~/Documents/Projects/yahoo-mlb/context/frameworks/signal-framework.md` — signal schema
-- `~/Documents/Projects/yahoo-mlb/context/frameworks/variant-catalog.md` — each specialist's advocate/critic priors
-- `~/Documents/Projects/yahoo-mlb/context/frameworks/decision-log-format.md` — log entry schema
-- `~/Documents/Projects/yahoo-mlb/context/frameworks/beginner-glossary.md` — jargon to plain English
-- `~/Documents/Projects/yahoo-mlb/context/frameworks/data-sources.md` — where to web-search
+- `yahoo-mlb/CLAUDE.md` — operating protocol and user profile
+- `yahoo-mlb/context/league-config.md` — league rules and state
+- `yahoo-mlb/context/team-profile.md` — current roster and FAAB
+- `yahoo-mlb/context/frameworks/signal-framework.md` — signal schema
+- `yahoo-mlb/context/frameworks/variant-catalog.md` — each specialist's advocate/critic priors
+- `yahoo-mlb/context/frameworks/decision-log-format.md` — log entry schema
+- `yahoo-mlb/context/frameworks/beginner-glossary.md` — jargon to plain English
+- `yahoo-mlb/context/frameworks/data-sources.md` — where to web-search
 
 **Step 0.2: Read the learning-loop tilts.**
-- `~/Documents/Projects/yahoo-mlb/tracker/variant-scoreboard.md` — which variant has been more often right per specialist
-- Last 3 entries in `~/Documents/Projects/yahoo-mlb/tracker/decisions-log.md` — recent context and any outcomes due today
+- `yahoo-mlb/tracker/variant-scoreboard.md` — which variant has been more often right per specialist
+- Last 3 entries in `yahoo-mlb/tracker/decisions-log.md` — recent context and any outcomes due today
 
 **Step 0.3: Note any decisions whose `will_verify_on` is today.** If any exist and today is Monday, the agenda must include a calibration pass — web-search the outcome, fill in `outcome`, `outcome_recorded_on`, and `variant_that_was_right`, and tally into the scoreboard.
 
@@ -297,7 +297,7 @@ The `mlb-beginner-translator` skill will walk the brief and insert inline transl
 - Any red-team finding with score ≥ 6 is surfaced as a mitigation line under the affected action.
 - No "consider," no "think about," no unexplained jargon.
 
-**Write the brief to:** `~/Documents/Projects/yahoo-mlb/briefs/YYYY-MM-DD-morning.md`
+**Write the brief to:** `yahoo-mlb/briefs/YYYY-MM-DD-morning.md`
 
 **Bridge to Phase 7:** Carry forward the TL;DR and the top 4 actions for the 5-line chat summary.
 
@@ -316,7 +316,7 @@ Today's top actions:
   1. [VERB] [object] — [one-phrase reason]
   2. [VERB] [object] — [one-phrase reason]
   3. [VERB] [object] — [one-phrase reason]
-Full brief: ~/Documents/Projects/yahoo-mlb/briefs/YYYY-MM-DD-morning.md
+Full brief: yahoo-mlb/briefs/YYYY-MM-DD-morning.md
 ```
 
 **Step 7.3:** Tell the user plainly: "Brief is written. Three actions above. The file has the full reasoning and any items flagged for your manual review. Anything you would like me to dig into further?"
@@ -468,8 +468,8 @@ DECISION LOG ENTRIES APPENDED TODAY
 [List of decision_id values written to tracker/decisions-log.md]
 
 ===============================================================
-Full signals: ~/Documents/Projects/yahoo-mlb/signals/[YYYY-MM-DD]-*.md
-Decision log: ~/Documents/Projects/yahoo-mlb/tracker/decisions-log.md
+Full signals: yahoo-mlb/signals/[YYYY-MM-DD]-*.md
+Decision log: yahoo-mlb/tracker/decisions-log.md
 ===============================================================
 ```
 
@@ -482,5 +482,5 @@ Today's top actions:
   1. [VERB] [object] — [one-phrase reason]
   2. [VERB] [object] — [one-phrase reason]
   3. [VERB] [object] — [one-phrase reason]
-Full brief: ~/Documents/Projects/yahoo-mlb/briefs/[YYYY-MM-DD]-morning.md
+Full brief: yahoo-mlb/briefs/[YYYY-MM-DD]-morning.md
 ```

--- a/agents/mlb-lineup-optimizer.md
+++ b/agents/mlb-lineup-optimizer.md
@@ -89,11 +89,11 @@ Orchestration only. Skills do the work.
 
 **This phase lives in the agent. It is the foundation.**
 
-**Step 0.1 — Read the league contract.** Open `/Users/kushaldsouza/Documents/Projects/yahoo-mlb/context/league-config.md`. Confirm format (H2H Categories, OBP instead of AVG, QS instead of W), roster shape (C, 1B, 2B, 3B, SS, OF×3, Util×2, SP×3, RP×2, P×5, BN×3, IL×3), and that lineups lock daily per-game.
+**Step 0.1 — Read the league contract.** Open `yahoo-mlb/context/league-config.md`. Confirm format (H2H Categories, OBP instead of AVG, QS instead of W), roster shape (C, 1B, 2B, 3B, SS, OF×3, Util×2, SP×3, RP×2, P×5, BN×3, IL×3), and that lineups lock daily per-game.
 
-**Step 0.2 — Read the team profile.** Open `/Users/kushaldsouza/Documents/Projects/yahoo-mlb/context/team-profile.md`. Pull the current active roster, current IL list, FAAB remaining, and any notes from prior runs (e.g., "Caminero returning from minor day-to-day tightness").
+**Step 0.2 — Read the team profile.** Open `yahoo-mlb/context/team-profile.md`. Pull the current active roster, current IL list, FAAB remaining, and any notes from prior runs (e.g., "Caminero returning from minor day-to-day tightness").
 
-**Step 0.3 — Read this week's opponent matchup state and archetype profile.** Open the relevant file in `/Users/kushaldsouza/Documents/Projects/yahoo-mlb/context/opponents/`. This file is produced by the coach's Phase 0.5 (`mlb-opponent-profiler` + `opponent-archetype-classifier`) and contains the opponent's MAP archetype (e.g., `punt_sv`, `stars_and_scrubs`), best-response hints, and per-cat strength/weakness map. If the opponent profile does not exist, ask the coach to run Phase 0.5 before proceeding — this agent must not fire against a generic opponent baseline (per game-theory principle #5).
+**Step 0.3 — Read this week's opponent matchup state and archetype profile.** Open the relevant file in `yahoo-mlb/context/opponents/`. This file is produced by the coach's Phase 0.5 (`mlb-opponent-profiler` + `opponent-archetype-classifier`) and contains the opponent's MAP archetype (e.g., `punt_sv`, `stars_and_scrubs`), best-response hints, and per-cat strength/weakness map. If the opponent profile does not exist, ask the coach to run Phase 0.5 before proceeding — this agent must not fire against a generic opponent baseline (per game-theory principle #5).
 
 **Step 0.4 — Pull today's MLB slate.** Use `WebSearch` / `WebFetch` to confirm: which games are scheduled today, probable starting pitchers for each team, confirmed lineups (MLB.com — usually posted ~3 hours before first pitch), and weather (rain risk, wind direction at open-air parks). Cite every URL.
 

--- a/agents/technical-reviewer.md
+++ b/agents/technical-reviewer.md
@@ -23,11 +23,11 @@ Pre-publish claim-check. **Simplification is the goal**; wrongness is the bug; b
 ## Paths
 
 **Reads:**
-- `/Users/kushaldsouza/Documents/Thinking/substacker/corpus/drafts/{slug}.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/glossary.md`
+- `substacker/corpus/drafts/{slug}.md`
+- `substacker/shared-context/glossary.md`
 
 **Writes:**
-- `/Users/kushaldsouza/Documents/Thinking/substacker/ops/technical-reviewer/YYYY-MM-DD-{slug}-review.md`
+- `substacker/ops/technical-reviewer/YYYY-MM-DD-{slug}-review.md`
 
 **Never writes to:** `corpus/drafts/` (writer's draft), `shared-context/glossary.md` (writer owns).
 

--- a/agents/trend-scout.md
+++ b/agents/trend-scout.md
@@ -23,16 +23,16 @@ Weekly external-signal compressor. Reads ~30-50 curated sources; emits ≤10 ite
 ## Paths
 
 **Reads:**
-- `/Users/kushaldsouza/Documents/Thinking/substacker/ops/trend-scout/watchlist.md` (source list)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/topic-ledger.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/goals.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/voice-profile.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/corpus/{seeds,drafts,published}/**` metadata only (titles, frontmatter)
+- `substacker/ops/trend-scout/watchlist.md` (source list)
+- `substacker/shared-context/topic-ledger.md`
+- `substacker/shared-context/goals.md`
+- `substacker/shared-context/voice-profile.md`
+- `substacker/corpus/{seeds,drafts,published}/**` metadata only (titles, frontmatter)
 
 **Writes:**
-- `/Users/kushaldsouza/Documents/Thinking/substacker/ops/trend-scout/YYYY-WW-digest.md`
-- `/Users/kushaldsouza/Documents/Thinking/substacker/ops/trend-scout/watchlist.md` (only via `update-watchlist` skill, monthly)
-- `/Users/kushaldsouza/Documents/Thinking/substacker/ops/trend-scout/.cache/` (HTML snapshots)
+- `substacker/ops/trend-scout/YYYY-WW-digest.md`
+- `substacker/ops/trend-scout/watchlist.md` (only via `update-watchlist` skill, monthly)
+- `substacker/ops/trend-scout/.cache/` (HTML snapshots)
 
 **Never writes:** `corpus/` (Scout proposes candidates; Librarian or writer promotes), `shared-context/topic-ledger.md` (Librarian owns).
 

--- a/skills/mlb-beginner-translator/SKILL.md
+++ b/skills/mlb-beginner-translator/SKILL.md
@@ -107,7 +107,7 @@ Internal signal values (numeric `daily_quality`, `regression_index`, `streamabil
 
 **Step 6: Collapse to action verbs**
 
-Every recommendation must end in one of the approved action verbs with no hedging. No "consider," "think about," "might want to," "could try." See the full ladder in [CLAUDE.md](/Users/kushaldsouza/Documents/Projects/yahoo-mlb/CLAUDE.md) rule 6. If the upstream agent hedged, collapse the hedge into a single verb plus an explicit fallback action.
+Every recommendation must end in one of the approved action verbs with no hedging. No "consider," "think about," "might want to," "could try." See the full ladder in [CLAUDE.md](yahoo-mlb/CLAUDE.md) rule 6. If the upstream agent hedged, collapse the hedge into a single verb plus an explicit fallback action.
 
 - [ ] Every recommendation ends in: START / SIT / ADD / DROP / BID $X / ACCEPT / COUNTER (with suggested counter) / REJECT
 - [ ] A dedicated "Actions" bullet list appears at the end of every user-facing output
@@ -177,7 +177,7 @@ Score the translated output against [resources/evaluators/rubric_mlb_beginner_tr
 
 ## Quick Reference
 
-**The action-verb ladder (from [CLAUDE.md](/Users/kushaldsouza/Documents/Projects/yahoo-mlb/CLAUDE.md) rule 6):**
+**The action-verb ladder (from [CLAUDE.md](yahoo-mlb/CLAUDE.md) rule 6):**
 
 ```
 START             -- put this player in your active lineup today
@@ -226,7 +226,7 @@ Example:
 - **[resources/template.md](resources/template.md)**: Inline gloss patterns by term category (stats, positions, matchups, advanced, transactions, archetypes, signal names). Before/after translation templates for briefs, trade memos, waiver memos, chat replies.
 - **[resources/methodology.md](resources/methodology.md)**: The first-mention rule, assumed-knowledge trap list, action-verb enforcement, worked before/after examples including a full lineup recommendation with jargon and without.
 - **[resources/evaluators/rubric_mlb_beginner_translator.json](resources/evaluators/rubric_mlb_beginner_translator.json)**: 10-criterion rubric (jargon detection, gloss accuracy, first-mention rule, assumed-knowledge rewrites, signal stripping, action-verb presence, player identification, uncertainty surfacing, tone, overall readability).
-- **Master glossary**: `/Users/kushaldsouza/Documents/Projects/yahoo-mlb/context/frameworks/beginner-glossary.md` -- authoritative source for plain-English definitions. This skill mirrors and extends it.
+- **Master glossary**: `yahoo-mlb/context/frameworks/beginner-glossary.md` -- authoritative source for plain-English definitions. This skill mirrors and extends it.
 
 **Inputs required:**
 

--- a/skills/mlb-decision-logger/SKILL.md
+++ b/skills/mlb-decision-logger/SKILL.md
@@ -191,15 +191,15 @@ e.g., 2026-04-17-lineup-01
 
 **Files touched:**
 
-- `~/Documents/Projects/yahoo-mlb/tracker/decisions-log.md` (append, or surgical edit of outcome fields)
-- `~/Documents/Projects/yahoo-mlb/tracker/variant-scoreboard.md` (row increments, tilt recompute)
-- `~/Documents/Projects/yahoo-mlb/tracker/calibration-review.md` (written only when high-confidence decision was wrong)
+- `yahoo-mlb/tracker/decisions-log.md` (append, or surgical edit of outcome fields)
+- `yahoo-mlb/tracker/variant-scoreboard.md` (row increments, tilt recompute)
+- `yahoo-mlb/tracker/calibration-review.md` (written only when high-confidence decision was wrong)
 
 **Files read:**
 
-- `~/Documents/Projects/yahoo-mlb/context/frameworks/decision-log-format.md` (schema of record)
-- `~/Documents/Projects/yahoo-mlb/tracker/decisions-log.md` (tail, for serialization and id assignment)
-- `~/Documents/Projects/yahoo-mlb/tracker/variant-scoreboard.md` (for calibration updates)
+- `yahoo-mlb/context/frameworks/decision-log-format.md` (schema of record)
+- `yahoo-mlb/tracker/decisions-log.md` (tail, for serialization and id assignment)
+- `yahoo-mlb/tracker/variant-scoreboard.md` (for calibration updates)
 
 **Key resources:**
 

--- a/skills/mlb-decision-logger/resources/template.md
+++ b/skills/mlb-decision-logger/resources/template.md
@@ -1,6 +1,6 @@
 # Decision Log Entry Template
 
-The authoritative schema lives at `~/Documents/Projects/yahoo-mlb/context/frameworks/decision-log-format.md`. This file mirrors that schema verbatim so the logger skill has a local reference. If the two diverge, `decision-log-format.md` wins and this file must be updated.
+The authoritative schema lives at `yahoo-mlb/context/frameworks/decision-log-format.md`. This file mirrors that schema verbatim so the logger skill has a local reference. If the two diverge, `decision-log-format.md` wins and this file must be updated.
 
 ## Table of Contents
 - [Entry Schema](#entry-schema)

--- a/skills/mlb-faab-sizer/resources/methodology.md
+++ b/skills/mlb-faab-sizer/resources/methodology.md
@@ -98,7 +98,7 @@ This is the baseball-specific calibration that adjusts `season_pace_multiplier` 
 
 **Step 1: Read the faab-log**
 
-Parse `/Users/kushaldsouza/Documents/Projects/yahoo-mlb/tracker/faab-log.md`. Each entry:
+Parse `yahoo-mlb/tracker/faab-log.md`. Each entry:
 
 ```
 ### {date} | {player} | {result}

--- a/skills/mlb-league-state-reader/SKILL.md
+++ b/skills/mlb-league-state-reader/SKILL.md
@@ -16,8 +16,8 @@ description: Parses Yahoo Fantasy Baseball league state (roster, standings, curr
 **Scenario**: Morning brief run on 2026-04-17. Coach needs current roster, matchup, FAAB, and standings before launching lineup-optimizer.
 
 **Inputs read first**:
-- `~/Documents/Projects/yahoo-mlb/context/league-config.md` (league ID 23756, team 5, 12 teams, 5x5 cats)
-- `~/Documents/Projects/yahoo-mlb/context/team-profile.md` (prior known roster skeleton)
+- `yahoo-mlb/context/league-config.md` (league ID 23756, team 5, 12 teams, 5x5 cats)
+- `yahoo-mlb/context/team-profile.md` (prior known roster skeleton)
 
 **Chrome navigation sequence** (authenticated):
 1. `https://baseball.fantasysports.yahoo.com/b1/23756/5` — roster with today's opponents per player
@@ -62,10 +62,10 @@ League State Reader Progress:
 
 Load the authoritative contract and the last known state before touching Yahoo. This both verifies the league ID/URL and provides the skeleton to diff against.
 
-- [ ] Read `~/Documents/Projects/yahoo-mlb/context/league-config.md` — confirm league ID 23756, team 5, roster shape (C/1B/2B/3B/SS/3OF/2UTIL/3SP/2RP/5P/3BN/3IL = 26), FAAB budget $100
-- [ ] Read `~/Documents/Projects/yahoo-mlb/context/team-profile.md` — capture prior FAAB remaining, prior roster for diff
-- [ ] Read `~/Documents/Projects/yahoo-mlb/context/frameworks/signal-framework.md` — confirm signal file format
-- [ ] Read `~/Documents/Projects/yahoo-mlb/context/frameworks/data-sources.md` — confirm the 5 Yahoo URLs
+- [ ] Read `yahoo-mlb/context/league-config.md` — confirm league ID 23756, team 5, roster shape (C/1B/2B/3B/SS/3OF/2UTIL/3SP/2RP/5P/3BN/3IL = 26), FAAB budget $100
+- [ ] Read `yahoo-mlb/context/team-profile.md` — capture prior FAAB remaining, prior roster for diff
+- [ ] Read `yahoo-mlb/context/frameworks/signal-framework.md` — confirm signal file format
+- [ ] Read `yahoo-mlb/context/frameworks/data-sources.md` — confirm the 5 Yahoo URLs
 
 **Step 2: Pull Yahoo pages via Claude-in-Chrome**
 
@@ -98,7 +98,7 @@ See [resources/template.md](resources/template.md#team-profile-output-format) fo
 
 **Step 5: Emit signal file**
 
-Write `~/Documents/Projects/yahoo-mlb/signals/YYYY-MM-DD-league-state.md` with YAML frontmatter per the signal framework. Every URL navigated must appear in `source_urls`. Degraded fetches drop `confidence` to 0.5; full-failure fields drop to 0.3 and are flagged. See [resources/template.md](resources/template.md#signal-file-output-format).
+Write `yahoo-mlb/signals/YYYY-MM-DD-league-state.md` with YAML frontmatter per the signal framework. Every URL navigated must appear in `source_urls`. Degraded fetches drop `confidence` to 0.5; full-failure fields drop to 0.3 and are flagged. See [resources/template.md](resources/template.md#signal-file-output-format).
 
 - [ ] Frontmatter: `type: league-state`, `date`, `emitted_by: mlb-league-state-reader`, `confidence`, `source_urls[]`
 - [ ] Body: roster table, standings table, matchup table, FAAB ledger, top-25 free agents

--- a/skills/mlb-league-state-reader/resources/methodology.md
+++ b/skills/mlb-league-state-reader/resources/methodology.md
@@ -246,6 +246,6 @@ Before writing the signal file, validate it against `context/frameworks/signal-f
 
 If the `mlb-signal-emitter` skill is available in this run, invoke it to validate before write. Otherwise, write directly and note in `tracker/decisions-log.md` that validation was skipped.
 
-**File path:** `~/Documents/Projects/yahoo-mlb/signals/YYYY-MM-DD-league-state.md` — one signal per day. If two runs happen on the same day, overwrite (the newer is more accurate). Do not append.
+**File path:** `yahoo-mlb/signals/YYYY-MM-DD-league-state.md` — one signal per day. If two runs happen on the same day, overwrite (the newer is more accurate). Do not append.
 
 **Downstream contract:** Once this signal exists for today, every other agent must read it instead of re-scraping Yahoo. This is the single source of truth for league state until tomorrow.

--- a/skills/mlb-league-state-reader/resources/template.md
+++ b/skills/mlb-league-state-reader/resources/template.md
@@ -16,7 +16,7 @@ Output formats for the two artifacts this skill produces: the overwritten `team-
 
 ## Team Profile Output Format
 
-Overwrite `~/Documents/Projects/yahoo-mlb/context/team-profile.md` with the following structure. This file is "current state" — do not preserve prior runs.
+Overwrite `yahoo-mlb/context/team-profile.md` with the following structure. This file is "current state" — do not preserve prior runs.
 
 ```markdown
 # Team Profile — ⚾ K L's Boomers
@@ -90,7 +90,7 @@ roster:
 
 ## Signal File Output Format
 
-Write to `~/Documents/Projects/yahoo-mlb/signals/YYYY-MM-DD-league-state.md`. Must conform to `context/frameworks/signal-framework.md`.
+Write to `yahoo-mlb/signals/YYYY-MM-DD-league-state.md`. Must conform to `context/frameworks/signal-framework.md`.
 
 ```markdown
 ---

--- a/skills/mlb-matchup-analyzer/SKILL.md
+++ b/skills/mlb-matchup-analyzer/SKILL.md
@@ -99,7 +99,7 @@ Every signal must land on a 0-100 scale where **50 = league-average / neutral**.
 
 **Step 7: Write platoon narrative**
 
-Per [CLAUDE.md](../../../yahoo-mlb/CLAUDE.md) rule 5: jargon-free or translated inline. For each key hitter of interest, state handedness and the SP's handedness, then describe the platoon edge or lack thereof in plain English. See [resources/template.md](resources/template.md#platoon-narrative-template).
+Per `yahoo-mlb/CLAUDE.md` rule 5: jargon-free or translated inline. For each key hitter of interest, state handedness and the SP's handedness, then describe the platoon edge or lack thereof in plain English. See [resources/template.md](resources/template.md#platoon-narrative-template).
 
 **Step 8: Emit and validate**
 

--- a/skills/mlb-opponent-profiler/SKILL.md
+++ b/skills/mlb-opponent-profiler/SKILL.md
@@ -181,7 +181,7 @@ Classifier returns the archetype; the 10 per-cat strength scores come from a sep
 **Step 8: Write file atomically**
 
 - [ ] Write to temp file `<slug>.md.tmp`, fsync, rename
-- [ ] Validate output against [opponent-profile-schema.md](../../../yahoo-mlb/context/frameworks/opponent-profile-schema.md) frontmatter + section order before rename
+- [ ] Validate output against `yahoo-mlb/context/frameworks/opponent-profile-schema.md` frontmatter + section order before rename
 
 **Step 9: Emit signal file**
 

--- a/skills/mlb-player-analyzer/resources/methodology.md
+++ b/skills/mlb-player-analyzer/resources/methodology.md
@@ -1,6 +1,6 @@
 # MLB Player Analyzer — Methodology
 
-Authoritative math and procedure for every signal this skill emits. The signal catalog is defined in `/Users/kushaldsouza/Documents/Projects/yahoo-mlb/context/frameworks/signal-framework.md`; this document explains *how* to compute each one.
+Authoritative math and procedure for every signal this skill emits. The signal catalog is defined in `yahoo-mlb/context/frameworks/signal-framework.md`; this document explains *how* to compute each one.
 
 ---
 

--- a/skills/mlb-playoff-scheduler/SKILL.md
+++ b/skills/mlb-playoff-scheduler/SKILL.md
@@ -57,7 +57,7 @@ Today's date is inside the prompt. If today < 2026-07-01, skip Steps 2-8 and emi
 
 **Step 2: Define playoff week windows**
 
-Per [context/league-config.md](../../../yahoo-mlb/context/league-config.md), playoffs are weeks 21, 22, 23 and end Sunday Sep 6, 2026. Working backward (weeks are Mon-Sun):
+Per `yahoo-mlb/context/league-config.md`, playoffs are weeks 21, 22, 23 and end Sunday Sep 6, 2026. Working backward (weeks are Mon-Sun):
 
 | Fantasy Week | Start (Mon) | End (Sun) |
 |---|---|---|
@@ -195,7 +195,7 @@ Pre-July 1: playoff_games = null, playoff_matchup_quality = null,
             body = "insufficient signal -- too early"
 ```
 
-**Key sources** (see [context/frameworks/data-sources.md](../../../yahoo-mlb/context/frameworks/data-sources.md)):
+**Key sources** (see `yahoo-mlb/context/frameworks/data-sources.md`):
 
 - MLB schedule: https://www.mlb.com/schedule
 - FanGraphs team schedule: https://www.fangraphs.com/teams/{team}/schedule

--- a/skills/mlb-playoff-scheduler/resources/methodology.md
+++ b/skills/mlb-playoff-scheduler/resources/methodology.md
@@ -46,7 +46,7 @@ Working backward from Sep 6 (Sunday):
 
 **Total window**: 21 calendar days. **Max games per team**: ~21 (rare; most teams log 17-20). A 21-game team almost certainly has a doubleheader from a makeup game -- flag in the notes column.
 
-**Cross-check**: If Yahoo's league page shows different week-to-date mapping (e.g., if the league commissioner shifted start-of-week for a specific holiday), the league config file wins. Re-read [context/league-config.md](../../../../yahoo-mlb/context/league-config.md) on every run to detect config changes.
+**Cross-check**: If Yahoo's league page shows different week-to-date mapping (e.g., if the league commissioner shifted start-of-week for a specific holiday), the league config file wins. Re-read `yahoo-mlb/context/league-config.md` on every run to detect config changes.
 
 ---
 

--- a/skills/mlb-playoff-scheduler/resources/template.md
+++ b/skills/mlb-playoff-scheduler/resources/template.md
@@ -14,7 +14,7 @@ Signal file template, per-team games grid, per-opponent quality table, and per-p
 
 ## Signal File Template (Post-July)
 
-Write to `signals/YYYY-MM-DD-playoff.md`. YAML frontmatter per [context/frameworks/signal-framework.md](../../../../yahoo-mlb/context/frameworks/signal-framework.md).
+Write to `signals/YYYY-MM-DD-playoff.md`. YAML frontmatter per `yahoo-mlb/context/frameworks/signal-framework.md`.
 
 ```markdown
 ---

--- a/skills/mlb-signal-emitter/SKILL.md
+++ b/skills/mlb-signal-emitter/SKILL.md
@@ -37,7 +37,7 @@ description: Validates and persists signal files to the yahoo-mlb signals direct
 | All numeric signals in declared range | PASS (all 0-100 signals clamped; regression_index in +-100) |
 | File path matches `signals/YYYY-MM-DD-<type>.md` convention | PASS |
 
-**Action**: Write to `~/Documents/Projects/yahoo-mlb/signals/2026-04-17-player-caminero.md` and return the absolute path.
+**Action**: Write to `yahoo-mlb/signals/2026-04-17-player-caminero.md` and return the absolute path.
 
 **Failure scenario**: If `confidence: 1.4` had been passed, validation fails. The skill does NOT write the file. It calls `mlb-decision-logger` with a failure entry: `kind: signal_validation_failure`, `signal_type: player`, `reason: confidence out of range (1.4 not in [0.0, 1.0])`, `emitter: mlb-player-analyzer`, and returns an error to the calling agent.
 
@@ -94,7 +94,7 @@ If this is a synthesized final signal, it must declare which variants produced i
 
 **Step 5: Determine and validate file path**
 
-The canonical path is `~/Documents/Projects/yahoo-mlb/signals/YYYY-MM-DD-<type>.md`. For an intermediate variant dump, use `YYYY-MM-DD-<type>-<variant>.md`. For per-player or per-game files, an optional identifier suffix is allowed: `YYYY-MM-DD-<type>-<identifier>.md`.
+The canonical path is `yahoo-mlb/signals/YYYY-MM-DD-<type>.md`. For an intermediate variant dump, use `YYYY-MM-DD-<type>-<variant>.md`. For per-player or per-game files, an optional identifier suffix is allowed: `YYYY-MM-DD-<type>-<identifier>.md`.
 
 - [ ] Compute path from `date` and `type` in frontmatter
 - [ ] Check that a signal of this type+date does not already exist unless the caller explicitly passed `overwrite: true`

--- a/skills/mlb-signal-emitter/resources/evaluators/rubric_mlb_signal_emitter.json
+++ b/skills/mlb-signal-emitter/resources/evaluators/rubric_mlb_signal_emitter.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "File Path Correctness",
-      "1": "Validator writes files outside ~/Documents/Projects/yahoo-mlb/signals/, OR uses wrong filename format, OR silently overwrites existing signals, OR accepts mismatched date in frontmatter vs filename.",
+      "1": "Validator writes files outside yahoo-mlb/signals/, OR uses wrong filename format, OR silently overwrites existing signals, OR accepts mismatched date in frontmatter vs filename.",
       "3": "Validator enforces the canonical path pattern but has a weak overwrite policy (e.g., overwrites by default), OR does not cross-check the date in frontmatter against the date in the filename.",
       "5": "Validator enforces signals/YYYY-MM-DD-<type>[-id|-variant].md strictly, creates the directory if missing, rejects paths that escape the signals directory (reason code 'path_escape'), cross-checks date in frontmatter against filename (reason code 'date_filename_mismatch'), requires overwrite: true to replace an existing file (reason code 'target_exists_no_overwrite')."
     },
@@ -132,7 +132,7 @@
     {
       "failure": "Path escape via user-supplied identifier",
       "symptom": "Caller passes identifier containing '../' or starting with '/'; file gets written outside the signals directory",
-      "detection": "Computed path does not start with ~/Documents/Projects/yahoo-mlb/signals/",
+      "detection": "Computed path does not start with yahoo-mlb/signals/",
       "fix": "Sanitize identifiers to lowercase-kebab-ASCII, reject any containing path separators, validate resolved path prefix against SIGNALS_DIR."
     },
     {

--- a/skills/mlb-signal-emitter/resources/methodology.md
+++ b/skills/mlb-signal-emitter/resources/methodology.md
@@ -1,6 +1,6 @@
 # Signal Validation Methodology
 
-This document specifies the exact rules the `mlb-signal-emitter` skill applies to every signal file before persisting it. These rules are the operational expression of `~/Documents/Projects/yahoo-mlb/context/frameworks/signal-framework.md`.
+This document specifies the exact rules the `mlb-signal-emitter` skill applies to every signal file before persisting it. These rules are the operational expression of `yahoo-mlb/context/frameworks/signal-framework.md`.
 
 ## Table of Contents
 - [Required Frontmatter Fields](#required-frontmatter-fields)
@@ -154,7 +154,7 @@ Per CLAUDE.md rule 3 ("Run both variants, every time"), every user-facing decisi
 
 ## File Path Conventions
 
-The canonical signals directory is `~/Documents/Projects/yahoo-mlb/signals/`.
+The canonical signals directory is `yahoo-mlb/signals/`.
 
 ### Naming rules
 
@@ -172,7 +172,7 @@ The canonical signals directory is `~/Documents/Projects/yahoo-mlb/signals/`.
 ### Path validation
 
 1. The skill computes the path from frontmatter `date` + `type` (+ optional identifier the caller passes).
-2. Rejects paths that do not start with the resolved `~/Documents/Projects/yahoo-mlb/signals/` prefix (prevents directory-escape bugs).
+2. Rejects paths that do not start with the resolved `yahoo-mlb/signals/` prefix (prevents directory-escape bugs).
 3. Ensures the `signals/` directory exists; creates it if missing.
 4. If the target path already exists:
    - Default: refuse to overwrite. Log a failure with reason `target exists, overwrite not requested`.
@@ -216,7 +216,7 @@ When any check fails, the skill performs these steps in order:
    actual: <what it got>
    caller_context: <any extra info the caller passed>
    ```
-3. **Call `mlb-decision-logger`** with the failure entry. This appends a structured section to `~/Documents/Projects/yahoo-mlb/tracker/decisions-log.md`. The decisions log is append-only per CLAUDE.md rule 4.
+3. **Call `mlb-decision-logger`** with the failure entry. This appends a structured section to `yahoo-mlb/tracker/decisions-log.md`. The decisions log is append-only per CLAUDE.md rule 4.
 4. **Return an error object to the caller** so the upstream skill/agent knows the emission failed. Shape:
    ```yaml
    status: error

--- a/skills/mlb-signal-emitter/resources/template.md
+++ b/skills/mlb-signal-emitter/resources/template.md
@@ -1,6 +1,6 @@
 # Signal File Template
 
-This file documents the canonical shape of a signal file. Every signal written to `~/Documents/Projects/yahoo-mlb/signals/` matches this template. The `mlb-signal-emitter` skill validates every file against these rules before persisting.
+This file documents the canonical shape of a signal file. Every signal written to `yahoo-mlb/signals/` matches this template. The `mlb-signal-emitter` skill validates every file against these rules before persisting.
 
 ## Table of Contents
 - [Canonical Blank Template](#canonical-blank-template)
@@ -103,7 +103,7 @@ consumes:
 
 ## Fully Populated Validated Example
 
-The following is a complete, validated signal file for a per-player daily signal. Every required frontmatter field is present. Every numeric signal in the body is inside its declared range. This file would pass `mlb-signal-emitter` validation cleanly and be written to `~/Documents/Projects/yahoo-mlb/signals/2026-04-17-player-caminero.md`.
+The following is a complete, validated signal file for a per-player daily signal. Every required frontmatter field is present. Every numeric signal in the body is inside its declared range. This file would pass `mlb-signal-emitter` validation cleanly and be written to `yahoo-mlb/signals/2026-04-17-player-caminero.md`.
 
 ```markdown
 ---

--- a/skills/variance-strategy-selector/SKILL.md
+++ b/skills/variance-strategy-selector/SKILL.md
@@ -231,4 +231,4 @@ def variance_strategy(p_win, asym, slots):
 - Poker bankroll skills that pick bet-size variance
 - Any agent deciding how hard to push a variance knob
 
-**Principle reference:** Game Theory Principles #6 (Variance-seeking as underdog -- the "cope" principle) in `/Users/kushaldsouza/Documents/Projects/yahoo-mlb/context/frameworks/game-theory-principles.md`.
+**Principle reference:** Game Theory Principles #6 (Variance-seeking as underdog -- the "cope" principle) in `yahoo-mlb/context/frameworks/game-theory-principles.md`.

--- a/skills/variance-strategy-selector/resources/evaluators/rubric_variance_strategy_selector.json
+++ b/skills/variance-strategy-selector/resources/evaluators/rubric_variance_strategy_selector.json
@@ -46,7 +46,7 @@
       "name": "Citations",
       "1": "No citation to game-theory-principles.md or underlying theory. Skill reads as a bare formula with no justification.",
       "3": "Cites Game Theory Principles #6 and one or two supporting references (Kelly, CLT), but citations not tied to the specific computations they justify.",
-      "5": "Cites Game Theory Principles #6 for the core underdog/favorite posture. Cites Kelly Criterion as the conceptual reference for why variance preference depends on edge. Cites Central Limit Theorem for the slot-dampening formula. Cites Kahneman & Tversky / prospect theory for the asymmetry amplification. Each citation is tied to the specific part of the decision rule it supports, and the `/Users/kushaldsouza/Documents/Projects/yahoo-mlb/context/frameworks/game-theory-principles.md` reference is the anchor."
+      "5": "Cites Game Theory Principles #6 for the core underdog/favorite posture. Cites Kelly Criterion as the conceptual reference for why variance preference depends on edge. Cites Central Limit Theorem for the slot-dampening formula. Cites Kahneman & Tversky / prospect theory for the asymmetry amplification. Each citation is tied to the specific part of the decision rule it supports, and the `yahoo-mlb/context/frameworks/game-theory-principles.md` reference is the anchor."
     }
   ],
   "guidance_by_type": {

--- a/skills/variance-strategy-selector/resources/methodology.md
+++ b/skills/variance-strategy-selector/resources/methodology.md
@@ -191,7 +191,7 @@ Any repeatable decision with (a) an estimable `P(win)`, (b) a controllable varia
 
 ## Citations and Further Reading
 
-- **Game Theory Principles #6** (`/Users/kushaldsouza/Documents/Projects/yahoo-mlb/context/frameworks/game-theory-principles.md`): the "cope" principle -- favorites minimize variance, underdogs maximize it. Operationalized for MLB fantasy in the `mlb-lineup-optimizer` consumer.
+- **Game Theory Principles #6** (`yahoo-mlb/context/frameworks/game-theory-principles.md`): the "cope" principle -- favorites minimize variance, underdogs maximize it. Operationalized for MLB fantasy in the `mlb-lineup-optimizer` consumer.
 - **Kelly, J. L. (1956)**, "A New Interpretation of Information Rate," Bell System Technical Journal. The original optimal-bet-size derivation; the conceptual backbone for why variance preference depends on edge.
 - **Thorp, E. O. (1969)**, "Optimal Gambling Systems for Favorable Games." Fractional Kelly and practical bankroll management.
 - **Markowitz, H. (1952)**, "Portfolio Selection," Journal of Finance. Mean-variance optimization; the foundational framework in which "variance is bad when you're ahead" was first formalized for investment.


### PR DESCRIPTION
## Why

This is a shared, open repository, but the README, several agents, and a number of skills hardcoded paths into private workspaces on my machine (`~/Documents/Projects/...`, `/Users/kushaldsouza/Documents/Thinking/...`). This PR removes those leaks while preserving each component's within-project folder structure.

## What changed

**Path references → project-relative.** Stripped the personal `~/Documents/...` and `/Users/kushaldsouza/Documents/...` prefixes from every companion-runtime path reference, leaving project-relative paths:

- `~/Documents/Projects/yahoo-mlb/context/league-config.md` → `yahoo-mlb/context/league-config.md`
- `/Users/kushaldsouza/Documents/Thinking/substacker/shared-context/section-map.md` → `substacker/shared-context/section-map.md`

This matches the convention the newest World Cup agents already use (`footballfantasy/context/...`) and the bare references already present in the same files (e.g. `curator.md` already referenced `substacker/shared-context/section-map.md`; the MLB agents already referenced `yahoo-mlb/context/frameworks/game-theory-principles.md`).

**Broken relative links fixed.** Converted 6 `../../../yahoo-mlb/...` markdown links — which assumed the private runtime sat next to this repo and were broken here — into project-relative code spans.

**README prose.** Reworded the `Pairs with ... at <personal path>` lines to describe a generic companion runtime/workspace, and dropped the `(see <personal path>)` pointers from the "I want to…" table so those rows match the clean style of the others.

## Scope & verification

- 32 files changed (README + 11 agents + 20 skill files), all 1:1 path swaps — no behavioral changes.
- `notes/`, `prompts/`, `scratchpad/`, `.claude/` are gitignored and were not touched.
- Edited JSON rubric files re-validated as parseable.
- Post-change scan confirms **zero** remaining `~/Documents` / `/Users/kushaldsouza` / `Documents/(Projects|Thinking)` references and **zero** `../../../<project>/` traversals in tracked files.

> Note: personal *identifiers* that aren't locations (e.g. fantasy team name, league ID) were left as-is since the ask was specifically about project locations / the Documents folder — happy to scrub those too if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)