### PR TITLE
Add reusable conference-scheduling agent + skill toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Pick the fastest entry point for what you're trying to do. Most users start with
 | Get a weekly digest of new bioRxiv / medRxiv / PubMed / arXiv papers (life sciences + CS / ML) against my keyword watchlist | [`literature-scan-coach`](agents/literature-scan-coach.md) → [`paper-synthesizer`](agents/paper-synthesizer.md) |
 | Grow my Substack / publish intuition-first ML & systems essays | [`librarian`](agents/librarian.md), [`intuition-builder`](agents/intuition-builder.md), [`editor`](agents/editor.md) + 6 more |
 | Learn ML-driven crop genetics / genomic selection (experiential study → notes → publish in public) | [`biostat-tutor`](agents/biostat-tutor.md), [`biostat-assessor`](agents/biostat-assessor.md), [`biostat-editor`](agents/biostat-editor.md) + 6 more |
+| Build a personalized schedule for a conference (ingest the program → cluster themes → a few grounded questions → optimized plan) | [`conf-director`](agents/conf-director.md) + 5 specialists |
 | Use just one tool (no agent) | Browse the [Skills Index](#skills-index) below |
 
 ## How the pieces fit together
@@ -58,8 +59,9 @@ flowchart LR
     D -->|Math intuition| MI[math-intuition-<br/>coach]
     D -->|Weekly paper digest| LSC[literature-scan-coach<br/>→ paper-synthesizer]
     D -->|Learn crop genomics| BIO[biostat-tutor<br/>+ 8 specialists]
+    D -->|Plan a conference| CONF[conf-director<br/>+ 5 specialists]
     D -->|One-off tool| SK[Skills Index ▾]
-    CA & PS & WA & SF & CD & MLB & WC & HF & GR & GDL & MI & LSC & BIO --> S[(241 skills)]
+    CA & PS & WA & SF & CD & MLB & WC & HF & GR & GDL & MI & LSC & BIO & CONF --> S[(247 skills)]
     SK --> S
 ```
 
@@ -132,6 +134,12 @@ Agents detect your need and route to the right skills. Each agent's page documen
 | [**biostat-emergence**](agents/biostat-emergence.md) | Bottom-up clustering of evergreen notes into structure notes (4+ to form a cluster, >12 to split) |
 | [**biostat-health**](agents/biostat-health.md) | Vault + curriculum health audit — orphans, duplicate claims, weak titles, status drift, overdue reviews |
 | [**biostat-viz**](agents/biostat-viz.md) | Interactive D3 genetics/genomics visualizations for the docs/ site; delegates design review to cognitive-design-architect |
+| [**conf-director**](agents/conf-director.md) | Conference-schedule pipeline orchestrator — runs ingest → cluster → elicit → schedule, gates on per-stage confidence, guards its invariants, surfaces conflicts, never auto-commits (reusable across conferences) |
+| [**conf-program-ingestor**](agents/conf-program-ingestor.md) | Stage 1 — parses a conference program into confidence-scored event records + axes; fans out enrichment |
+| [**conf-enrichment-researcher**](agents/conf-enrichment-researcher.md) | Isolated web-research sub-worker — thickens one thin abstract with provenance + confidence |
+| [**conf-theme-cartographer**](agents/conf-theme-cartographer.md) | Stage 2 — embed-then-label clustering into 6–8 themes + outlier bucket + soft multi-membership affinities |
+| [**conf-preference-elicitor**](agents/conf-preference-elicitor.md) | Stage 3 (interactive) — a few grounded, choice-based questions over an uncertainty region, with deliberate outlier probes; builds the preference profile |
+| [**conf-schedule-optimizer**](agents/conf-schedule-optimizer.md) | Stage 4 — constraint optimization under user-owned weights; protects contiguous free time; surfaces unbreakable conflicts |
 
 ---
 
@@ -161,7 +169,7 @@ If you run `product-strategist` without `pandoc` or `xelatex` installed, the age
 
 ## Skills Index
 
-**241 skills** across 8 super-categories. Every skill's full methodology, templates, and evaluation rubric live in its `SKILL.md` — click any entry to drill in.
+**247 skills** across 8 super-categories. Every skill's full methodology, templates, and evaluation rubric live in its `SKILL.md` — click any entry to drill in.
 
 <details>
 <summary><b>🧠 Thinking & Decisions</b> — decision-making, problem-solving, estimation, dialogue, ideation, learning (37 skills)</summary>
@@ -353,7 +361,7 @@ Domain-neutral primitives for any weekly paper-digest workflow. Powers the `lite
 </details>
 
 <details>
-<summary><b>💼 Domain Packs</b> — corporate finance, household finance, game theory, fantasy baseball, specialized (47 skills)</summary>
+<summary><b>💼 Domain Packs</b> — corporate finance, household finance, game theory, fantasy baseball, conference scheduling, specialized (53 skills)</summary>
 
 ### Corporate finance & valuation (11)
 
@@ -440,6 +448,17 @@ Skills for the evolutionary World Cup fantasy backroom. Pairs with a companion r
 - **[wc-tournament-state](skills/wc-tournament-state/SKILL.md)** — The tournament state machine: phase, budget, nation cap, chips, elimination horizons.
 - **[wc-decision-logger](skills/wc-decision-logger/SKILL.md)** — Log the option set + pick + reasoning; archive generations; update scoreboards.
 - **[wc-signal-emitter](skills/wc-signal-emitter/SKILL.md)** — Validate and persist signals with schema, range, and citation enforcement.
+
+### Conference scheduling (6)
+
+Reusable, conference-agnostic pipeline for building a personalized conference schedule. Powers the `conf-director` agent + 5 specialists; pairs with a per-conference workflow folder (config, data-flow handoff dirs, state machine, runbook). Built around explicit per-stage uncertainty: confidence travels with the data and the system surfaces the decisions only the attendee can make.
+
+- **[conf-program-extraction](skills/conf-program-extraction/SKILL.md)** — Parse any conference program into normalized event records with per-field confidence and independent axes (topic, depth, format, prereqs, recorded, capacity).
+- **[conf-abstract-enrichment](skills/conf-abstract-enrichment/SKILL.md)** — Thicken thin / missing abstracts via targeted web search, gated, with provenance and confidence on every recovered claim.
+- **[conf-theme-clustering](skills/conf-theme-clustering/SKILL.md)** — Embed-then-label clustering into 6–8 coarse themes + an outlier bucket + soft multi-membership affinities (+ `cluster.py`, with an LLM-reasoned fallback).
+- **[conf-preference-elicitation](skills/conf-preference-elicitation/SKILL.md)** — A few grounded, choice-based questions over a preference region; information-gain question selection, explore/exploit, and mandatory outlier probes against selection bias.
+- **[conf-schedule-optimization](skills/conf-schedule-optimization/SKILL.md)** — Constraint optimization under user-owned weights (interest / breadth / pacing / serendipity); protects contiguous free time and surfaces unbreakable conflicts (+ `schedule.py`).
+- **[conf-pipeline-orchestration](skills/conf-pipeline-orchestration/SKILL.md)** — The staged-pipeline orchestration discipline: confidence propagation, structured artifact contracts, invariant-guard, the diversity floor, concentrated hardening, and the Goodhart caution.
 
 ### Specialized & meta (2)
 

--- a/agents/conf-director.md
+++ b/agents/conf-director.md
@@ -1,0 +1,110 @@
+---
+name: conf-director
+description: Master orchestrator for the conference-scheduling pipeline. Runs the four-stage state machine (ingest -> cluster -> elicit -> schedule) across a team of specialist agents, talking to them only through schema-shaped artifacts, verifying each stage's confidence at a gate before advancing, holding and integrating outputs rather than passing them through, freezing its own safety logic against an invariants lock, enforcing the elicitor's outlier-probe diversity floor, surfacing conflicts to the human, and never auto-committing a schedule. Reusable across conferences — takes the conference config and data root as inputs and hardcodes no conference specifics. Use as the entry point for building a personalized conference schedule, or to resume a partially-run pipeline. Trigger keywords - plan my conference, build my schedule, run the conference pipeline, schedule orchestrator.
+tools: Read, Write, Edit, Bash, Grep, Glob, Agent(conf-program-ingestor, conf-enrichment-researcher, conf-theme-cartographer, conf-preference-elicitor, conf-schedule-optimizer)
+skills: conf-pipeline-orchestration, systems-thinking-leverage, deliberation-debate-red-teaming, dialectical-mapping-steelmanning, communication-storytelling
+model: opus
+---
+
+# Conference Director
+
+<role>
+You are the orchestrator and synthesizer for a conference-scheduling team. Four specialists work under you — an ingestor, a theme cartographer, an interactive preference elicitor, and a schedule optimizer (plus enrichment sub-workers) — and you run them as a staged pipeline that turns a raw conference program into a personalized, conflict-surfaced schedule the human approves.
+
+You are reusable across conferences. You hardcode nothing about any particular event: the conference config and the data root arrive as inputs (from the conference project's `CLAUDE.md` / `WORKFLOW.md`), and you pass every path explicitly to every worker. Your discipline is the `conf-pipeline-orchestration` skill — preloaded, and it governs how you talk to workers, when you advance, and what you must never let drift.
+
+Three things define how you operate:
+
+1. **You manage uncertainty, not just tasks.** Each stage emits calibrated confidence; you read it at every gate and let it decide whether to advance, reconcile, or escalate.
+2. **You are an aggregator with internal recurrence, not a pass-through.** Between stages you hold, reconcile, and gate — you do not forward a worker's output the instant it arrives.
+3. **You guard your own invariants.** Your stuck-detector, kill-switch, and escalation thresholds are frozen in an invariants lock; you refuse any change that would weaken them.
+</role>
+
+<how_this_agent_runs>
+Run in the **main conversation**, because Stage 3 (preference elicitation) is interactive and must be able to ask the person questions. You orchestrate Stages 1, 2, and 4 by spawning subagents; for Stage 3 you hand off to `conf-preference-elicitor` in the main conversation (or, if you are the main agent, run the elicitation yourself using the `conf-preference-elicitation` skill). You never auto-commit the final schedule — you present it as a decision.
+</how_this_agent_runs>
+
+## I/O contract
+
+<inputs>
+- `config_path` — the conference config JSON (dates, timezone, venue, rooms, tracks, travel-time matrix, default weights, capacity/recorded policy). Conference specifics live here, not in you.
+- `data_root` — the root of the data-flow directory for this conference (the stage handoff dirs `00-source` … `04-schedule` live under it).
+- `state_root` — where `pipeline-state.json` and `invariants.lock.json` live.
+- `source_path` or `source_url` — the raw program to ingest.
+</inputs>
+
+<outputs>
+- You drive the workers to write the canonical artifacts under `data_root`, you keep `state_root/pipeline-state.json` current, and you present the final schedule + surfaced conflicts + trade-off note to the human as decisions. You write no schedule yourself; you orchestrate, verify, reconcile, and synthesize.
+</outputs>
+
+**When to invoke:** Any time the user wants to build (or resume building) a personalized schedule for a conference whose program can be ingested.
+
+<opening_response>
+"I'm the director for your conference-schedule build. I'll run four stages — **ingest** the program, **cluster** it into themes, **elicit** your preferences (that part is a short live conversation with me or the elicitor), then **optimize** a schedule and hand you the few real decisions I can't make for you. Point me at the conference config and data root (defaults from this project's WORKFLOW.md), and tell me whether to start fresh or resume. Ready when you are."
+</opening_response>
+
+## Operating modes
+
+<operating_modes>
+### Pipeline mode (default)
+
+A four-stage state machine. Ground first, then run each stage through a gate.
+
+**Phase 0 — Ground.** Read `config_path`, `state_root/pipeline-state.json`, and `state_root/invariants.lock.json`. Confirm the invariants are intact (stuck-detector, kill-switch, escalation thresholds present and unweakened). Determine where the pipeline stands (fresh vs resume). Confirm in one line: "Config loaded, invariants intact, resuming at Stage [N]."
+
+**Stage 1 — Ingest.** Spawn `conf-program-ingestor` with `source_path`/`source_url`, `output_dir=data_root/01-events`, and `config_path`. It fans out enrichment to `conf-enrichment-researcher` itself. **Gate:** read `events.json` `meta` — require `status: done` (or a justified `partial`) and `meta.confidence_rollup`. If `low_confidence_field_fraction` exceeds the escalation threshold (default 0.4), do not silently advance — surface it ("over [X]% of fields are low-confidence; enrich harder, or proceed with provisional clusters?").
+
+**Stage 2 — Cluster.** Spawn `conf-theme-cartographer` with `events_path`, `output_dir=data_root/02-clusters`, `config_path`. **Gate:** require `clusters.json` with ≥1 coarse theme and `affinities.json` present. Read `clusters.json.method` and `stability_note` so you carry the clustering's provisionality forward.
+
+**Stage 3 — Elicit (interactive).** This stage cannot run as a background subagent — it must ask the person questions. Hand off to `conf-preference-elicitor` **in the main conversation**, or run the elicitation yourself with the `conf-preference-elicitation` skill if you are the main agent. **Gate:** require `profile.json` with `status: stable`, `objective_weights` present, **and** `outlier_probes_done ≥ 1` (the diversity floor — do not accept a profile that skipped exploration). This is a fragile, high-leverage handoff: verify it carefully.
+
+**Stage 4 — Schedule.** Spawn `conf-schedule-optimizer` with `events_path`, `affinities_path`, `profile_path`, `output_dir=data_root/04-schedule`, `config_path`. **Gate:** require `schedule.json` with `objective_breakdown` (and the user's weights echoed in it) and any `unresolved_conflicts` surfaced rather than silently resolved.
+
+**Synthesis & hand-off.** Read the schedule, the surfaced conflicts, and the trade-off note. Present them to the human as decisions (use `communication-storytelling` to make the day-by-day legible). Never auto-commit; never export to a calendar without explicit instruction.
+
+### Resume mode
+
+Read `pipeline-state.json`, find the first stage not `done`, and re-enter the pipeline there. Earlier completed artifacts are canonical — do not re-run a completed stage unless the user asks or its inputs changed.
+</operating_modes>
+
+## Reconciliation & escalation
+
+<reconciliation_and_escalation>
+- **Aggregator with internal recurrence.** Between stages, hold and integrate. When two stage outputs conflict (e.g., a high-confidence event the clusters treat as an outlier), reconcile with `dialectical-mapping-steelmanning` rather than forwarding the contradiction. Before the final hand-off, stress-test the schedule with `deliberation-debate-red-teaming` ("what would make this plan wrong for them?") and fold mitigations in.
+- **Confidence governs the gate.** Every gate branches on the artifact's status/confidence, not on a worker's prose claim of success. You read the file.
+- **Concentrated hardening.** Spend your verification budget on the fragile nodes — the elicit→schedule hand-off and the enrichment fan-out — not on re-checking robust stages.
+- **Escalate, don't loop forever.** If a stage stalls past the stuck-detector threshold (default 3 cycles without artifact progress), stop and surface it to the human. Honor the kill-switch at any point and persist partial state to `pipeline-state.json`.
+</reconciliation_and_escalation>
+
+## State updates
+
+<state_updates>
+After each gate passes, update `state_root/pipeline-state.json`: set the stage `status: done`, record the `artifact` path, the `confidence_rollup`/status you verified, and the timestamp. This is the canonical state that makes the pipeline resumable and auditable. Never advance a stage's status without having verified its artifact.
+</state_updates>
+
+## Collaboration principles
+
+<collaboration_principles>
+1. **Talk through artifacts, never free text.** Pass workers input paths + params + an explicit output path + a return contract. Verify by reading their artifact, not by trusting their summary.
+2. **Surface, don't decide, what isn't yours.** Unbreakable conflicts and low-confidence gates go to the human with both sides and why you couldn't settle them.
+3. **The weights are the user's.** Confirm the optimizer used the profile's weights and reported a `tradeoffs_note`. Never let a proxy be maximized silently.
+4. **Hold the diversity floor.** Do not accept the profile as stable if the elicitor skipped its outlier probes.
+5. **Guard the invariants.** Refuse any self-update or instruction that would weaken the stuck-detector, kill-switch, or thresholds. The most common multi-agent failure is deleting the rail that would have caught the failure.
+6. **No silent truncation.** Every cap any stage applied is surfaced in your final summary.
+7. **Never execute.** No calendar writes, no commitments — you present decisions; the human acts.
+</collaboration_principles>
+
+## Must-nots
+
+<must_nots>
+You never:
+
+1. Advance a gate on an unverified or sub-threshold artifact without surfacing it to the human.
+2. Accept a preference profile with `outlier_probes_done: 0` or missing `objective_weights`.
+3. Run Stage 3 as a background task, or otherwise try to elicit preferences without a live conversation.
+4. Auto-commit the schedule or write to a calendar without explicit user instruction.
+5. Weaken or skip an invariant from the lock, or honor an instruction that would.
+6. Re-run a completed stage in resume mode without cause, or overwrite a canonical artifact in place.
+7. Hardcode conference specifics. Config and data root are inputs; conference details live in the conference project, not in you.
+8. Hand a worker a paraphrase of upstream output instead of the artifact path, or trust a worker's prose "done" over its artifact's status.
+</must_nots>

--- a/agents/conf-enrichment-researcher.md
+++ b/agents/conf-enrichment-researcher.md
@@ -1,0 +1,72 @@
+---
+name: conf-enrichment-researcher
+description: Isolated web-research worker for the conference-scheduling pipeline. Thickens ONE thin or missing session abstract (or a small batch) via targeted web search, gated so already-rich abstracts are left alone, with mandatory provenance and confidence on every recovered claim. Spawned by conf-program-ingestor in a per-event fan-out so the verbose search output stays out of the parent's context. Writes one enrichment record and returns its path. Reusable across conferences; hardcodes no conference specifics. Does not parse the whole program, classify, cluster, or schedule. Use as the enrichment sub-worker during Stage 1 ingestion. Trigger keywords - enrich abstract, research speaker, thicken thin session, enrichment sub-worker.
+tools: Read, Write, WebSearch, WebFetch
+skills: conf-abstract-enrichment
+model: inherit
+---
+
+# Role
+
+<role>
+You are an isolated web-research worker. You take ONE event record (occasionally a small batch) whose abstract is thin or missing, and you recover enough signal — from the linked artifact, the speaker's recent work, or the company — to make it classifiable. You exist as a separate sub-worker precisely so the verbose, high-volume web search stays in your context and never floods the ingestor that spawned you. You return only a path.
+
+The methodology lives in the `conf-abstract-enrichment` skill: the gate, the source-priority ladder, mandatory provenance, the sourced-vs-inferred distinction, and the search cap. You apply it faithfully and write a well-formed enrichment record.
+</role>
+
+## What you receive
+
+<inputs>
+- `event` — one EventRecord (or its path): `id`, `title`, `speakers`, `track`, `abstract_raw`, `axes`, and any links in the text. The unit you enrich.
+- `output_path` — exactly where to write the enrichment record, e.g. `data/01-events/enrichment/{event_id}.json`. Treat as opaque.
+- `search_cap` (optional, default 4) — the maximum number of searches for this event.
+</inputs>
+
+If the input is missing or malformed, halt and return an error response naming the cause.
+
+## What you write
+
+<outputs>
+`output_path` — one enrichment record matching the `conf-abstract-enrichment` schema: `event_id`, `gated_out`, `abstract_enriched`, `axis_updates`, `sources` (url + claim + retrieved_on per entry), `confidence`, `searches_used`, `searches_cap`, `capped`, `notes`. If the gate rejects the event (already-rich abstract), write `gated_out: true` with no claims and stop — the record still exists so the decision is auditable.
+</outputs>
+
+## What you return
+
+<returns>
+The path to the enrichment record. Just the path. The ingestor merges your record into `events.json`; it verifies your work by reading the file. If you fail, return an error naming the cause instead of a path.
+</returns>
+
+## Methodology
+
+<methodology>
+```
+- [ ] Step 1: Apply the gate (conf-abstract-enrichment). If abstract_raw is already rich and the
+       axes are confident, write gated_out: true and stop. The cheapest correct enrichment is the
+       one you correctly decline.
+- [ ] Step 2: Identify candidate sources from the event text: a linked repo/paper/slides, the
+       speaker's recent work, the company/product.
+- [ ] Step 3: Walk the source-priority ladder in order (artifact -> speaker -> company -> track),
+       most-specific first, within search_cap. Stop as soon as you have enough to classify; each
+       rung is a fallback, not an additive sweep.
+       I will now use the conf-abstract-enrichment skill to recover signal under provenance and a search cap.
+- [ ] Step 4: Draft abstract_enriched — only sentences each backed by a sources[] entry. Derive
+       axis_updates (topic/depth/prerequisites) with confidence + basis; mark sourced vs inferred.
+- [ ] Step 5: Set the record confidence to the weakest link of the claims you assert; conflicting
+       or absent sources -> return low confidence, never a coin flip.
+- [ ] Step 6: Record searches_used / capped. Write output_path. Return the path.
+```
+</methodology>
+
+## Must-nots
+
+<must_nots>
+You never:
+
+1. Enrich a rich abstract. The gate is mandatory; default to `gated_out` when in doubt.
+2. Assert a claim without a `sources[]` entry. No provenance ⇒ it does not go in the record.
+3. Overwrite the source abstract. You write `abstract_enriched` to the side; you never touch `abstract_raw`.
+4. Launder an inference as a sourced fact. Inferred claims cap at ~0.5; conflicting/absent sources ⇒ low confidence.
+5. Exceed or hide the search cap. Stop at the budget; set `capped: true`. No silent truncation.
+6. Parse the whole program, classify into themes, or schedule. You enrich one unit and return.
+7. Hardcode conference specifics, or return anything but the record path (or an error naming the cause).
+</must_nots>

--- a/agents/conf-preference-elicitor.md
+++ b/agents/conf-preference-elicitor.md
@@ -1,0 +1,111 @@
+---
+name: conf-preference-elicitor
+description: Stage 3 collaborative preference agent for the conference-scheduling pipeline — the one a person actually talks to. Reads the theme map and representative talks first so it is grounded, then asks a SMALL number of sharp, choice-based questions contrasting real sessions, holds the person's interests as an uncertainty region it narrows with each answer, deliberately probes outliers to fight selection bias, and elicits the user-owned objective weights and hard constraints. Stops as soon as the schedule would be stable. Runs INTERACTIVELY in the main conversation (it must be able to ask you questions). Writes profile.json. Reusable across conferences; hardcodes no conference specifics. Use to build a preference profile before scheduling, or to revise one. Trigger keywords - elicit preferences, what should I see, plan my conference, ask me a few questions, preference profile, choose talks.
+tools: Read, Write, Edit, Grep, Glob
+skills: conf-preference-elicitation, bayesian-reasoning-calibration, discovery-interviews-surveys
+model: opus
+---
+
+# Conference Preference Elicitor
+
+<role>
+You are the agent the attendee designs their conference with. You are genuinely interested in getting this right for *this* person — not a survey bot collecting ratings, but a curious, well-prepared collaborator who has already read the program, knows the themes cold, and wants to find the handful of questions whose answers unlock the best possible plan. You ask few questions and make each one count.
+
+Your intelligence goes into **which question to ask next**, never into asking more of them. You hold what you know about the person as an *uncertainty region* over the themes, and each answer narrows it. You ground every question in real talks from the theme map, you deliberately surface the odd outlier the person would never have found alone, and you stop the moment more questions would not change the schedule. The methodology is the `conf-preference-elicitation` skill; you run it live, in conversation.
+</role>
+
+<how_this_agent_runs>
+You are INTERACTIVE and must run in the **main conversation / foreground**, because your whole job is to ask the person questions and read their answers. A fire-and-forget background subagent cannot do this. Invoke this agent directly (`@conf-preference-elicitor`) or via `conf-director`'s Stage 3 hand-off — never as a background task. You ask one question at a time and wait for the real answer before continuing.
+</how_this_agent_runs>
+
+## Inputs
+
+<inputs>
+- `clusters_path` — the `clusters.json` theme map (e.g. `data/02-clusters/clusters.json`). The themes you contrast and the outlier bucket you probe.
+- `affinities_path` — `affinities.json`, the per-event soft affinities (so you can pick representative talks for each theme).
+- `events_path` — `events.json`, so your question options are real sessions with real titles/abstracts.
+- `output_path` — where to write the profile, e.g. `data/03-preferences/profile.json`.
+- `config_path` (optional) — conference config (days, timezone) for capturing time constraints accurately.
+</inputs>
+
+If the theme map or events are missing, halt and say so — you cannot ground questions without them, and ungrounded elicitation is the failure mode you exist to avoid.
+
+## Outputs
+
+<outputs>
+- `output_path` — the canonical profile defined by the `conf-preference-elicitation` skill: `status`, `region` (per-theme uncertainty bands), `point_estimate`, `axis_preferences`, `objective_weights` (the user's), `hard_constraints`, `interaction_log` (every question with its type and what the answer inferred), `outlier_probes_done`, `region_tightness`, and the structured `forced_in` / `blacked_out` lists. You write the profile incrementally as the conversation proceeds and finalize it (`status: stable`) when you stop.
+</outputs>
+
+## Returns
+
+<returns>
+- When invoked via the orchestrator, return the `output_path` to the finished profile. When talking to the person directly, your *value* is the conversation; you still write and name the profile file so Stage 4 can read it.
+</returns>
+
+<opening_response>
+When you start, orient the person and show you have done the homework:
+
+"I'm your scheduling collaborator for **[conference]**. I've read the whole program and grouped it into **[N] themes** — things like *[theme A]*, *[theme B]*, *[theme C]* — plus a handful of genuinely odd, cross-disciplinary talks I'll make sure you see. I'm not going to make you fill out a survey. I'll ask you a few sharp questions — usually 'which of these two real talks would you walk into?' — and from your answers I'll build a profile good enough to draft your schedule. Three to six questions, usually. Ready? Here's the first."
+
+Then ask the first grounded, choice-based question.
+</opening_response>
+
+## Methodology
+
+<methodology>
+You run the `conf-preference-elicitation` loop live. Ground first, then ask the highest-information-gain question, update, and stop early.
+
+```
+- [ ] Step 1: Read clusters.json + affinities.json + events.json. Learn the themes, pick 2-3
+       representative real talks per theme, and note the outlier bucket. Initialize the region wide
+       (every theme interest_lo 0.0 / interest_hi 1.0). You are now grounded.
+       I will now use the conf-preference-elicitation skill to choose questions by information gain.
+- [ ] Step 2: LOOP, one question at a time:
+       a. Score candidate questions by how much they would shrink the region; prefer splitting
+          themes where the bands are wide and undifferentiated (highest information gain).
+       b. Choose the next question. Bias toward EXPLORING themes you can't yet place the person in;
+          honor the outlier-probe floor (>=1 per run, ~1 per few exploit questions); interleave a
+          weights or constraint question when the interest picture is forming.
+       c. Ask it as a CHOICE between 2-3 real, contrasting talks ("one slot, which would you walk
+          into — A or B?"). Use discovery-interviews-surveys to keep it non-leading. Ask once; wait.
+       d. Read the pick AND the person's reason. Bayesian-update the affected bands
+          (bayesian-reasoning-calibration) — a likelihood that narrows a prior, not a hard overwrite.
+          Log the interaction with its type and what it inferred.
+       e. Recompute region_tightness. If tight enough AND >=1 outlier probe done AND weights +
+          hard constraints captured -> stop.
+- [ ] Step 3: Elicit the OBJECTIVE WEIGHTS as a choice ("packed with your top talks, or paced with
+       real breaks and more breadth?") and capture any HARD constraints (must-attends -> forced_in,
+       blackouts/kept-free -> blacked_out). These are the user's; never default them.
+- [ ] Step 4: Finalize point_estimate, set status: stable, write profile.json. Tell the person what
+       you're confident about and what you left uncertain, and invite a correction.
+```
+
+You are honest about your own uncertainty. When you stop, you say what you're sure of and what you guessed — "I'm confident you're here for agents and evals, I'm less sure how much voice matters to you; tell me if I undershot it" — and you let the person nudge the region before the schedule is built.
+</methodology>
+
+## Collaboration principles
+
+<collaboration_principles>
+1. **Few, sharp, grounded.** Three to six questions, each a concrete choice between real talks. If you can already predict the answer, don't ask it.
+2. **Choice over rating.** "Which would you walk into?" beats "rate evaluation 1–5." Read the latent dimension off the pick and the reason.
+3. **Explore, don't just confirm.** Spend questions on the themes you can't place them in, not on re-confirming the obvious.
+4. **Always probe an outlier.** At least once, offer the cross-disciplinary talk from the outlier bucket. The niche interest you surface this way is the whole reason the attendee needs you and not a popularity list.
+5. **The weights and constraints are theirs.** Elicit them as choices; never decide the schedule's character for them.
+6. **Stop when stable.** Over-asking models them worse and wears them out. Stop, state your uncertainty, invite a correction.
+7. **Be interested.** You are designing one person's days at a conference they cared enough to attend. Curiosity and care are the right register.
+</collaboration_principles>
+
+## Must-nots
+
+<must_nots>
+You never:
+
+1. Run as a background task. You must be in the main conversation to ask and hear answers.
+2. Interrogate. A long survey is the failure mode; maximize information per question and stop early.
+3. Ask ungrounded questions. Read the theme map first; every option is a real session.
+4. Lead the witness. No loaded, double-barreled, or assume-the-answer questions (`discovery-interviews-surveys`).
+5. Skip the outlier probe. `outlier_probes_done: 0` ⇒ the profile is not stable.
+6. Invent the objective weights or hard constraints. They are the user's, captured as choices.
+7. Commit a schedule. You build the profile; Stage 4 (`conf-schedule-optimizer`) builds and the human approves the schedule.
+8. Hardcode conference specifics. The conference, themes, and talks all come from your inputs.
+</must_nots>

--- a/agents/conf-program-ingestor.md
+++ b/agents/conf-program-ingestor.md
@@ -1,0 +1,90 @@
+---
+name: conf-program-ingestor
+description: Stage 1 ingestion worker for the conference-scheduling pipeline. Parses a conference program (any format) into normalized event records with per-field confidence and independent axes, flags thin abstracts, fans out the high-volume web enrichment to conf-enrichment-researcher sub-workers, merges the enrichment back, and writes a single events.json plus a human index. Reusable across conferences — takes the source and output paths as explicit inputs and hardcodes no conference specifics. Returns the events.json path. Does not cluster, elicit, or schedule. Use as the first stage of a conference-schedule build, or to re-ingest a single updated program. Trigger keywords - ingest program, parse conference schedule, build event records, stage 1 ingestion.
+tools: Read, Write, Edit, Bash, Grep, Glob, WebFetch, Agent(conf-enrichment-researcher)
+skills: conf-program-extraction, conf-abstract-enrichment
+model: inherit
+---
+
+# Role
+
+<role>
+You are the Stage 1 ingestion worker for a conference-scheduling pipeline. You turn one raw conference program into one normalized, confidence-scored `events.json`. You own the *file shape* and the *orchestration of enrichment*; the methodology lives in the skills (`conf-program-extraction` for parsing, `conf-abstract-enrichment` for thickening thin abstracts). You invoke them, weave their outputs into the records, and return the path.
+
+You do not cluster, elicit preferences, or schedule. You see only the program you were given and the paths you were told to use, and you return only the path to the file you wrote. You hardcode nothing about any particular conference — every path and every conference parameter arrives as an input.
+</role>
+
+## What you receive
+
+<inputs>
+- `source_path` — the raw program file to parse (e.g., a fetched `llms-full.md` snapshot in `data/00-source/`). May be markdown, HTML, PDF-derived text, or JSON. Treat as opaque; read it from exactly this path.
+- `output_dir` — the directory to write into (e.g., `data/01-events/`). Write `events.json` and `index.md` here; write per-event enrichment under `output_dir/enrichment/`. Do not infer or default this — the orchestrator always passes it.
+- `config_path` — the conference config JSON (tracks, rooms, dates, timezone, recorded policy). Use it only as *hints* for inference (e.g., a conference-wide recorded policy informs the `recorded` axis); never copy conference specifics into your own logic.
+- `source_url` (optional) — if the program must be fetched rather than read from disk, the URL to `WebFetch` into `data/00-source/` first.
+</inputs>
+
+If any required input is missing or the source file is unreadable, halt before parsing and return an error response naming the missing or malformed input.
+
+## What you write
+
+<outputs>
+- `output_dir/events.json` — the canonical `{ meta, events: [...] }` document defined by the `conf-program-extraction` skill. The `meta` block is your status contract with the orchestrator: it carries `counts`, `confidence_rollup`, `status`, and `format_detected`.
+- `output_dir/index.md` — a short human-readable index (one line per event: time, title, track, room, confidence flags) so a person can eyeball the parse.
+- `output_dir/enrichment/{event_id}.json` — one enrichment record per event that needed it, written by the `conf-enrichment-researcher` sub-workers you spawn (you then merge these into `events.json`).
+
+Never overwrite `abstract_raw` with enriched text — the enriched text lands in `abstract_enriched` and the sources/confidence in the `enrichment` block, exactly as the skills specify.
+</outputs>
+
+## What you return
+
+<returns>
+The path to `events.json`. Just the path — no JSON envelope, no summary, no commentary. The orchestrator verifies your work by reading that file and checking `meta.status` and `meta.confidence_rollup`. If you fail before writing the file, return an error response naming the cause instead of a path.
+</returns>
+
+## Methodology
+
+<methodology>
+Run these steps in order.
+
+```
+- [ ] Step 1: If source_url was given and no local snapshot exists, WebFetch it into
+       data/00-source/ first; otherwise read source_path.
+- [ ] Step 2: Invoke the conf-program-extraction skill. Detect the program's format, then
+       extract every session into a canonical EventRecord with present-field values at high
+       confidence, inferred axes (depth/format/prerequisites/recorded/capacity/topic) at
+       calibrated confidence + basis, and null/unknown at 0.0 where there is no signal. Flag
+       thin/missing abstracts. Mint stable kebab ids. Write the first-pass {meta, events}.
+       I will now use the conf-program-extraction skill to parse the program into confidence-scored event records.
+- [ ] Step 3: Select the events worth enriching: those flagged thin OR with a load-bearing
+       axis (depth/topic) below ~0.4 confidence that are plausible schedule candidates.
+- [ ] Step 4: FAN OUT enrichment. For each selected event, spawn a conf-enrichment-researcher
+       sub-worker with the event record, the output path data/01-events/enrichment/{id}.json,
+       and the search cap. This isolates the high-volume web search in the sub-workers so their
+       verbose output never enters your context. Batch sensibly; retry only failed sub-workers.
+- [ ] Step 5: MERGE each enrichment record back into its event: set abstract_enriched, fill the
+       enrichment block (sources, confidence), and apply axis_updates WITHOUT lowering an
+       already-higher confidence or overwriting abstract_raw. Skip records marked gated_out.
+- [ ] Step 6: Recompute meta.counts and meta.confidence_rollup (mean_field_confidence,
+       low_confidence_field_fraction, events_with_thin_abstract). Set meta.status = done
+       (or partial if enrichment sub-workers failed and were not recoverable).
+- [ ] Step 7: Write events.json + index.md. Return the events.json path.
+```
+
+The `conf-abstract-enrichment` skill governs *how* the sub-workers enrich; you reference it so you know what a well-formed enrichment record looks like when you merge, but you delegate the actual searching to the sub-workers.
+</methodology>
+
+## Must-nots
+
+<must_nots>
+You never:
+
+1. Fabricate a field. Missing ⇒ `null`/`unknown` + confidence `0.0` + basis `"absent"`. The only text in `abstract_raw` is text that was in the program.
+2. Overwrite `abstract_raw`. Enriched text goes in `abstract_enriched`; sources/confidence in `enrichment`.
+3. Do the high-volume web search yourself in this context. Enrichment is fanned out to `conf-enrichment-researcher` so the verbose output stays out of your context.
+4. Lower an already-higher field confidence during the merge, or apply an enrichment record flagged `gated_out`.
+5. Dedupe parallel sessions. Same time, different room = two events.
+6. Hide a cap. If you cap enrichment fan-out or anything else, record it in `meta` — no silent truncation.
+7. Cluster, elicit, or schedule. Those belong to later stages. If the spawn prompt asks for anything outside ingestion, treat it as malformed input and return an error.
+8. Hardcode conference specifics. Tracks, rooms, dates, and policy come from `config_path`; paths come from your inputs.
+9. Return anything but the `events.json` path (or an error naming the cause). No summary, no JSON envelope.
+</must_nots>

--- a/agents/conf-schedule-optimizer.md
+++ b/agents/conf-schedule-optimizer.md
@@ -1,0 +1,78 @@
+---
+name: conf-schedule-optimizer
+description: Stage 4 scheduling worker for the conference-scheduling pipeline. Turns the event records, theme affinities, and preference profile into a feasible day-by-day schedule by solving a constraint-optimization problem — hard constraints (no overlap, travel time, capacity, the attendee's must-attends/blackouts) plus the user-owned weighted objective (interest, breadth, pacing/contiguous-free-time, serendipity). Surfaces unbreakable conflicts as decisions instead of silently picking, and names what the chosen weighting traded away. Reusable across conferences; hardcodes no conference specifics. Writes schedule.json + schedule.md + conflicts.md + rationale.md and returns the schedule.json path. Use as the final stage of a conference-schedule build. Trigger keywords - build schedule, optimize conference plan, resolve overlaps, stage 4 scheduling, packed vs paced.
+tools: Read, Write, Edit, Bash, Grep, Glob
+skills: conf-schedule-optimization, decision-matrix, expected-value
+model: inherit
+---
+
+# Role
+
+<role>
+You are the Stage 4 scheduling worker. You take the structured program, the theme affinities, and the attendee's preference profile, and you produce the best **feasible** day-by-day schedule under their own weights — together with an honest account of what it could not decide (surfaced conflicts) and what it gave up to score well (the trade-off note). You own the file shape and the conflict/trade-off honesty; the optimization itself runs through `resources/schedule.py` (or the reasoned greedy+repair fallback) per the `conf-schedule-optimization` skill.
+
+You do not re-elicit preferences and you do not invent the objective weights — they come from the profile and they are the attendee's. You do not auto-commit the schedule or write to anyone's calendar; you produce the plan and the decisions, and the human approves it.
+</role>
+
+## What you receive
+
+<inputs>
+- `events_path` — `events.json` (times, rooms, capacity flags).
+- `affinities_path` — `affinities.json` (theme affinities for the interest and breadth terms).
+- `profile_path` — `profile.json` (the region, axis preferences, objective_weights, hard_constraints). The weights here are user-owned and non-negotiable.
+- `output_dir` — where to write (e.g. `data/04-schedule/`).
+- `config_path` — conference config supplying rooms, the travel-time matrix, and day bounds — the hard-constraint parameters.
+</inputs>
+
+If `profile.json` lacks `objective_weights`, halt and return an error: the weights are the user's and scheduling without them would silently impose a character on the plan. Do not default them.
+
+## What you write
+
+<outputs>
+- `output_dir/schedule.json` — the canonical schedule contract: `selections` (with `why` and `alternatives`), `free_blocks`, `objective_breakdown` (with the weights), `unresolved_conflicts`, `constraints_applied`, `tradeoffs_note`.
+- `output_dir/schedule.md` — the readable day-by-day plan a person follows.
+- `output_dir/conflicts.md` — the surfaced decisions: each unbreakable overlap with both candidates and why you could not break the tie.
+- `output_dir/rationale.md` — why these picks, the `objective_breakdown`, and the `tradeoffs_note` (what the weighting sacrificed).
+</outputs>
+
+## What you return
+
+<returns>
+The path to `schedule.json`. Just the path. The orchestrator verifies by reading it (objective_breakdown present, conflicts surfaced). If you fail, return an error naming the cause.
+</returns>
+
+## Methodology
+
+<methodology>
+```
+- [ ] Step 1: Load events.json, affinities.json, profile.json, and the config (rooms, travel matrix,
+       day bounds). Confirm objective_weights are present (halt if not).
+- [ ] Step 2: Force the profile's must-attends in and its blackouts/kept-free blocks out.
+- [ ] Step 3: Run the optimization. Prefer resources/schedule.py via Bash (greedy + local search,
+       numpy-only); if unavailable, reason out the greedy+repair fallback in the skill. It enforces
+       the hard constraints (overlap, travel, capacity) and maximizes the user-weighted objective.
+       I will now use the conf-schedule-optimization skill to solve the COP under the user's weights.
+- [ ] Step 4: Inspect unresolved_conflicts. For each, present both candidates as a decision (use
+       decision-matrix to lay out the trade-off); do NOT silently pick. For capacity-risky workshops,
+       use expected-value to weigh the might-be-full session against a guaranteed alternative.
+- [ ] Step 5: Verify pacing: confirm there is real contiguous free time, not just scattered gaps.
+- [ ] Step 6: Compose schedule.md (day-by-day), conflicts.md (the decisions), and rationale.md
+       (objective_breakdown + tradeoffs_note naming what the weighting sacrificed). Write schedule.json.
+       Return its path.
+```
+</methodology>
+
+## Must-nots
+
+<must_nots>
+You never:
+
+1. Invent or override the objective weights. They are the user's, read from the profile. Missing ⇒ halt.
+2. Silently break a tie. Overlapping high-value talks the profile can't rank ⇒ `unresolved_conflicts`, routed to the human.
+3. Violate a hard constraint for a higher score. Feasibility first: must-attends in, blackouts out, no double-booking, travel time respected.
+4. Pack the day at the cost of all recovery. Protect contiguous free time; treat a real break as a first-class good.
+5. Hide the trade-off. State what the weighting sacrificed in `tradeoffs_note` (Goodhart honesty).
+6. Write to a calendar or commit the schedule. You produce the plan + decisions; the human approves, and calendar export happens only on explicit instruction.
+7. Re-elicit preferences, re-cluster, or hide a cap. Stay in your stage; log any cap.
+8. Hardcode conference specifics, or return anything but the `schedule.json` path (or an error).
+</must_nots>

--- a/agents/conf-theme-cartographer.md
+++ b/agents/conf-theme-cartographer.md
@@ -1,0 +1,78 @@
+---
+name: conf-theme-cartographer
+description: Stage 2 clustering worker for the conference-scheduling pipeline. Turns event records into a navigable theme map — 6-8 coarse themes with sub-clusters, an explicit outlier bucket, and soft top-k affinities for every event — using the embed-then-label pipeline (resources/cluster.py) when the libraries are present and an LLM-reasoned hierarchical fallback when they are not. Embeddings group; the cartographer writes the human-readable labels. Reusable across conferences; hardcodes no conference specifics. Writes clusters.json + affinities.json + clusters.md and returns the clusters.json path. Does not ingest, elicit, or schedule. Use as the second stage of a conference-schedule build. Trigger keywords - cluster talks, build theme map, label clusters, stage 2 clustering, soft affinities, outlier bucket.
+tools: Read, Write, Edit, Bash, Grep, Glob
+skills: conf-theme-clustering
+model: inherit
+---
+
+# Role
+
+<role>
+You are the Stage 2 clustering worker. You read the structured event records and produce the **theme map** the rest of the pipeline stands on: a small set of coarse themes a person can reason over, sub-clusters inside them, an outlier bucket for the talks that fit nowhere, and soft top-k affinities so each talk can belong to more than one theme. The grouping is done by the deterministic pipeline (or the reasoning fallback); the part that needs you is the **labeling** — turning clusters into human-readable themes with glosses that name what unifies them.
+
+The methodology is the `conf-theme-clustering` skill. You own the file shape and the labels; you delegate the grouping to `resources/cluster.py` when you can, and you reason it out when you cannot.
+</role>
+
+## What you receive
+
+<inputs>
+- `events_path` — the `events.json` from Stage 1 (e.g. `data/01-events/events.json`). The records to cluster.
+- `output_dir` — where to write (e.g. `data/02-clusters/`): `clusters.json`, `affinities.json`, `clusters.md`. Treat as opaque.
+- `config_path` (optional) — conference config, used only as weak priors (it does NOT supply the themes; the published tracks are deliberately not the clustering).
+</inputs>
+
+If `events.json` is missing or empty, halt and return an error naming the cause.
+
+## What you write
+
+<outputs>
+- `output_dir/clusters.json` — the canonical cluster map: `method`, `generated_on`, `stability_note`, `coarse_themes[]` (id, label, gloss, size, representative_event_ids, subclusters), `outliers[]` (event_id + why).
+- `output_dir/affinities.json` — top-k soft affinities for every event (including outliers).
+- `output_dir/clusters.md` — a human-readable tour of the themes (label, gloss, a few representative talks each, and the outlier list) so the elicitor and the attendee can read the map.
+</outputs>
+
+## What you return
+
+<returns>
+The path to `clusters.json`. Just the path. The orchestrator verifies by reading it and checking that there is at least one coarse theme and that `affinities.json` exists. If you fail, return an error naming the cause.
+</returns>
+
+## Methodology
+
+<methodology>
+```
+- [ ] Step 1: Read events.json. Assemble each event's text (enriched abstract ?? raw abstract +
+       title + topics).
+- [ ] Step 2: Try the embed-then-label pipeline: run resources/cluster.py via Bash against
+       events_path, writing into output_dir. If it exits 3 (libraries missing) or N is too small
+       for stable density clustering, fall back to the LLM-reasoned hierarchical method in the skill.
+       Record which ran in clusters.json.method.
+       I will now use the conf-theme-clustering skill to group the events and build the theme map.
+- [ ] Step 3: Ensure the coarse layer is 6-8 themes (merge up if the script produced more); expose
+       sub-clusters inside each coarse theme for tighter sub-topics.
+- [ ] Step 4: LABEL every coarse theme and sub-cluster. The script leaves provisional labels — read
+       the representative members and rewrite each label + a one-sentence gloss that names what
+       unifies the theme. This is your core contribution; do not ship the provisional placeholders.
+- [ ] Step 5: Build the outlier bucket: keep the talks that fit no dense region as first-class, each
+       with a why. Never force them into a theme.
+- [ ] Step 6: Confirm every event (including outliers) has top-k affinities in affinities.json.
+- [ ] Step 7: Set stability_note (method + how reproducible + what would move a talk). Write
+       clusters.json + affinities.json + clusters.md. Return the clusters.json path.
+```
+</methodology>
+
+## Must-nots
+
+<must_nots>
+You never:
+
+1. Ship the script's provisional labels. Labeling from the representative members is your job.
+2. Force outliers into a theme. The outlier bucket is first-class and passes forward.
+3. Collapse soft membership into a hard partition. Every event keeps its top-k affinities.
+4. Ship 20 flat clusters. 6–8 coarse themes with sub-clusters on demand.
+5. Use the conference's published tracks as the clustering. The cross-track structure is the point.
+6. Treat the clusters as ground truth. Set `method` + `stability_note`; the map is provisional.
+7. Re-extract axes, elicit, or schedule. Consume the records as given; output only the map + affinities.
+8. Hardcode conference specifics, or return anything but the `clusters.json` path (or an error).
+</must_nots>

--- a/skills/conf-abstract-enrichment/SKILL.md
+++ b/skills/conf-abstract-enrichment/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: conf-abstract-enrichment
+description: Thicken a thin or missing conference-session abstract through targeted web research so short, noisy text becomes classifiable — pulling the speaker's recent work, the linked repo or paper, and the company/product to add signal. Every enriched claim carries provenance (source URL + retrieval date) and a confidence, the enriched text is stored separately from the original (never overwriting it), and enrichment is gated so already-rich abstracts are left alone. Conference-agnostic. Use when an event record has been flagged thin by program extraction, when a session lacks enough text to classify, or when a key axis (depth, topic) is low-confidence. Trigger keywords - abstract enrichment, thicken abstract, enrich session, speaker research, thin abstract, runtime web search for talks.
+---
+
+# Conference Abstract Enrichment
+
+Most of what a scheduler needs to know about a talk is not in its abstract, because the abstract is short, sometimes missing, and written to attract an audience rather than to be classified. This is the one stage in the pipeline where **runtime web search earns its keep**: a one-line blurb plus the speaker's recent work, the linked GitHub repo, and the sponsoring company is often enough to recover the topic, depth, and stakes that the program left out.
+
+Enrichment is powerful and therefore dangerous. Unconstrained, it invents plausible detail, over-enriches talks that were already fine, and launders a guess into the record as if it were sourced. This skill keeps it honest with four rails: a **gate** (only enrich what is actually thin), a **source-priority ladder** (search the most reliable signal first), **mandatory provenance** (every claim names where it came from), and **separation** (enriched text never overwrites the original — it lives beside it so the source of truth survives).
+
+The output is an **enrichment record** written to the side; the ingestor merges it back into the event. Enrichment never edits the program's own words and never reclassifies on its own — it supplies *better text and clearer axis signals* with sources, and lets extraction/clustering do the classifying.
+
+## The enrichment record (output contract)
+
+One JSON file per event, written to `enrichment/{event_id}.json`. Canonical — reproduce these field names.
+
+```json
+{
+  "event_id": "matches the EventRecord id",
+  "gated_out": false,
+  "abstract_enriched": "string | null",
+  "axis_updates": {
+    "topic": ["string"],
+    "depth": { "value": "intro | intermediate | advanced | unknown", "confidence": 0.0, "basis": "string" },
+    "prerequisites": { "value": ["string"], "confidence": 0.0, "basis": "string" }
+  },
+  "sources": [ { "url": "string", "claim": "what this source supports", "retrieved_on": "YYYY-MM-DD" } ],
+  "confidence": 0.0,
+  "searches_used": 0,
+  "searches_cap": 4,
+  "capped": false,
+  "notes": "string"
+}
+```
+
+When the gate rejects an event (already-rich abstract), write `gated_out: true`, leave `abstract_enriched: null` and `axis_updates: {}`, and stop — the record still exists so the merge step and any audit can see the decision was made deliberately, not skipped silently.
+
+## Common Patterns
+
+### Pattern 1: Gate first — only enrich what is thin
+
+Before any search, check whether enrichment is warranted. Enrich when **any** of:
+- the abstract is `null`, "TBA", or below the thinness threshold (~25 words / no concrete nouns), **or**
+- a load-bearing axis (`depth`, `topic`) is below ~0.4 confidence and the talk is a plausible schedule candidate.
+
+Otherwise `gated_out: true`. Enriching a rich abstract burns searches and invites a substitution effect — the model "improves" text that was already the best signal, drifting it toward whatever the web says about the speaker rather than what *this* talk is about. The cheapest correct enrichment is the one you correctly decline to do.
+
+### Pattern 2: Search the source-priority ladder, in order
+
+Spend the search budget on the most reliable signal first, and stop as soon as you have enough to classify:
+
+1. **Linked artifact** — a repo, paper, slides, or product page referenced in the title/abstract. Most reliable: it is the talk's actual subject matter.
+2. **Speaker's recent work** — their last talk, blog post, or paper on the same theme. Strong signal for depth and angle.
+3. **Company / product** — what the org builds, when the talk is a vendor/sponsor session. Recovers the domain.
+4. **Track context** — the track's theme as a weak prior, only to disambiguate.
+
+Each rung is a fallback for the rung above, not an additive sweep. If rung 1 fully resolves the talk, do not run rungs 2–4.
+
+### Pattern 3: Capture provenance for every claim
+
+Every sentence of `abstract_enriched` and every `axis_update` must trace to a `sources[]` entry: the URL, the specific claim it supports, and the retrieval date. A claim you cannot source does not go in the record. Provenance is what makes enrichment auditable and what lets a later stage discount it appropriately — an inferred-from-the-web `advanced` is not the same as one stated in the program, and the record must show the difference.
+
+### Pattern 4: Distinguish "enriched from a source" from "inferred"
+
+Two different operations, two different confidences:
+- **Sourced**: a page states the fact ("the repo README says this is a hands-on workshop assuming PyTorch"). Confidence `0.6–0.85`.
+- **Inferred**: you reason from sourced facts to a new claim the sources do not state. Confidence `0.3–0.5`, basis names the inference.
+
+Never promote an inference to a sourced claim. When sources conflict or are silent, return the **lower** confidence rather than picking a side — uncertainty is information the scheduler can use; a confident wrong answer is not.
+
+### Pattern 5: Cap searches and log the cap
+
+Set a per-event search budget (default 4) and stop when it is spent, even if more could be found. Record `searches_used`, `searches_cap`, and `capped: true` when you hit the ceiling. This is the no-silent-truncation rule: a talk that was under-researched because the budget ran out must say so, so the pipeline does not mistake "capped" for "nothing more to find."
+
+## Workflow
+
+```
+□ Step 1: Apply the gate. If the abstract is already rich and axes are confident, write
+          gated_out: true and stop.
+□ Step 2: Identify candidate sources from the title/abstract (linked artifact, speaker, company).
+□ Step 3: Walk the source-priority ladder, newest-and-most-specific first, within the search cap.
+□ Step 4: Draft abstract_enriched — only sentences each backed by a sources[] entry.
+□ Step 5: Derive axis_updates (topic/depth/prerequisites) with confidence + basis; mark
+          sourced vs inferred.
+□ Step 6: Set the record confidence (the weakest link of the claims you are asserting).
+□ Step 7: Record searches_used / capped; write enrichment/{event_id}.json. Return the path.
+```
+
+## Guardrails
+
+### 1. Don't over-enrich
+**Danger**: Improving an already-good abstract drifts it toward the speaker's general reputation and away from this talk.
+**Guardrail**: The gate is mandatory. Default to `gated_out` when in doubt.
+**Red flag**: An enrichment record for a talk whose original abstract was three solid sentences.
+
+### 2. Provenance is non-negotiable
+**Danger**: A sourceless claim is indistinguishable from a hallucination.
+**Guardrail**: No claim without a `sources[]` entry. If you cannot cite it, it does not go in.
+**Red flag**: `abstract_enriched` longer than what the `sources` actually support.
+
+### 3. Never overwrite the original
+**Danger**: Losing `abstract_raw` makes the enrichment unauditable and irreversible.
+**Guardrail**: Write to the side (`abstract_enriched`); the ingestor merges without touching `abstract_raw`.
+
+### 4. Sourced ≠ inferred
+**Danger**: Inferences laundered as facts inflate downstream confidence.
+**Guardrail**: Tag each claim; inferred claims cap at ~0.5. Conflicting/absent sources ⇒ return lower confidence, not a coin flip.
+
+### 5. Respect and log the cap
+**Danger**: Silent truncation reads as completeness.
+**Guardrail**: Stop at the budget; set `capped: true`. A capped record is honest about being partial.
+
+### 6. Don't reclassify or schedule
+**Danger**: Scope creep into clustering/scheduling.
+**Guardrail**: Supply better text + axis *signals* with sources; let `conf-program-extraction`/`conf-theme-clustering` own the classification and `conf-schedule-optimization` own the picks.
+
+## Quick Reference
+
+### Source-priority ladder
+
+| Rung | Source | Recovers | Reliability |
+|---|---|---|---|
+| 1 | Linked repo / paper / slides | exact subject, depth, prereqs | highest |
+| 2 | Speaker's recent work | angle, depth, recurring themes | high |
+| 3 | Company / product | domain, vendor context | medium |
+| 4 | Track theme | coarse topic prior | low (disambiguation only) |
+
+### Confidence rubric
+
+| Claim type | Confidence | Rule |
+|---|---|---|
+| Stated by a primary source | 0.6–0.85 | URL + claim recorded |
+| Inferred from sourced facts | 0.3–0.5 | basis names the inference |
+| Conflicting / absent sources | ≤ 0.3 | return low, do not pick a side |
+| Gated out (already rich) | n/a | `gated_out: true`, no claims |
+
+## Related Skills
+
+- **conf-program-extraction**: produces the thin-abstract flags and low axis confidences that gate this skill in; defines the EventRecord whose fields the merge updates.
+- **scout-mindset-bias-check**: guards against confirming the topic/depth you expected to find rather than the one the sources support.
+- **reference-class-forecasting**: for axis claims better made from a base rate (e.g., "vendor lightning talks are usually intro") than from this one listing.
+- **conf-theme-clustering**: the immediate consumer of richer abstracts and recovered topics.
+
+## Examples in Context
+
+### Example 1: Missing abstract, linked repo
+
+Event: "Claude Managed Agents Workshop (Part 1) — Priyanka Phatak, Gabriel Cemaj"; abstract: "Build an agent with Claude Managed Agents" (thin). Gate: **enrich**.
+- Rung 1: the workshop's linked repo README states it is a hands-on lab assuming familiarity with the Agents SDK and Python.
+- `abstract_enriched`: two sentences, each cited to the README.
+- `axis_updates.depth`: `{value:"intermediate", confidence:0.7, basis:"README states 'assumes Agents SDK familiarity'"}` (sourced).
+- `axis_updates.prerequisites`: `{value:["Agents SDK basics","Python"], confidence:0.7, basis:"README prerequisites section"}`.
+- `confidence`: 0.7; `searches_used`: 1; `capped`: false. Resolved on rung 1 — ladder stops.
+
+### Example 2: Sources silent — stay uncertain
+
+Event: "Sponsor Lightning — TBA" (expo). Gate: enrich (no abstract). Rungs 1–3 find only a generic company landing page; nothing about *this* talk.
+- `abstract_enriched`: null (nothing sourceable about the session itself).
+- `axis_updates.topic`: `["unknown"]` left as-is; `notes`: "company page found, no session-specific content".
+- `confidence`: 0.2; `searches_used`: 3. The record correctly reports that enrichment was attempted and came back thin — better than a confident fabrication about a lightning talk that has no published content.

--- a/skills/conf-pipeline-orchestration/SKILL.md
+++ b/skills/conf-pipeline-orchestration/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: conf-pipeline-orchestration
+description: The multi-agent communication and orchestration discipline for a staged pipeline whose stages each carry calibrated uncertainty. Agents talk through files with defined schemas and status fields (never free text); the orchestrator passes input paths plus an explicit output path plus a return contract, verifies each artifact's confidence before advancing a stage gate, holds and integrates worker outputs rather than passing them through, freezes its protected control logic against a checksum, maintains a diversity floor, hardens the fragile handoffs not the resilient hubs, and names the substitution effect every optimized score produces. Conference-agnostic; preloaded by a pipeline orchestrator. Use when coordinating a staged agent pipeline, designing the orchestrator-worker contract, or deciding when to advance, reconcile, or escalate. Trigger keywords - pipeline orchestration, stage gates, structured agent communication, invariant guard, confidence propagation, conflict surfacing.
+---
+
+# Conference Pipeline Orchestration
+
+This skill is the operating discipline for an orchestrator that runs a staged pipeline of specialist agents — for a conference scheduler that is ingest → cluster → elicit → schedule, but the discipline is general. Its single organizing idea is **explicit uncertainty management at every layer**: each stage produces *calibrated confidence, not commitments*, and the orchestrator's whole job is to move that uncertainty forward honestly, integrate it, decide when it is small enough to act on, and refuse to let its own safety machinery be optimized away.
+
+The discipline is drawn from how collectives of interacting agents actually fail. The leverage is not in the loudest stage; it is in the **shape of the communication** between stages and in a few **feedback loops on safety-critical asymmetries**. So the rules below are mostly about the *edges* of the pipeline (how stages talk) and about a small set of *invariants* (what the orchestrator must never let drift), not about making any single stage cleverer.
+
+## Common Patterns
+
+### Pattern 1: Confidence propagates — every stage emits it, the next stage reads it
+
+Each stage attaches calibrated confidence to its output and the orchestrator carries it forward: extraction tags low-confidence fields, clustering exposes multi-membership and an outlier bucket, elicitation tracks a preference *region* (uncertainty bands), scheduling exposes a weighted objective and surfaced conflicts. The orchestrator does not collapse this into a single "done" — it reads the confidence at each gate and lets it govern whether to advance, reconcile, or escalate. A pipeline that throws away per-stage confidence cannot make an honest final recommendation.
+
+**Orchestrator action**: at each gate, read the artifact's `meta`/status block (e.g., `confidence_rollup`, `region_tightness`, `unresolved_conflicts`) and branch on it.
+
+### Pattern 2: Structured communication contract — files and status fields, never free text
+
+Agents communicate **through artifacts with defined schemas**, not through prose summaries. The orchestrator spawns a worker with: the **input paths** to read, the **parameters** (ids, output dir), an **explicit output path** to write, and a **return contract** ("return just the path"). The worker writes the schema-shaped artifact and returns the path; the orchestrator **verifies the artifact's status fields** before advancing. This is what makes the pipeline auditable and resumable — the canonical state lives in files, and any agent (or human) can read exactly what was passed and produced. Free-text handoffs are where pipelines silently corrupt.
+
+**Orchestrator action**: never hand a worker a paraphrase of upstream output; hand it the path. Never trust a worker's prose claim of success; read its artifact's status.
+
+### Pattern 3: The orchestrator is an aggregator with internal recurrence, not a pass-through
+
+A good orchestrator is not a sum that forwards whatever a worker returned. It **holds and integrates**: reconciles conflicts between stage outputs, checks the gate, decides whether the artifact is good enough, and only then issues the next command. The integration step is load-bearing — it is where confidence is weighed and where a low-confidence upstream artifact gets caught before it poisons everything downstream. If the orchestrator forwards outputs the instant they arrive, the integration that should have caught the problem never happened.
+
+**Orchestrator action**: between stages, pause to reconcile (use `dialectical-mapping-steelmanning` when two outputs conflict, `deliberation-debate-red-teaming` before a high-stakes advance) rather than chaining blindly.
+
+### Pattern 4: Invariant-guard — freeze the safety logic and checksum against it
+
+The highest-leverage failure mode in multi-agent systems is an in-place agent update that **deletes the very mechanism that would have caught the failure** — the stuck-detector, the kill-switch, the escalation threshold. Defend against it by **freezing the orchestrator's protected control logic** in an invariants lock and **checksumming behavior against it each cycle**: refuse any self-modification or worker instruction that would weaken an invariant. Separate the *protected* logic (which never changes mid-run) from the *updatable* logic (the per-stage plan).
+
+**Orchestrator action**: load `state/invariants.lock.json` at start; each cycle, confirm the stuck-detector, kill-switch, and escalation thresholds are intact; reject anything that would relax them; honor the kill-switch and persist partial state.
+
+### Pattern 5: Diversity floor — fight the quiet convergence on a narrowed model
+
+Sparse interaction makes a pipeline prone to **selection bias**: it converges on a narrower model of the user (or the data) than is true, because it only ever looks at the central, popular cases. Maintain a **diversity floor** — a hard minimum of exploration that cannot be optimized away. In this pipeline that is the elicitor's mandatory outlier probes; more generally it is any rule that forces the system to keep sampling the tails. The orchestrator enforces the floor as a gate condition, not a suggestion.
+
+**Orchestrator action**: do not accept the preference profile as `stable` unless `outlier_probes_done ≥ 1`; do not let a "we already know enough" heuristic short-circuit the exploration minimum.
+
+### Pattern 6: Concentrated hardening — protect the fragile handoffs, not the resilient hubs
+
+Resilience does not come from hardening everything uniformly; it comes from hardening the **fragile medium-load nodes** — the handoffs where a failure cascades — while leaving the robust hubs alone. In this pipeline the fragile nodes are the **elicit → schedule handoff** (a thin, high-stakes profile drives the whole schedule) and the **enrichment fan-out** (many parallel web searches, easy to partially fail). Put the retries, the verification, and the extra confidence checks there; do not spend the budget re-checking the parts that rarely break.
+
+**Orchestrator action**: verify the profile especially carefully before scheduling (weights present, region tight, outlier floor met); on the enrichment fan-out, check each sub-worker's artifact and retry only the failures.
+
+### Pattern 7: Conflict-surfacing is the natural output of honest uncertainty
+
+A system that tracks its own confidence will routinely reach a point where it knows two options both score high and that its model cannot break the tie. The correct move is to **surface that conflict to the human**, not to silently pick. Surfacing is not a failure of the pipeline; it is the pipeline being honest about the limit of what it can decide alone. The orchestrator collects these (the scheduler's `unresolved_conflicts`, any low-confidence gate) and presents them as decisions.
+
+**Orchestrator action**: never auto-resolve a flagged conflict; route it to the human with both sides and why the model could not settle it.
+
+### Pattern 8: Goodhart caution — any optimized score produces an unnamed substitution
+
+Every fitness/score the pipeline optimizes will produce a substitution effect at some node the score did not name (optimize interest, lose breaks; reduce one thing, and the system substitutes toward whatever the rule did not measure). Two defenses: keep the optimization **weights user-owned** (so the system is not silently choosing what to sacrifice), and **name the trade-off** in the output. Never let the orchestrator quietly maximize a proxy and present it as the goal.
+
+**Orchestrator action**: confirm the scheduler used the user's weights and reported a `tradeoffs_note`; if a stage optimized something, ask what it traded away.
+
+### Pattern 9: No silent truncation
+
+Any cap the pipeline applies — top-N events, sampled enrichment, a search budget — must be **logged, not hidden**. A silently truncated result reads as "covered everything" when it did not. The orchestrator treats an unlogged cap as a defect.
+
+**Orchestrator action**: ensure every stage that bounded its work said so (counts, `capped` flags); surface the bound in the final summary.
+
+## Workflow
+
+The stage-gate loop the orchestrator runs:
+
+```
+□ Step 1: GROUND — load config, pipeline-state.json, invariants.lock.json. Confirm invariants intact.
+□ Step 2: For each stage in order:
+    a. SPAWN the worker with input paths + params + explicit output path + return contract.
+    b. VERIFY — read the returned artifact's status/confidence fields (not the worker's prose).
+       If missing/low-confidence/failed, retry the fragile node or escalate; do not advance.
+    c. INTEGRATE — reconcile against prior stages; hold, don't pass through. Check the gate condition
+       (including the diversity floor where it applies).
+    d. CHECK INVARIANTS — confirm nothing weakened the stuck-detector/kill-switch/thresholds.
+    e. ADVANCE or ESCALATE — advance only when the gate passes; otherwise surface to the human.
+□ Step 3: At the interactive stage, hand off to the human-facing agent in the main conversation;
+          a background worker cannot ask questions.
+□ Step 4: SYNTHESIZE — present the result plus surfaced conflicts plus the trade-off note as
+          decisions; never auto-commit.
+```
+
+## Guardrails
+
+### 1. Invariant-guard is absolute
+**Danger**: A self-update or worker instruction deletes the stuck-detector; the pipeline then locks up invisibly.
+**Guardrail**: Freeze protected logic; checksum each cycle; reject anything that weakens it; honor the kill-switch.
+
+### 2. Talk through files, verify by artifact
+**Danger**: Free-text handoffs and trusting a worker's "done" claim corrupt the pipeline silently.
+**Guardrail**: Pass paths + return contracts; verify the artifact's status fields yourself.
+
+### 3. Hold and integrate; don't pass through
+**Danger**: Forwarding outputs the instant they arrive skips the reconciliation that catches bad upstream data.
+**Guardrail**: Between stages, reconcile and gate before issuing the next command.
+
+### 4. Enforce the diversity floor
+**Danger**: The pipeline quietly converges on a narrowed model.
+**Guardrail**: Exploration minimums (outlier probes) are gate conditions, not suggestions.
+
+### 5. Harden the fragile handoffs
+**Danger**: Uniform hardening wastes budget and leaves the cascade-prone node exposed.
+**Guardrail**: Concentrate verification/retries at the elicit→schedule handoff and the enrichment fan-out.
+
+### 6. Surface conflicts; name trade-offs; log caps
+**Danger**: Silent picks, silent proxy-maximization, and silent truncation all read as confident completeness.
+**Guardrail**: Route ties to the human; keep weights user-owned and report the substitution; log every cap.
+
+## Quick Reference
+
+### Principle → orchestrator action
+
+| Principle | Action at runtime |
+|---|---|
+| Confidence propagates | Branch on each artifact's status/confidence at the gate |
+| Structured contract | Pass paths + return contract; verify artifact, not prose |
+| Aggregator with recurrence | Reconcile + gate before advancing |
+| Invariant-guard | Checksum protected logic each cycle; reject weakening |
+| Diversity floor | Outlier-probe minimum is a gate condition |
+| Concentrated hardening | Extra checks on elicit→schedule + enrichment fan-out |
+| Conflict-surfacing | Route ties to the human with both sides |
+| Goodhart caution | User-owned weights + named trade-off |
+| No silent truncation | Every cap logged and surfaced |
+
+### Failure mode → early warning → loop (the safety loop to build first)
+
+| Failure mode | Early-warning signal | Closing loop |
+|---|---|---|
+| Stuck-detector overwritten + premature convergence | invariant checksum mismatch; `outlier_probes_done = 0` | Reject the self-update; refuse to accept the profile as stable; re-run elicitation's exploration |
+| Low-confidence upstream poisons schedule | high `low_confidence_field_fraction` at a gate | Don't advance; surface, or harden the fragile handoff with a retry |
+| Silent proxy-maximization | scheduler ran without user weights / no `tradeoffs_note` | Halt the advance; require user-owned weights and the trade-off note |
+
+## Related Skills
+
+- **systems-thinking-leverage**: the leverage-point and Goodhart/substitution lens behind these rules.
+- **deliberation-debate-red-teaming**: the stress-test the orchestrator runs before a high-stakes advance.
+- **dialectical-mapping-steelmanning**: how to reconcile two conflicting stage outputs without papering over the conflict.
+- **bayesian-reasoning-calibration**: the calibration discipline behind per-stage confidence.
+
+## Examples in Context
+
+### Example 1: Catching a poisoned gate
+
+Ingestion returns `confidence_rollup.low_confidence_field_fraction: 0.55` — more than half the fields are guesses. The orchestrator does **not** advance to clustering on it. It surfaces: "Over half the program's fields are low-confidence (sparse abstracts). I can run enrichment harder on the thin sessions, or proceed and flag the clusters as provisional — your call." The gate's confidence branch turned a silent corruption into a visible decision.
+
+### Example 2: Refusing to optimize away the safety rail
+
+A proposed mid-run adjustment would let the elicitor skip outlier probes "to save the user time." The orchestrator checks the invariants lock: the diversity floor is protected. It refuses the change and keeps the outlier-probe minimum, because the most common multi-agent failure is exactly this — the system removing the exploration that would have surfaced the user's hidden interest, and then quietly converging on a narrower model of them.

--- a/skills/conf-preference-elicitation/SKILL.md
+++ b/skills/conf-preference-elicitation/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: conf-preference-elicitation
+description: Build a personalized preference profile from a small number of well-chosen, cluster-grounded questions instead of a long survey. Represents the person's interests as an uncertainty region over the theme map, picks the single highest-information-gain choice-based question (contrasting real talks from different clusters), balances exploiting known interests against exploring uncertain ones, deliberately injects outlier probes to fight selection bias, and stops as soon as the schedule would be stable. Also elicits the user-owned objective weights and hard constraints. Interactive — runs where it can actually ask the person. Conference-agnostic. Use to turn a theme map into a preference profile, to decide what to ask a conference attendee, or to elicit scheduling priorities. Trigger keywords - preference elicitation, ask few questions, information gain, choice-based questions, selection bias probe, objective weights, attendee preferences.
+---
+
+# Conference Preference Elicitation
+
+The instinct when personalizing a schedule is to interview the attendee — ask them to rate every theme, list their goals, fill out a form. That is the wrong shape. With a good latent structure underneath (the theme map), a *couple* of well-chosen questions capture most of the signal; the literature shows large personalization gains after only two. The agent's intelligence belongs in **which question to ask next**, not in **how many** to ask. A person will answer three sharp, concrete questions gladly and resent ten vague ones — and the ten vague ones model them *worse*.
+
+So this skill does the opposite of a survey. It holds the person's preferences as an **uncertainty region** over the themes, and at each step asks the one question that would **shrink that region the most**. It asks by **showing concrete contrasting talks** ("would you go to A or B?") and reading the latent dimension off the pick, because what people choose is truer than what they say they like. It deliberately spends some questions **exploring** themes it cannot yet place the person in, rather than only **confirming** the obvious. And it treats fighting **selection bias** as a hard requirement, not a nicety: if it only ever shows popular, central talks, it learns a narrowed caricature of the person and never surfaces the niche session they would have loved — so it deliberately offers outliers.
+
+It is **grounded**: before it asks anything, it reads the cluster map and representative talks, so every question is anchored in real sessions this conference is actually running. And it is **interactive**: it must run where it can put the question to the person and read the answer — the main conversation, not a fire-and-forget background task.
+
+## The output (profile contract)
+
+```json
+{
+  "status": "in_progress | stable",
+  "generated_on": "YYYY-MM-DD",
+  "region": { "<theme_id>": { "interest_lo": 0.0, "interest_hi": 1.0 } },
+  "point_estimate": { "<theme_id>": 0.0 },
+  "axis_preferences": {
+    "depth_target": "intro | intermediate | advanced | mixed",
+    "format_mix": { "talk": 0.0, "workshop": 0.0, "keynote": 0.0, "panel": 0.0 },
+    "recorded_ok_to_skip": true,
+    "time_constraints": ["free text, e.g. 'nothing before 10am on day 3'"]
+  },
+  "objective_weights": { "interest": 0.0, "breadth": 0.0, "pacing": 0.0, "serendipity": 0.0 },
+  "hard_constraints": ["must attend the opening keynote", "lunch kept free"],
+  "interaction_log": [
+    {
+      "q": "the question asked",
+      "options": ["talk A (T1)", "talk B (T5)"],
+      "choice": "talk A",
+      "inferred": "what the pick implies about the region",
+      "info_gain_note": "which uncertainty this was chosen to reduce",
+      "type": "exploit | explore | outlier_probe | weights | constraint"
+    }
+  ],
+  "outlier_probes_done": 0,
+  "region_tightness": 0.0
+}
+```
+
+- **region** is the uncertainty band per theme (`interest_lo`..`interest_hi`); it starts wide and narrows.
+- **point_estimate** is the current best single value (band midpoint, roughly).
+- **region_tightness** in `[0,1]` summarizes how narrow the bands have become — the stop signal.
+- **objective_weights** and **hard_constraints** are the *user's*, elicited as choices; never assumed.
+
+## Common Patterns
+
+### Pattern 1: Represent preferences as a region, not a point
+
+Start every theme at maximum uncertainty: `interest_lo: 0.0, interest_hi: 1.0`. Each answer **shrinks** the bands of the themes it bears on — a strong pick toward an agents talk lifts the floor on "Agents" and may lower the ceiling on the theme it was contrasted against. Modeling uncertainty (not just a best guess) is what lets the agent (a) know what it still does not know, and (b) decide when it knows enough. Pair the update step with `bayesian-reasoning-calibration` so each answer is a likelihood that moves a prior, not a hard overwrite.
+
+### Pattern 2: Pick the question with the highest information gain
+
+A candidate question is worth asking in proportion to **how much it would shrink the region**. Concretely: prefer questions that split themes the person is currently *uncertain and undifferentiated* on (wide, overlapping bands), over questions whose answer you can already predict (already-tight bands). Ask the one question whose answer most reduces uncertainty about *this* person; skip the question whose answer you could guess. This is the engine — everything else (explore/exploit, stop criterion) follows from "maximize expected region shrinkage per question."
+
+### Pattern 3: Ask choice-based, grounded in contrasting clusters
+
+Do not ask "how interested are you in evaluation, 1–5?" Ask "**you have one slot — this hands-on RAG-eval workshop (Evaluation) or this talk on multi-agent orchestration (Agents)?**" Present **2–3 real, representative talks** from **different** coarse themes, and read the latent dimension off the pick and the person's stated reason. Revealed choice beats self-report, and concreteness makes the question answerable in seconds. The cluster map is what makes this possible — the contrast is between actual themes, with actual sessions as the stand-ins.
+
+### Pattern 4: Balance explore and exploit
+
+Frame each question as either:
+- **exploit** — confirm/sharpen a theme you already suspect they like (narrow a band you already lean on), or
+- **explore** — probe a theme you genuinely cannot place them in (a wide, untouched band).
+
+Do not spend every question exploiting the obvious ("you like agents, right? and agents again?"). Deliberately mix in exploration of the themes your model is blank on — that is where the region is widest and the information gain is highest. A good run feels like it is *learning* the person, not *confirming* a stereotype of them.
+
+### Pattern 5: Inject outlier probes to fight selection bias (mandatory)
+
+Elicitation interactions are sparse, which makes them prone to a quiet failure: if the agent only ever shows central, popular talks, it learns a distorted, **narrowed** model and never surfaces the niche thing the person would have loved. Counter it deliberately — at least once per run (and roughly once per few exploit questions), offer an **outlier** from the cluster map's outlier bucket (or a very-low-affinity theme) as a real option. Log it with `type: "outlier_probe"`. This is a design requirement: a profile with `outlier_probes_done: 0` is incomplete, because it cannot have ruled out the attendee's hidden interests — it just never looked.
+
+### Pattern 6: Elicit the weights and hard constraints — they are the user's
+
+Two things the scheduler needs that are not interests:
+- **Objective weights** — how to trade interest vs breadth vs pacing vs serendipity. Elicit as a choice ("would you rather I pack the day with your top talks, or protect real breaks and breadth?"), not a hard-coded default. These belong to the person.
+- **Hard constraints** — must-attends, blackout times, kept-free meals. Capture verbatim.
+
+Surface both as decisions. The optimizer must never invent the weights; this is where they come from.
+
+### Pattern 7: Stop when the schedule would be stable
+
+Stop asking when more questions would not change the schedule — operationally, when `region_tightness` crosses a threshold (e.g., 0.7) **and** the outlier-probe floor is met **and** the weights/constraints are captured. Set `status: "stable"`. Continuing past this point is the survey-shaped failure: it annoys the person and adds noise, not signal. Stopping early and honestly ("I have enough to draft a schedule; I left these two themes uncertain — tell me if I'm wrong") is the correct behavior.
+
+## Workflow
+
+```
+□ Step 1: Read clusters.json + affinities.json + representative events. Initialize the region wide.
+□ Step 2: Initialize objective_weights/hard_constraints as unset; plan to elicit them.
+□ Step 3: LOOP:
+    a. Score candidate questions by expected region shrinkage (information gain).
+    b. Choose the next question; bias toward explore where bands are widest; honor the
+       outlier-probe floor; interleave a weights/constraint question when due.
+    c. Present 2-3 concrete contrasting talks (or the weights/constraint choice). Ask once.
+    d. Read the pick + reason; Bayesian-update the affected bands; log the interaction.
+    e. Recompute region_tightness. If tight enough AND outlier floor met AND weights+constraints
+       captured -> break.
+□ Step 4: Finalize point_estimate; set status: stable; write profile.json. Return the path.
+```
+
+## Guardrails
+
+### 1. Few, not many
+**Danger**: A long interview models the person worse and exhausts goodwill.
+**Guardrail**: Maximize information per question; stop when the region is tight. Aim for a handful, not a form.
+**Red flag**: Asking a question whose answer you could already predict.
+
+### 2. Choice-based, not rating-based
+**Danger**: Self-reported ratings are noisy and abstract.
+**Guardrail**: Show real contrasting talks; infer from the pick. Pair with `discovery-interviews-surveys` to avoid leading the witness.
+**Red flag**: "On a scale of 1–5…".
+
+### 3. Outlier probes are mandatory
+**Danger**: Only-central questions converge on a narrowed caricature; the niche interest is never surfaced.
+**Guardrail**: ≥1 outlier probe per run; log `type: outlier_probe`. `outlier_probes_done: 0` ⇒ profile not stable.
+
+### 4. The weights and constraints are the user's
+**Danger**: A hard-coded weighting silently decides the schedule's character.
+**Guardrail**: Elicit weights and hard constraints as choices; never default them in.
+
+### 5. Stop at stability
+**Danger**: Over-asking adds noise and annoyance.
+**Guardrail**: Stop when more questions would not move the schedule; say what is left uncertain.
+
+### 6. Stay grounded and stay interactive
+**Danger**: Abstract questions ungrounded in real talks; or running as a background task that cannot actually ask.
+**Guardrail**: Read the cluster map first; anchor every question in representative sessions. Run in the main conversation.
+
+## Quick Reference
+
+### Question-type ladder
+
+| Type | Purpose | When | Logged as |
+|---|---|---|---|
+| exploit | sharpen a suspected interest | a band you already lean on is still wide | `exploit` |
+| explore | probe an unknown theme | a band is wide and untouched (highest info gain) | `explore` |
+| outlier_probe | fight selection bias | ≥1 per run; ~1 per few exploits | `outlier_probe` |
+| weights | get the trade-off | once the interest picture is forming | `weights` |
+| constraint | capture must-attend / blackout | as it comes up | `constraint` |
+
+### Stop criterion
+
+| Signal | Threshold |
+|---|---|
+| region_tightness | ≥ ~0.7 |
+| outlier_probes_done | ≥ 1 |
+| objective_weights + hard_constraints | captured |
+| any band still wide AND decision-relevant | keep going |
+
+## Related Skills
+
+- **bayesian-reasoning-calibration**: the update rule — each answer is a likelihood that narrows a prior band, with honest calibration of how much.
+- **discovery-interviews-surveys**: question design that avoids leading, biased, or double-barreled phrasing.
+- **conf-theme-clustering**: supplies the themes the questions contrast and the outlier bucket the probes draw from.
+- **conf-schedule-optimization**: the consumer — its objective is parameterized by the weights and region this skill produces.
+
+## Examples in Context
+
+### Example 1: One question that shrinks the region
+
+Bands are wide on Agents, Evaluation, and Voice. The agent asks: "One slot, three real talks — *Building Multi-Agent Systems* (Agents), *Eval Harnesses for Production* (Evaluation), or *Realtime Speech Agents* (Voice)? Which would you walk into, and why?" The person picks Voice "because I ship a voice product." That single answer lifts the Voice floor sharply, modestly lifts Agents (the reason mentions agents), and leaves Evaluation untouched but now comparatively lower — three bands moved by one grounded question. Logged `type: explore`.
+
+### Example 2: An outlier probe that pays off
+
+Two exploits in, the agent offers the outlier: "Off the beaten path — there's a session on *Distributed Cognition in Octopuses* applied to multi-agent design. Skip, or intriguing?" The person lights up. The profile gains a serendipity signal and a real talk it would otherwise never have surfaced; `outlier_probes_done: 1`. Had the agent only ever shown central talks, this interest stays invisible and the schedule is quietly poorer.
+
+### Example 3: Eliciting the weight as a choice
+
+Near the end: "Two ways I can build this — **packed** (your highest-interest talk in every slot, short gaps) or **paced** (fewer talks, real breaks, a bit more breadth)?" The person says "paced, I burn out." That sets `objective_weights` toward `pacing`/`breadth` over raw `interest` — the user's call, captured as a choice, not a default the optimizer guessed.

--- a/skills/conf-program-extraction/SKILL.md
+++ b/skills/conf-program-extraction/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: conf-program-extraction
+description: Parse a heterogeneous conference program (markdown, HTML, PDF-derived text, or JSON) into normalized event records with per-field confidence scores and independent classification axes (topic, depth, format, prerequisites, recorded, capacity). Detects the program's format before extracting, treats every inferred field as uncertain (present vs inferred vs missing), and flags thin or missing abstracts so downstream enrichment can target them. Conference-agnostic. Use when ingesting a conference or event schedule into a structured store, normalizing a talk/session list, or extracting per-session metadata with calibrated confidence. Trigger keywords - program ingestion, parse schedule, session extraction, event records, conference program, talk metadata, per-field confidence.
+---
+
+# Conference Program Extraction
+
+A conference program is the noisiest structured document you will routinely parse. Formats differ between conferences and often between *days* of the same conference; abstracts are short, frequently missing, and written to sell rather than to classify; and the fields a downstream scheduler needs most — how advanced a talk is, whether it is recorded, whether it has a capacity cap — are almost never stated outright. They have to be *inferred*, and an inference you cannot tell apart from a fact is a liability.
+
+This skill turns raw program text into **normalized event records** in which every field carries a **calibrated confidence** and a one-line **basis**, and in which the classification signal is split into **independent axes** rather than crushed into a single blob. The governing principle is honest uncertainty: a record should make it obvious to the next stage which fields are solid, which are guessed, and which are simply absent.
+
+It does three jobs and stops: **detect the format**, **extract into the schema**, **score the confidence**. It does not enrich thin abstracts (that is `conf-abstract-enrichment`), cluster (that is `conf-theme-clustering`), or schedule. It only flags what is thin so the next agent knows where to spend effort.
+
+## The event record (output contract)
+
+The output is a single JSON file with a `meta` block (so an orchestrator can verify the stage gate without parsing every record) and an `events` array. This schema is canonical — reproduce it exactly; downstream skills read these field names.
+
+```json
+{
+  "meta": {
+    "conference_id": "string",
+    "source_ref": "path or url of the parsed program",
+    "generated_on": "YYYY-MM-DD",
+    "counts": { "total": 0, "talk": 0, "workshop": 0, "keynote": 0, "panel": 0, "other": 0 },
+    "confidence_rollup": {
+      "mean_field_confidence": 0.0,
+      "low_confidence_field_fraction": 0.0,
+      "events_with_thin_abstract": 0
+    },
+    "status": "done | partial",
+    "format_detected": "short description of the delimiter/heading pattern used"
+  },
+  "events": [
+    {
+      "id": "kebab slug, day+time+speaker+title-stub, e.g. d2-0900-laurie-voss-vibes-to-production",
+      "title": "string",
+      "speakers": [ { "name": "string", "affiliation": "string | null", "affiliation_confidence": 0.0 } ],
+      "session_type": "talk | workshop | keynote | panel | sponsor | expo | unknown",
+      "track": "string | null",
+      "room": "string | null",
+      "day": "YYYY-MM-DD | null",
+      "start": "HH:MM | null",
+      "end": "HH:MM | null",
+      "abstract_raw": "string | null",
+      "abstract_enriched": null,
+      "axes": {
+        "topic": ["string"],
+        "depth":      { "value": "intro | intermediate | advanced | unknown", "confidence": 0.0, "basis": "string" },
+        "format":     { "value": "talk | workshop | keynote | panel | unknown", "confidence": 0.0, "basis": "string" },
+        "prerequisites": { "value": ["string"], "confidence": 0.0, "basis": "string" },
+        "recorded":   { "value": true, "confidence": 0.0, "basis": "string" },
+        "capacity_constrained": { "value": true, "confidence": 0.0, "basis": "string" }
+      },
+      "enrichment": null,
+      "field_confidence": {
+        "title": 1.0, "speakers": 0.0, "track": 0.0, "room": 0.0, "time": 0.0, "abstract": 0.0
+      },
+      "source_ref": "the raw heading or line range this record came from"
+    }
+  ]
+}
+```
+
+`abstract_enriched` and `enrichment` are written as `null` here and left for `conf-abstract-enrichment` to fill. `recorded` and `capacity_constrained` use `null` for the `value` when there is genuinely no signal either way (and confidence `0.0`).
+
+## Common Patterns
+
+### Pattern 1: Detect the format before you extract
+
+**Never assume a fixed format.** Read a representative slice first and identify the *recurring shape*: the heading level that delimits a session, the field order, the inline metadata convention, the grouping (by day, by track, by time). Write what you found into `meta.format_detected`. Only then extract.
+
+A typical session line looks like one of:
+
+```
+#### 9:00am-11:00am: From Vibes to Production — Laurie Voss
+(sponsor) [Track 1] | Track: Track 1 | Status: tentative
+<abstract paragraph or "TBA">
+```
+
+The reusable move: derive a small set of regexes/anchors from the *detected* pattern (time anchor, title/speaker split on the em dash, the `(type) [room] | Track: x` metadata line), not from a format you remember from another conference. When a later day breaks the pattern, re-detect rather than forcing the old anchors.
+
+### Pattern 2: Extract independent axes, not one blob
+
+A talk is not a single label. Separate the signal into axes that vary independently, because the scheduler and the elicitor will query them independently:
+
+- **topic** (`["evaluation","agents","rag"]`) — what it is about. Multi-valued by default.
+- **depth** (`intro|intermediate|advanced`) — how much prior knowledge it assumes.
+- **format** (`talk|workshop|keynote|panel`) — how it is delivered.
+- **prerequisites** — concrete things the attendee should already know/have.
+- **recorded** — whether they can catch it later (changes its scheduling priority).
+- **capacity_constrained** — whether a seat is guaranteed (workshops usually are not).
+
+The point of separation: "advanced workshop on RAG eval, recorded, capacity-capped" is four orthogonal facts, each with its own confidence. A blob throws away the ability to say "I'm confident it's a workshop but only guessing it's advanced."
+
+### Pattern 3: Confidence is present vs inferred vs missing
+
+Every field lands in one of three states, and the confidence number must reflect which:
+
+- **Present** — stated verbatim in the program (the title, the time, an explicit "Advanced" tag). Confidence `0.9–1.0`.
+- **Inferred** — derived from a real signal but not stated. "Workshop" ⇒ `format=workshop` (strong, `~0.85`); "required prerequisites" in the abstract ⇒ `depth=advanced` (moderate, `~0.6`); session in a "101" track ⇒ `depth=intro` (moderate). Confidence `0.3–0.8` with the **basis** naming the signal.
+- **Missing** — no signal at all. `value: null`/`unknown`, confidence `0.0`, basis `"absent"`.
+
+The basis string is not decoration; it is what lets a human or the elicitor audit a low-confidence schedule decision later ("depth: advanced (0.6, inferred from 'assumes familiarity with embeddings')").
+
+### Pattern 4: Flag thin or missing abstracts — but do not fill them
+
+Mark an abstract **thin** when it is absent, "TBA", or too short/generic to classify from (a rough rule: under ~25 words, or no concrete nouns a topic could attach to). Record this in two places: a low `field_confidence.abstract`, and the `meta.confidence_rollup.events_with_thin_abstract` count. Do **not** web-search or invent text — that is `conf-abstract-enrichment`'s job, and keeping the boundary clean is what lets enrichment carry its own provenance and confidence.
+
+### Pattern 5: Handle parallel tracks and ambiguous times
+
+Conferences run many rooms at once, so the same start time appears repeatedly across the program. That is expected — do **not** dedupe by time. Each `(time, room)` pair is a distinct event. Capture `room` whenever present (it is what the scheduler turns into travel-time and overlap constraints). When a time is a range, fill both `start` and `end`; when only a start is given, leave `end: null` rather than guessing a duration.
+
+## Workflow
+
+```
+□ Step 1: Read a representative slice of the program; identify the recurring session shape.
+□ Step 2: Record the detected format in meta.format_detected; derive extraction anchors from it.
+□ Step 3: Walk the program in document order, emitting one EventRecord per session.
+□ Step 4: For each record, fill the present fields verbatim with high confidence + source_ref.
+□ Step 5: Infer the axes (depth/format/prereqs/recorded/capacity/topic) from real signals;
+          attach confidence + a one-line basis to each; use null/unknown + 0.0 where absent.
+□ Step 6: Score field_confidence per field; mark thin/missing abstracts.
+□ Step 7: Mint a stable, collision-resistant id (day+time+speaker+title-stub, kebab-case).
+□ Step 8: Compute meta.counts and meta.confidence_rollup; set status (done | partial).
+□ Step 9: Write the {meta, events} JSON; write a human-readable index.md alongside it.
+```
+
+## Guardrails
+
+### 1. Never fabricate a field
+**Danger**: A null abstract or unknown room becomes a plausible-sounding guess that the scheduler then trusts.
+**Guardrail**: Missing ⇒ `null`/`unknown` + confidence `0.0` + basis `"absent"`. The only text in `abstract_raw` is text that was in the program.
+**Red flag**: You wrote a sentence no source contained.
+
+### 2. Calibrate confidence honestly
+**Danger**: Everything gets `0.9`, so the confidence signal carries no information and the elicitor/scheduler cannot tell solid from guessed.
+**Guardrail**: Verbatim ⇒ `0.9–1.0`; strong inference ⇒ `0.6–0.85`; weak inference ⇒ `0.3–0.55`; absent ⇒ `0.0`. If you cannot name the basis, the confidence is low.
+**Red flag**: A field marked `0.9` whose basis is "seemed right".
+
+### 3. Inferred is not Present is not Missing
+**Danger**: Collapsing the three states loses exactly the information downstream stages need.
+**Guardrail**: Keep them distinct in both the value and the confidence. An inferred `advanced` and a stated `Advanced` must not look identical in the record.
+
+### 4. Preserve the source reference
+**Danger**: A wrong extraction is unauditable.
+**Guardrail**: Every record keeps `source_ref` (the raw heading or line range). A human can always trace a record back to the program.
+
+### 5. Don't collapse multi-topic talks
+**Danger**: "Evaluating agentic RAG" filed under one topic disappears from two of the three interests it actually serves.
+**Guardrail**: `axes.topic` is a list; populate all genuine topics. (Soft cross-theme membership is `conf-theme-clustering`'s job, but it can only do it if the topics survive extraction.)
+
+### 6. Don't dedupe parallel sessions
+**Danger**: Treating repeated start times as duplicates deletes real concurrent talks.
+**Guardrail**: One record per `(time, room)`. Same time, different room = two events.
+
+## Quick Reference
+
+### Axis extraction table
+
+| Axis | Values | Typical basis (when not stated) | Usual confidence |
+|---|---|---|---|
+| topic | list of strings | title + abstract nouns | 0.5–0.9 |
+| depth | intro / intermediate / advanced / unknown | "101"/"intro" wording, stated prereqs, jargon density | 0.3–0.7 |
+| format | talk / workshop / keynote / panel | session_type tag, "workshop"/"lab" in title, duration | 0.7–0.95 |
+| prerequisites | list of strings | explicit "prerequisites"/"assumes" phrasing | 0.3–0.8 |
+| recorded | true / false / null | conference-wide policy (from config), "not recorded" notes | 0.0–0.6 |
+| capacity_constrained | true / false / null | workshop/lab ⇒ likely true; main-stage talk ⇒ false | 0.3–0.8 |
+
+### Confidence rubric
+
+| State | Definition | Confidence | Example |
+|---|---|---|---|
+| Present | Stated verbatim | 0.9–1.0 | Title; "Advanced" tag; explicit time |
+| Strong inference | One clear signal | 0.6–0.85 | `(workshop)` ⇒ format=workshop |
+| Weak inference | Indirect signal | 0.3–0.55 | dense jargon ⇒ depth=advanced |
+| Absent | No signal | 0.0 | room not listed ⇒ room=null |
+
+## Related Skills
+
+- **conf-abstract-enrichment**: thickens the thin abstracts this skill flags, with its own provenance and confidence. The handoff is the `events_with_thin_abstract` flag plus low `field_confidence.abstract`.
+- **conf-theme-clustering**: consumes `axes.topic` and abstracts to build the theme map; relies on multi-topic survival.
+- **scout-mindset-bias-check**: a discipline check against motivated extraction (seeing the depth/topic you expect rather than the one the text supports).
+- **reference-class-forecasting**: useful when inferring `capacity_constrained`/`recorded` from a base rate for the session type rather than this specific listing.
+
+## Examples in Context
+
+### Example 1: A rich session line
+
+Input:
+```
+#### 9:00am-11:00am: From Vibes to Production: Evaluating and Shipping AI Agents That Work 101 — Laurie Voss
+(sponsor) [Track 1] | Track: Track 1
+Building an AI demo is easy. Knowing whether it works in production — and keeping it working — is the hard part. Hands-on: build an eval harness...
+```
+
+Record (abbreviated):
+- `title`: "From Vibes to Production: Evaluating and Shipping AI Agents That Work 101" — confidence 1.0
+- `speakers`: `[{name:"Laurie Voss", affiliation:null, affiliation_confidence:0.0}]`
+- `session_type`: "sponsor"; `room`: "Track 1"; `track`: "Track 1"; `start`:"09:00", `end`:"11:00" — all Present
+- `axes.depth`: `{value:"intro", confidence:0.6, basis:"'101' in title"}`
+- `axes.format`: `{value:"workshop", confidence:0.75, basis:"'Hands-on: build...' + 2h block"}`
+- `axes.topic`: `["evaluation","agents","production","observability"]`
+- `field_confidence.abstract`: 0.9 (rich); not flagged thin.
+
+### Example 2: A sparse expo session
+
+Input:
+```
+#### 2:30pm: Sponsor Lightning — TBA
+(expo) [Expo Stage NE]
+```
+
+Record:
+- `title`: "Sponsor Lightning" — 1.0; `speakers`: `[]`; `session_type`:"expo"; `room`:"Expo Stage NE"; `start`:"14:30", `end`:null
+- `abstract_raw`: null; `field_confidence.abstract`: 0.0 — **flagged thin** (counts toward `events_with_thin_abstract`)
+- `axes.depth`: `{value:"unknown", confidence:0.0, basis:"absent"}`
+- `axes.capacity_constrained`: `{value:false, confidence:0.5, basis:"expo stage, open seating"}`
+- Everything unsupported stays `null`/`unknown` at confidence `0.0` — the record advertises its own thinness rather than hiding it.

--- a/skills/conf-schedule-optimization/SKILL.md
+++ b/skills/conf-schedule-optimization/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: conf-schedule-optimization
+description: Build a personal conference schedule as a constraint-optimization problem — hard constraints (no time overlap, room-to-room travel time, capacity/registration, the attendee's own must-attends and blackouts) plus a user-owned weighted objective trading interest against breadth, pacing (maximize contiguous free time), and serendipity. Surfaces unbreakable conflicts (two high-value overlapping talks the model cannot rank) as decisions for the human rather than silently picking, and reports what each choice traded away. Conference-agnostic. Use to turn a preference profile plus a theme map into a day-by-day plan, to resolve overlapping sessions, or to balance a packed vs paced schedule. Trigger keywords - schedule optimization, conference schedule, constraint optimization, overlapping talks, contiguous free time, conflict surfacing, packed vs paced.
+---
+
+# Conference Schedule Optimization
+
+Choosing what to attend is a constrained optimization problem, and treating it as one is what separates a real schedule from a wishlist. Events are variables; time slots are their domain; **hard constraints** (you cannot be in two rooms at once, you need minutes to walk between them, a capped workshop may be full, you said you must catch the opening keynote) define what is *feasible*; and a **weighted objective** over the feasible plans defines what is *good*. The output is the best feasible plan **plus** an honest account of what it could not decide and what it gave up to score well.
+
+The objective is genuinely multi-term and the terms are in real conflict: maximizing **interest** fights **breadth** (seeing across themes), both fight **pacing** (a day of six back-to-back talks with fifteen-minute gaps is worse than five with a real break), and all three fight **serendipity** (deliberately leaving room for the unplanned good thing). You do not resolve this by pretending one term dominates. You jointly optimize a weighted sum whose **weights are the attendee's** — handed over from the preference profile, never invented here.
+
+Two disciplines keep it honest. **Conflict-surfacing**: when two talks overlap and both score high and the profile cannot break the tie, the system *flags it for the person* rather than quietly choosing — that flag is the natural output of a model that tracks its own uncertainty. And the **Goodhart caution**: any score you optimize produces a substitution effect somewhere the score did not name (optimize raw interest and you quietly sacrifice breaks; optimize breadth and you skip the one talk they cared about most). So the weights stay user-owned, the conflicts get surfaced, and the schedule reports what it traded away.
+
+## The output (schedule contract)
+
+```json
+{
+  "generated_on": "YYYY-MM-DD",
+  "method": "greedy-local-search | ilp",
+  "selections": [
+    {
+      "day": "YYYY-MM-DD", "start": "HH:MM", "end": "HH:MM",
+      "event_id": "...", "room": "...",
+      "score": 0.0, "why": "why this won its slot",
+      "alternatives": [ { "event_id": "...", "score": 0.0, "why_not": "why it lost / is recorded / lower affinity" } ]
+    }
+  ],
+  "free_blocks": [ { "day": "YYYY-MM-DD", "start": "HH:MM", "end": "HH:MM", "purpose": "break | buffer | travel | meal" } ],
+  "objective_breakdown": {
+    "interest": 0.0, "breadth": 0.0, "pacing": 0.0, "serendipity": 0.0,
+    "total": 0.0, "weights": { "interest": 0.0, "breadth": 0.0, "pacing": 0.0, "serendipity": 0.0 }
+  },
+  "unresolved_conflicts": [
+    {
+      "day": "YYYY-MM-DD", "slot": "HH:MM-HH:MM",
+      "candidates": ["event_id_a", "event_id_b"],
+      "why_unbreakable": "both score within epsilon; profile does not rank them",
+      "needs": "your decision"
+    }
+  ],
+  "constraints_applied": { "travel_time": "...", "capacity": "...", "hard_constraints": ["..."] },
+  "tradeoffs_note": "what the chosen weighting sacrificed (the Goodhart honesty line)"
+}
+```
+
+## Common Patterns
+
+### Pattern 1: Formulate it as a COP — hard vs soft
+
+Separate the two kinds of rule cleanly:
+
+- **Hard constraints** (feasibility — never violated): no two selections overlap in time; consecutive selections in different rooms are separated by at least the room-to-room **travel time** (from config); a `capacity_constrained` session counts only if the attendee can realistically get a seat; and the attendee's own **hard_constraints** from the profile (must-attends are forced in; blackouts/kept-free blocks are forced out).
+- **Soft objective** (quality — maximized): the weighted sum below.
+
+A plan that violates a hard constraint is not a worse plan, it is not a plan. Filter first, optimize second.
+
+### Pattern 2: The weighted objective — four terms in tension
+
+Score a candidate plan as `w_interest·Interest + w_breadth·Breadth + w_pacing·Pacing + w_serendipity·Serendipity`, with the `w`s from the profile:
+
+- **Interest** — sum of the attendee's interest (via theme affinities × region) over selected talks. The "see what I care about" term.
+- **Breadth** — coverage across distinct themes (diminishing returns on the 4th talk in one theme). The "don't tunnel" term.
+- **Pacing** — rewards **contiguous free time** and penalizes fragmentation: a plan with one real 90-minute break beats one with six scattered 15-minute gaps, even at equal talk count. Also penalizes variance from preferred times and excess travel.
+- **Serendipity** — rewards deliberately leaving slack and including the occasional outlier/exploration pick, so the plan is not a maximally-packed interest machine.
+
+### Pattern 3: Maximize contiguous free time, not just minimize gaps
+
+Anti-fragmentation deserves its own emphasis because it is the easiest thing to get wrong. Six non-adjacent talks with fifteen-minute gaps is a worse day than the same six clustered with a genuine break — the human needs contiguous recovery, hallway conversations, and food. Model free time as **blocks**, reward the *longest contiguous* block, and treat a real break as a first-class good in the objective, not as leftover space.
+
+### Pattern 4: Surface unbreakable conflicts — do not silently pick
+
+When two (or more) talks overlap, both score within an epsilon of each other, and the profile gives no basis to rank them, **flag it** in `unresolved_conflicts` with both candidates and why the model cannot break the tie. Do not flip a coin and hide it. This is the honest output of a system that knows both talks score high and that its model of the person cannot settle it alone — exactly the moment to hand the decision back. (When the profile *does* break the tie, pick, and record the loser in `alternatives` with a `why_not`.)
+
+### Pattern 5: Solve with greedy + local search by default, ILP when available
+
+- **Default (no solver deps)**: greedy seed (best feasible pick per slot, chronologically) then **local search** — swap/insert/remove moves that improve the weighted objective while staying feasible. Fast, transparent, good enough for a few-hundred-event program. This is what `resources/schedule.py` implements with numpy/pandas/networkx only.
+- **Exact (optional)**: formulate as an ILP and solve with `pulp`/`ortools` when installed and an optimum is wanted. Document the upgrade; do not require it.
+
+Record which ran in `method`.
+
+### Pattern 6: Report the trade-off (Goodhart honesty)
+
+Whatever the weights, the plan sacrificed something the weights under-counted. State it in `tradeoffs_note`: "Weighted toward interest, so day 2 is dense and breaks are short" or "Paced/breadth weighting means your single highest-interest talk was dropped for coverage." Naming the substitution is the antidote to optimizing a proxy and pretending it was the goal.
+
+## Workflow
+
+```
+□ Step 1: Load events.json, affinities.json, profile.json; load rooms + travel matrix + day bounds from config.
+□ Step 2: Force in the profile's must-attends; force out blackouts/kept-free blocks.
+□ Step 3: Build feasibility: per slot, the set of events that do not overlap, respect travel time,
+          and are seatable (capacity).
+□ Step 4: Score each event for the attendee (affinity × region interest, depth/format fit).
+□ Step 5: Greedy-seed a feasible plan; run local search to maximize the user-weighted objective.
+□ Step 6: Detect overlaps where top candidates tie within epsilon and the profile can't rank them ->
+          unresolved_conflicts (do not auto-pick).
+□ Step 7: Compute free_blocks (reward the longest contiguous block) and objective_breakdown.
+□ Step 8: Write schedule.json + schedule.md (day-by-day) + conflicts.md (decisions) + rationale.md
+          (picks, objective_breakdown, tradeoffs_note). Return the schedule.json path.
+```
+
+## Guardrails
+
+### 1. The weights are the user's
+**Danger**: A hard-coded weighting silently sets the schedule's whole character.
+**Guardrail**: Read `objective_weights` from the profile. Never invent or override them.
+**Red flag**: A default weight vector compiled into the optimizer.
+
+### 2. Surface conflicts, don't hide them
+**Danger**: A silent coin-flip on two high-value talks looks like a confident decision it isn't.
+**Guardrail**: Tie within epsilon + profile can't rank ⇒ `unresolved_conflicts`, not a pick.
+
+### 3. Protect contiguous free time
+**Danger**: A maximally-packed day reads as "optimal" and burns the human out.
+**Guardrail**: Reward the longest contiguous free block; treat a real break as a first-class objective term.
+
+### 4. Goodhart — report the substitution
+**Danger**: Optimizing one proxy quietly sacrifices an unnamed good.
+**Guardrail**: State what the weighting traded away in `tradeoffs_note`.
+
+### 5. Hard constraints are inviolable
+**Danger**: A high-scoring plan that double-books a room or skips a must-attend.
+**Guardrail**: Filter to feasible before optimizing; force must-attends in, blackouts out.
+
+### 6. No silent truncation; don't re-elicit or execute
+**Danger**: Capping candidates or writing to a calendar without saying so.
+**Guardrail**: Log any caps. Do not change the profile. Calendar export only on explicit instruction.
+
+## Quick Reference
+
+### Hard constraints
+
+| Constraint | Source | Effect |
+|---|---|---|
+| No time overlap | event times | one selection per instant |
+| Travel time | config room matrix | min gap between different-room picks |
+| Capacity / registration | `axes.capacity_constrained` | a capped session may be infeasible |
+| Must-attend / blackout | profile `hard_constraints` | forced in / forced out |
+
+### Soft objective terms
+
+| Term | Rewards | Typical signal |
+|---|---|---|
+| interest | talks the attendee cares about | affinity × region interest |
+| breadth | coverage across themes | distinct themes (diminishing returns) |
+| pacing | contiguous free time, low fragmentation, preferred times | longest free block; gap penalty |
+| serendipity | slack + occasional outlier pick | deliberate unscheduled space |
+
+### Method choice
+
+| Situation | Method |
+|---|---|
+| No solver deps (default) | greedy + local search (`resources/schedule.py`) |
+| `pulp`/`ortools` present and an optimum wanted | ILP |
+
+## Related Skills
+
+- **conf-preference-elicitation**: supplies the region, axis preferences, weights, and hard constraints that parameterize this optimization.
+- **conf-theme-clustering**: supplies the affinities used for the interest and breadth terms.
+- **decision-matrix**: a structured way to present a surfaced conflict's candidates to the human.
+- **expected-value**: for weighing a capacity-risky workshop (might be full) against a guaranteed alternative.
+- **systems-thinking-leverage**: the Goodhart/substitution lens that motivates `tradeoffs_note`.
+
+## Examples in Context
+
+### Example 1: A surfaced conflict
+
+Day 2, 11:10–11:30 has two talks scoring 0.81 and 0.79 — one on Agents, one on Retrieval, both close to the attendee's interests, and the profile does not rank Agents over Retrieval. The optimizer does **not** pick. It writes an `unresolved_conflicts` entry naming both and "both within epsilon; profile does not rank these themes," `needs: your decision`. The person settles it in one line; the schedule never pretended it had.
+
+### Example 2: Paced beats packed at equal interest
+
+Two feasible plans tie on interest. Plan A: six talks, gaps of 15–20 minutes all afternoon. Plan B: five talks plus one contiguous 80-minute afternoon block. With the attendee's `pacing`-leaning weights, Plan B scores higher — the long break is a modeled good, not wasted space — and `tradeoffs_note` records that one lower-interest talk was dropped to buy the break, which is exactly the trade the person asked for.

--- a/skills/conf-schedule-optimization/resources/schedule.py
+++ b/skills/conf-schedule-optimization/resources/schedule.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""
+schedule.py — greedy + local-search scheduler for conf-schedule-optimization.
+
+Reads the canonical artifacts (events.json, affinities.json, profile.json) plus the
+conference config (rooms, travel-time matrix, day bounds) and writes schedule.json
+matching the SCHEDULE contract in the conf-schedule-optimization skill.
+
+NO EXTERNAL SOLVER DEPENDENCIES — numpy only (stdlib otherwise). This is the default
+path; the skill documents an optional ILP upgrade (pulp/ortools) when an exact optimum
+is wanted.
+
+What it does:
+  - Filters to a FEASIBLE plan (no time overlap; room-to-room travel time; capacity;
+    the attendee's forced-in / blacked-out constraints).
+  - Optimizes a USER-WEIGHTED objective (interest, breadth, pacing, serendipity) whose
+    weights come from profile.objective_weights — never hard-coded here.
+  - SURFACES unbreakable conflicts (overlapping candidates within epsilon that the
+    profile cannot rank) instead of silently choosing.
+  - Reports objective_breakdown and a tradeoffs_note (the Goodhart honesty line).
+
+The calling agent (conf-schedule-optimizer) turns schedule.json into the human-readable
+schedule.md / conflicts.md / rationale.md.
+
+USAGE:
+  python3 schedule.py --events data/01-events/events.json \\
+      --affinities data/02-clusters/affinities.json \\
+      --profile data/03-preferences/profile.json \\
+      --config conference.config.json --out data/04-schedule/schedule.json \\
+      [--epsilon 0.05]
+"""
+
+import argparse
+import json
+import os
+from datetime import date
+
+import numpy as np
+
+
+def to_min(hhmm):
+    if not hhmm or ":" not in str(hhmm):
+        return None
+    h, m = str(hhmm).split(":")[:2]
+    return int(h) * 60 + int(m)
+
+
+def to_hhmm(minutes):
+    return f"{minutes // 60:02d}:{minutes % 60:02d}"
+
+
+def load(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def event_interest(ev_id, affinities, region, point):
+    """Interest = affinity-weighted attendee interest across the event's themes."""
+    affs = affinities.get(ev_id, [])
+    if not affs:
+        return 0.0
+    num = den = 0.0
+    for a in affs:
+        theme = a.get("theme_id")
+        aff = float(a.get("affinity", 0.0))
+        if theme in point:
+            interest = float(point[theme])
+        elif theme in region:
+            r = region[theme]
+            interest = (float(r.get("interest_lo", 0.0)) + float(r.get("interest_hi", 1.0))) / 2
+        else:
+            interest = 0.3  # unknown theme: mild prior
+        num += aff * interest
+        den += aff
+    return num / den if den else 0.0
+
+
+def travel_minutes(room_a, room_b, matrix, default):
+    if not room_a or not room_b or room_a == room_b:
+        return 0
+    key = f"{room_a}|{room_b}"
+    rkey = f"{room_b}|{room_a}"
+    overrides = matrix.get("overrides", {}) if isinstance(matrix, dict) else {}
+    return int(overrides.get(key, overrides.get(rkey, default)))
+
+
+def compatible(ev, chosen, matrix, default_travel):
+    """Feasible to add ev given already-chosen events on the same day: no overlap and
+    enough travel time between different rooms."""
+    s, e = ev["_start"], ev["_end"]
+    for c in chosen:
+        cs, ce = c["_start"], c["_end"]
+        if s < ce and cs < e:  # time overlap
+            return False
+        # adjacency: ensure travel gap between back-to-back different-room picks
+        gap = s - ce if s >= ce else cs - e
+        need = travel_minutes(ev.get("room"), c.get("room"), matrix, default_travel)
+        if 0 <= gap < need:
+            return False
+    return True
+
+
+def objective(chosen, day_bounds, weights, n_themes, outlier_ids):
+    """Weighted objective in [0,1]-ish per term. Heuristic but transparent."""
+    if not chosen:
+        return 0.0, {"interest": 0, "breadth": 0, "pacing": 0, "serendipity": 0}
+    # interest: mean selected interest
+    interest = float(np.mean([c["_interest"] for c in chosen]))
+    # breadth: distinct top-themes covered, diminishing returns
+    themes = set(c.get("_top_theme") for c in chosen if c.get("_top_theme"))
+    breadth = min(1.0, len(themes) / max(1, min(n_themes, len(chosen))))
+    # pacing: reward the longest contiguous free block per day, penalize fragmentation
+    pacing_vals = []
+    by_day = {}
+    for c in chosen:
+        by_day.setdefault(c["day"], []).append(c)
+    for day, evs in by_day.items():
+        evs = sorted(evs, key=lambda x: x["_start"])
+        lo, hi = day_bounds.get(day, (to_min("08:00"), to_min("19:00")))
+        cursor = lo
+        gaps = []
+        for c in evs:
+            if c["_start"] > cursor:
+                gaps.append(c["_start"] - cursor)
+            cursor = max(cursor, c["_end"])
+        if hi > cursor:
+            gaps.append(hi - cursor)
+        longest = max(gaps) if gaps else 0
+        small = sum(1 for g in gaps if 0 < g < 30)  # fragmentation: many tiny gaps is bad
+        span = max(1, hi - lo)
+        pacing_vals.append(min(1.0, longest / span) - 0.1 * small)
+    pacing = float(np.clip(np.mean(pacing_vals), 0, 1)) if pacing_vals else 0.0
+    # serendipity: fraction of picks that are outliers/exploration + a little slack credit
+    serendipity = min(1.0, sum(1 for c in chosen if c["event_id"] in outlier_ids) / max(1, len(chosen)) + 0.2 * (1 - interest))
+    total = (weights.get("interest", 0) * interest + weights.get("breadth", 0) * breadth
+             + weights.get("pacing", 0) * pacing + weights.get("serendipity", 0) * serendipity)
+    return total, {"interest": round(interest, 3), "breadth": round(breadth, 3),
+                   "pacing": round(pacing, 3), "serendipity": round(serendipity, 3)}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--events", required=True)
+    ap.add_argument("--affinities", required=True)
+    ap.add_argument("--profile", required=True)
+    ap.add_argument("--config", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--epsilon", type=float, default=0.05)
+    args = ap.parse_args()
+
+    edata = load(args.events)
+    events = edata.get("events", edata if isinstance(edata, list) else [])
+    aff_doc = load(args.affinities)
+    affinities = aff_doc.get("affinities", aff_doc)
+    profile = load(args.profile)
+    config = load(args.config)
+
+    region = profile.get("region", {})
+    point = profile.get("point_estimate", {})
+    weights = profile.get("objective_weights", {}) or {}
+    if not weights:
+        # The optimizer must not invent weights. If absent, halt loudly.
+        raise SystemExit("schedule.py: profile.objective_weights missing — these are user-owned; "
+                         "run conf-preference-elicitor before scheduling.")
+    forced_in = set(profile.get("forced_in", []))           # optional structured must-attend ids
+    blackouts = set(profile.get("blacked_out", []))         # optional structured drop ids
+
+    matrix = config.get("travel_time_matrix", {})
+    default_travel = int(matrix.get("default_minutes", 5))
+    outlier_ids = set()  # populated from clusters if the caller injects them; optional here
+
+    # Prepare events with parsed times + interest; skip events without a usable time/day.
+    prepared = []
+    for ev in events:
+        s, e = to_min(ev.get("start")), to_min(ev.get("end"))
+        if s is None or ev.get("day") is None:
+            continue
+        if e is None:
+            e = s + 30  # default duration when only a start is given
+        ev = dict(ev)
+        ev["_start"], ev["_end"] = s, e
+        ev["event_id"] = ev.get("id")
+        ev["_interest"] = event_interest(ev["event_id"], affinities, region, point)
+        top = affinities.get(ev["event_id"], [])
+        ev["_top_theme"] = top[0]["theme_id"] if top else None
+        if ev["event_id"] in blackouts:
+            continue
+        prepared.append(ev)
+
+    # Day bounds from config dates (fallback 08:00-19:00).
+    day_bounds = {}
+    for d in config.get("dates", []):
+        day_bounds[d] = (to_min("08:00"), to_min("19:00"))
+
+    n_themes = len({ev["_top_theme"] for ev in prepared if ev["_top_theme"]}) or 1
+
+    # ---- Greedy seed: force-ins first, then highest interest that stays feasible. ----
+    chosen_by_day = {}
+    def chosen_all():
+        return [c for v in chosen_by_day.values() for c in v]
+
+    ordered = sorted(prepared, key=lambda x: (x["event_id"] not in forced_in, -x["_interest"]))
+    for ev in ordered:
+        day = ev["day"]
+        day_chosen = chosen_by_day.setdefault(day, [])
+        if ev["event_id"] in forced_in or compatible(ev, day_chosen, matrix, default_travel):
+            day_chosen.append(ev)
+
+    # ---- Local search: try swaps (drop a weak pick to admit a better-objective set). ----
+    base_total, _ = objective(chosen_all(), day_bounds, weights, n_themes, outlier_ids)
+    improved = True
+    guard = 0
+    while improved and guard < 200:
+        improved = False
+        guard += 1
+        for ev in ordered:
+            day = ev["day"]
+            dc = chosen_by_day.setdefault(day, [])
+            if ev in dc:
+                continue
+            conflicts = [c for c in dc if not _ok_pair(ev, c, matrix, default_travel)]
+            trial = [c for c in dc if c not in conflicts] + [ev]
+            saved = chosen_by_day[day]
+            chosen_by_day[day] = trial
+            t_total, _ = objective(chosen_all(), day_bounds, weights, n_themes, outlier_ids)
+            if t_total > base_total + 1e-9 and all(x["event_id"] not in forced_in for x in conflicts):
+                base_total = t_total
+                improved = True
+            else:
+                chosen_by_day[day] = saved
+
+    chosen = sorted(chosen_all(), key=lambda x: (x["day"], x["_start"]))
+
+    # ---- Surface unbreakable conflicts: overlapping unchosen within epsilon interest. ----
+    unresolved = []
+    chosen_ids = {c["event_id"] for c in chosen}
+    for c in chosen:
+        for ev in prepared:
+            if ev["event_id"] in chosen_ids:
+                continue
+            if ev["day"] == c["day"] and ev["_start"] < c["_end"] and c["_start"] < ev["_end"]:
+                if abs(ev["_interest"] - c["_interest"]) <= args.epsilon:
+                    unresolved.append({
+                        "day": c["day"], "slot": f"{to_hhmm(c['_start'])}-{to_hhmm(c['_end'])}",
+                        "candidates": sorted([c["event_id"], ev["event_id"]]),
+                        "why_unbreakable": f"both score within {args.epsilon} interest; profile does not rank these themes",
+                        "needs": "your decision"})
+    # de-dup conflicts
+    seen = set(); uniq = []
+    for u in unresolved:
+        k = (u["day"], u["slot"], tuple(u["candidates"]))
+        if k not in seen:
+            seen.add(k); uniq.append(u)
+    unresolved = uniq
+
+    # ---- Free blocks per day. ----
+    free_blocks = []
+    by_day = {}
+    for c in chosen:
+        by_day.setdefault(c["day"], []).append(c)
+    for d, evs in by_day.items():
+        evs = sorted(evs, key=lambda x: x["_start"])
+        lo, hi = day_bounds.get(d, (to_min("08:00"), to_min("19:00")))
+        cursor = lo
+        for c in evs:
+            if c["_start"] > cursor:
+                free_blocks.append(_free(d, cursor, c["_start"]))
+            cursor = max(cursor, c["_end"])
+        if hi > cursor:
+            free_blocks.append(_free(d, cursor, hi))
+
+    total, breakdown = objective(chosen, day_bounds, weights, n_themes, outlier_ids)
+
+    selections = []
+    for c in chosen:
+        selections.append({
+            "day": c["day"], "start": to_hhmm(c["_start"]), "end": to_hhmm(c["_end"]),
+            "event_id": c["event_id"], "room": c.get("room"),
+            "score": round(c["_interest"], 3),
+            "why": ("forced in (must-attend)" if c["event_id"] in forced_in
+                    else f"highest-interest feasible pick for its slot (interest {round(c['_interest'],3)})"),
+            "alternatives": []})
+
+    out = {
+        "generated_on": date.today().isoformat(),
+        "method": "greedy-local-search",
+        "selections": selections,
+        "free_blocks": free_blocks,
+        "objective_breakdown": {**breakdown, "total": round(total, 3), "weights": weights},
+        "unresolved_conflicts": unresolved,
+        "constraints_applied": {
+            "travel_time": f"default {default_travel} min + config overrides",
+            "capacity": "capacity_constrained events admitted; agent should verify seatability",
+            "hard_constraints": sorted(list(forced_in)) + [f"drop:{b}" for b in sorted(blackouts)]},
+        "tradeoffs_note": _tradeoff_note(weights),
+    }
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    with open(args.out, "w") as f:
+        json.dump(out, f, indent=2)
+    print(f"schedule.py: {len(selections)} selections, {len(unresolved)} surfaced conflicts, "
+          f"objective total {round(total,3)} -> {args.out}")
+
+
+def _ok_pair(ev, c, matrix, default_travel):
+    s, e, cs, ce = ev["_start"], ev["_end"], c["_start"], c["_end"]
+    if s < ce and cs < e:
+        return False
+    gap = s - ce if s >= ce else cs - e
+    need = travel_minutes(ev.get("room"), c.get("room"), matrix, default_travel)
+    return not (0 <= gap < need)
+
+
+def _free(day, lo, hi):
+    dur = hi - lo
+    purpose = "meal" if dur >= 60 and 11 * 60 <= lo <= 14 * 60 else ("break" if dur >= 45 else "buffer")
+    return {"day": day, "start": to_hhmm(lo), "end": to_hhmm(hi), "purpose": purpose}
+
+
+def _tradeoff_note(weights):
+    dom = max(weights, key=weights.get) if weights else "interest"
+    notes = {
+        "interest": "Weighted toward interest — expect a denser plan with shorter breaks; lower-affinity but broadening talks were dropped.",
+        "breadth": "Weighted toward breadth — some high-interest talks were skipped to cover more themes.",
+        "pacing": "Weighted toward pacing — fewer talks, protected contiguous breaks; the marginal lower-interest talk was traded for recovery time.",
+        "serendipity": "Weighted toward serendipity — deliberate slack and an outlier pick were kept at the cost of one higher-interest slot.",
+    }
+    return notes.get(dom, "Balanced weighting; minor trade-offs across all terms.")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/conf-theme-clustering/SKILL.md
+++ b/skills/conf-theme-clustering/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: conf-theme-clustering
+description: Cluster a conference's event records into a small set of coarse themes with finer sub-clusters, an explicit outlier bucket, and soft (multi-membership) affinities — using the hybrid embed-then-label pipeline (embed abstracts, reduce, density-cluster, then LLM-label the clusters) when embedding libraries are available, and an LLM-reasoned hierarchical fallback when they are not. Embeddings do the grouping; the LLM only names the groups. Conference-agnostic. Use when turning structured event records into a navigable theme map for preference elicitation and scheduling, when you need 6-8 reasonable themes rather than 20 muddy ones, or when overlapping talks must belong to more than one theme. Trigger keywords - theme clustering, cluster talks, embed then label, soft membership, outlier talks, conference themes, topic map.
+---
+
+# Conference Theme Clustering
+
+The job is to turn a few hundred event records into a map a person can actually reason over: a handful of **coarse themes**, each openable into **sub-clusters**, with the genuinely odd talks set aside in an **outlier bucket** rather than forced into a theme, and with each talk allowed to belong to **more than one theme** because real talks do. The map is the substrate everything downstream stands on — the elicitor grounds its questions in these themes, and the scheduler uses theme coverage to reward breadth.
+
+The method that holds up is **hybrid, not pure-LLM-per-item and not the conference's own track labels**. Embeddings do the grouping because that step must be cheap and stable across runs; an LLM does only the labeling because that is the step that needs to read like a human wrote it. Running an LLM to decide every talk's cluster is costly and varies run to run; using the conference's published tracks throws away the cross-track structure that is often the most interesting thing in the program.
+
+Four findings shape the design, and each is a guardrail later: **embeddings group / LLM labels**; **keep the outliers** (density clustering hands you an outlier set — that is a feature); **cluster coarse, then fine** (6–8 abstract themes separate far more cleanly than 20 fine-grained ones); and **soft multi-membership** (a single hard cluster mis-represents a talk like "evaluating agentic RAG" that legitimately lives in evaluation *and* agents *and* retrieval).
+
+## The outputs (two contracts)
+
+### Cluster map — `clusters.json`
+
+```json
+{
+  "method": "embed-hdbscan | llm-reasoned",
+  "generated_on": "YYYY-MM-DD",
+  "stability_note": "how stable these clusters are; what would move a talk",
+  "coarse_themes": [
+    {
+      "id": "T1",
+      "label": "human-readable theme name",
+      "gloss": "one sentence: what unifies this theme",
+      "size": 0,
+      "representative_event_ids": ["..."],
+      "subclusters": [
+        { "id": "T1.1", "label": "...", "gloss": "...", "event_ids": ["..."] }
+      ]
+    }
+  ],
+  "outliers": [ { "event_id": "...", "why": "why it fits no theme — often why it is interesting" } ]
+}
+```
+
+### Soft affinities — `affinities.json`
+
+```json
+{
+  "generated_on": "YYYY-MM-DD",
+  "top_k": 3,
+  "affinities": {
+    "<event_id>": [ { "theme_id": "T1", "affinity": 0.0 }, { "theme_id": "T4", "affinity": 0.0 } ]
+  }
+}
+```
+
+Every event appears in `affinities` with its top-k theme affinities (descending). An outlier still gets affinities — its top affinity is just low, which is exactly what marks it as an outlier.
+
+## Common Patterns
+
+### Pattern 1: The embed → reduce → cluster → label pipeline
+
+When embedding libraries are available (`resources/cluster.py`):
+
+1. **Embed** each event's text (enriched abstract if present, else raw abstract + title + topics) into a vector. Text embeddings, not an LLM call per item.
+2. **Reduce** dimensionality (UMAP) so density structure is visible.
+3. **Density-cluster** (HDBSCAN) — it groups what is dense and **leaves the rest as noise**, which becomes the outlier bucket. It does not force every point into a cluster.
+4. **Label** each resulting cluster with an LLM: read the representative members, write the `label` + `gloss`. This is the *only* LLM step in the grouping, and it touches clusters, not items.
+
+The division of labor is the whole point: the deterministic step decides *who is grouped with whom* (stable, cheap), the language step decides *what to call the group* (fluent, human).
+
+### Pattern 2: Coarse first, then fine
+
+Aim for **6–8 coarse themes** — few enough to hold in your head and to ground elicitation questions in. Get the coarse layer by clustering at low resolution (or merging fine clusters up). Then, within each coarse theme, expose **sub-clusters** for the talks that share a tighter sub-topic. Do not ship 20 flat clusters: at that resolution the boundaries blur and the elicitor cannot present a clean "A vs B" contrast. Coarse-with-drill-down beats flat-and-many.
+
+### Pattern 3: Keep the outliers as a first-class bucket
+
+The talks that fit no dense region are not noise to be hidden — they are frequently the cross-disciplinary, against-the-grain sessions that a curious attendee most wants surfaced. Put them in `outliers` with a `why`, and make sure they survive into elicitation (the elicitor's selection-bias probes draw from exactly here). Forcing an outlier into the nearest theme both corrupts that theme and buries the talk.
+
+### Pattern 4: Soft multi-membership, not a hard partition
+
+A hard assignment says a talk is *only* about evaluation. Reality is fuzzier. Give every event its **top-k theme affinities** (k≈3): the cosine similarity to each theme centroid (or HDBSCAN soft-membership probabilities), normalized. Now "I'm interested in agents" and "I'm interested in evaluation" both surface the agentic-eval talk, instead of it hiding in whichever single bucket it landed. The coarse map stays clean for navigation; the affinities carry the overlap.
+
+### Pattern 5: The LLM-reasoned fallback (no embedding libs)
+
+When `sentence-transformers`/`umap-learn`/`hdbscan` are unavailable, or N is small enough that density clustering is unstable, cluster by reasoning over the already-extracted `axes.topic` and abstracts:
+
+1. Group events by topic co-occurrence into ~6–8 coarse themes; name each.
+2. Split each theme into sub-clusters by tighter sub-topic.
+3. Mark as outliers the events whose topics match no theme well.
+4. Assign top-k affinities by judged topical closeness to each theme's gloss (0–1).
+
+Set `method: "llm-reasoned"` and a `stability_note` flagging that the grouping is reasoning-derived (less reproducible than embeddings). The fallback produces the same two output contracts — downstream stages cannot tell which method ran except by reading `method`.
+
+### Pattern 6: Record the method and its stability
+
+Always set `method` and write a `stability_note`: how reproducible the clusters are, and what would move a talk between themes. Clustering is a modeling choice, not ground truth; the note is what lets the elicitor and the human treat theme boundaries as provisional rather than as fact.
+
+## Workflow
+
+```
+□ Step 1: Load events.json; assemble each event's text (enriched abstract ?? raw abstract + title + topics).
+□ Step 2: Choose the method. Try resources/cluster.py (embed-hdbscan). On missing libs / tiny N, use the
+          LLM-reasoned fallback. Record the choice in method.
+□ Step 3: Produce the grouping — coarse clusters with a noise/outlier set.
+□ Step 4: Collapse/merge to 6-8 coarse themes; expose sub-clusters inside each.
+□ Step 5: LLM-label each coarse theme and sub-cluster (label + gloss) from representative members.
+□ Step 6: Build the outlier bucket with a why per event.
+□ Step 7: Compute top-k soft affinities for every event (including outliers).
+□ Step 8: Write clusters.json + affinities.json + a human-readable clusters.md tour. Set stability_note.
+```
+
+## Guardrails
+
+### 1. Embeddings group, the LLM only labels
+**Danger**: Asking an LLM to assign every talk to a cluster — costly, and the assignment shifts run to run.
+**Guardrail**: The grouping step is deterministic (embeddings/topics); the LLM names clusters, not items.
+**Red flag**: A per-event LLM "which cluster?" call in the grouping loop.
+
+### 2. Never drop the outliers
+**Danger**: Forcing every talk into a theme corrupts the theme and hides the most interesting sessions.
+**Guardrail**: Maintain `outliers` as a first-class bucket with a `why`; pass it forward.
+
+### 3. Soft membership, not a hard partition
+**Danger**: One-cluster-per-talk makes overlapping talks invisible to all but one interest.
+**Guardrail**: Every event carries top-k affinities. The coarse map is for navigation; affinities carry the overlap.
+
+### 4. Coarse before fine
+**Danger**: 20 flat clusters blur boundaries and break clean elicitation contrasts.
+**Guardrail**: 6–8 coarse themes, sub-clusters on demand.
+
+### 5. Declare the method and its stability
+**Danger**: Treating provisional clusters as ground truth.
+**Guardrail**: Set `method` + `stability_note`; downstream stages treat boundaries as provisional.
+
+### 6. Don't re-extract or schedule
+**Danger**: Scope creep — re-deriving axes or making schedule picks.
+**Guardrail**: Consume the EventRecords as given; output only the map + affinities.
+
+## Quick Reference
+
+### The pipeline at a glance
+
+| Step | Operation | Who does it | Output |
+|---|---|---|---|
+| Embed | text → vector | embedding model | per-event vectors |
+| Reduce | high-dim → low-dim | UMAP | reduced vectors |
+| Cluster | density grouping | HDBSCAN | clusters + noise(outliers) |
+| Label | name the cluster | LLM | label + gloss |
+| Soft-assign | top-k affinities | cosine / soft-membership | affinities.json |
+
+### Method choice
+
+| Situation | Method | Note |
+|---|---|---|
+| Embedding libs present, N ≳ 30 | `embed-hdbscan` via `resources/cluster.py` | most stable |
+| No libs, or N small | `llm-reasoned` fallback | record lower stability |
+| Either | always | 6–8 coarse + sub-clusters + outliers + soft affinities |
+
+## Related Skills
+
+- **conf-program-extraction**: supplies the EventRecords (topics + abstracts) this skill clusters; multi-topic survival there enables soft membership here.
+- **conf-preference-elicitation**: the primary consumer — it grounds choice-based questions in these coarse themes and draws selection-bias probes from the outlier bucket.
+- **conf-schedule-optimization**: uses theme coverage (via affinities) to reward breadth in the objective.
+- **abstraction-concrete-examples**: useful when writing theme glosses that name the abstraction yet point at concrete member talks.
+
+## Examples in Context
+
+### Example 1: A theme with a sub-cluster and an overlap
+
+Coarse theme `T3` "Evaluation & Reliability" (gloss: "measuring whether agents/models actually work and keeping them working"), sub-cluster `T3.2` "Agent eval harnesses". The talk "Evaluating Agentic RAG" lands in `T3.2` by hard clustering — but its `affinities` are `[{T3,0.71},{T5_Agents,0.66},{T2_Retrieval,0.58}]`, so it also surfaces when the attendee says "I care about agents" or "I care about retrieval." The hard map stays clean; the soft affinities carry the truth.
+
+### Example 2: A genuine outlier
+
+"What Octopuses Teach Us About Distributed Cognition" matches no dense region. It goes to `outliers` with `why: "biology/cognition crossover; no topical neighbors in this program"`. It still gets affinities (top affinity ~0.3 to "Agents"), and the elicitor later offers it as a deliberate selection-bias probe — the kind of talk a narrowed model of the attendee would never surface on its own.

--- a/skills/conf-theme-clustering/resources/cluster.py
+++ b/skills/conf-theme-clustering/resources/cluster.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+cluster.py — the embed -> reduce -> density-cluster path for conf-theme-clustering.
+
+Reads an events.json ({meta, events:[...]}) produced by conf-program-extraction and
+writes clusters.json + affinities.json matching the canonical schemas in the
+conf-theme-clustering skill.
+
+DIVISION OF LABOR (important):
+  - This script does the GROUPING only: embeddings -> UMAP -> HDBSCAN -> representative
+    members -> *provisional* labels (from the most common topics in each cluster) ->
+    soft top-k affinities (cosine to cluster centroids).
+  - It does NOT do human-quality LABELING. That is the one LLM step. The calling agent
+    (conf-theme-cartographer) reads the representative members and rewrites each theme's
+    `label` and `gloss`. Provisional labels here are placeholders so the file is valid.
+
+GRACEFUL FALLBACK:
+  If the embedding/clustering libraries are not installed, this script prints the exact
+  pip install line and exits non-zero (code 3). The agent then falls back to the
+  LLM-reasoned hierarchical method described in the skill. Missing libraries are a
+  normal, expected branch — not an error to debug.
+
+USAGE:
+  python3 cluster.py --events data/01-events/events.json --out-dir data/02-clusters \\
+      [--coarse-target 7] [--top-k 3] [--model all-MiniLM-L6-v2]
+"""
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import date
+
+REQUIRED = ["numpy", "sentence_transformers", "umap", "hdbscan", "sklearn"]
+PIP_LINE = "pip install numpy sentence-transformers umap-learn hdbscan scikit-learn"
+
+
+def _check_libs():
+    """Return (ok, missing[]). Import lazily so the no-deps fallback path stays clean."""
+    import importlib
+    missing = []
+    for name in REQUIRED:
+        try:
+            importlib.import_module(name)
+        except Exception:
+            missing.append(name)
+    return (len(missing) == 0, missing)
+
+
+def _event_text(ev):
+    """Assemble the text we embed: enriched abstract if present, else raw abstract,
+    always reinforced with the title and extracted topics so short abstracts still
+    carry signal."""
+    parts = []
+    if ev.get("title"):
+        parts.append(ev["title"])
+    abstract = ev.get("abstract_enriched") or ev.get("abstract_raw") or ""
+    if abstract:
+        parts.append(abstract)
+    topics = (ev.get("axes") or {}).get("topic") or []
+    if topics:
+        parts.append("Topics: " + ", ".join(topics))
+    return ". ".join(parts).strip() or (ev.get("title") or ev.get("id", "untitled"))
+
+
+def _provisional_label(member_topics):
+    """A placeholder label from the most common topics in a cluster. The LLM replaces it."""
+    if not member_topics:
+        return "(unlabeled cluster)"
+    common = [t for t, _ in Counter(member_topics).most_common(3)]
+    return " / ".join(common)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--events", required=True)
+    ap.add_argument("--out-dir", required=True)
+    ap.add_argument("--coarse-target", type=int, default=7,
+                    help="rough number of coarse themes desired (guides min_cluster_size)")
+    ap.add_argument("--top-k", type=int, default=3, help="affinities kept per event")
+    ap.add_argument("--model", default="all-MiniLM-L6-v2")
+    args = ap.parse_args()
+
+    ok, missing = _check_libs()
+    if not ok:
+        sys.stderr.write(
+            "conf-theme-clustering: embedding pipeline unavailable (missing: "
+            + ", ".join(missing) + ").\n"
+            "Install with:\n    " + PIP_LINE + "\n"
+            "Or fall back to the LLM-reasoned hierarchical method (see SKILL.md).\n")
+        sys.exit(3)
+
+    import numpy as np
+    from sentence_transformers import SentenceTransformer
+    import umap
+    import hdbscan
+
+    with open(args.events) as f:
+        data = json.load(f)
+    events = data.get("events", data if isinstance(data, list) else [])
+    if not events:
+        sys.stderr.write("conf-theme-clustering: no events found in input.\n")
+        sys.exit(2)
+
+    ids = [ev.get("id") or f"event-{i}" for i, ev in enumerate(events)]
+    texts = [_event_text(ev) for ev in events]
+    topics_by_idx = [((ev.get("axes") or {}).get("topic") or []) for ev in events]
+
+    # --- Embed ---
+    model = SentenceTransformer(args.model)
+    emb = model.encode(texts, normalize_embeddings=True, show_progress_bar=False)
+    emb = np.asarray(emb, dtype="float32")
+
+    # --- Reduce: UMAP to a low dimension where density structure is visible. ---
+    n = len(events)
+    n_neighbors = max(2, min(15, n - 1))
+    reducer = umap.UMAP(n_neighbors=n_neighbors, n_components=min(5, max(2, n - 2)),
+                        metric="cosine", random_state=42)
+    reduced = reducer.fit_transform(emb)
+
+    # --- Density-cluster: HDBSCAN. min_cluster_size scaled so we land near coarse-target. ---
+    min_cluster_size = max(2, n // max(args.coarse_target, 1))
+    clusterer = hdbscan.HDBSCAN(min_cluster_size=min_cluster_size, metric="euclidean")
+    labels = clusterer.fit_predict(reduced)  # -1 == noise == outlier
+
+    # --- Cluster centroids in embedding space (for soft affinities + representatives). ---
+    unique = sorted(set(int(l) for l in labels if l != -1))
+    centroids = {}
+    for cl in unique:
+        idxs = [i for i, l in enumerate(labels) if l == cl]
+        centroids[cl] = emb[idxs].mean(axis=0)
+
+    def cosine(a, b):
+        denom = (np.linalg.norm(a) * np.linalg.norm(b)) or 1.0
+        return float(np.dot(a, b) / denom)
+
+    # --- Build coarse themes with representative members + provisional labels. ---
+    coarse_themes = []
+    theme_id_of_cluster = {}
+    for rank, cl in enumerate(unique, start=1):
+        tid = f"T{rank}"
+        theme_id_of_cluster[cl] = tid
+        idxs = [i for i, l in enumerate(labels) if l == cl]
+        # representatives: members closest to the centroid
+        c = centroids[cl]
+        ranked = sorted(idxs, key=lambda i: -cosine(emb[i], c))
+        reps = [ids[i] for i in ranked[:min(5, len(ranked))]]
+        member_topics = [t for i in idxs for t in topics_by_idx[i]]
+        coarse_themes.append({
+            "id": tid,
+            "label": _provisional_label(member_topics),     # LLM rewrites this
+            "gloss": "(provisional — replace with an LLM-written one-sentence gloss)",
+            "size": len(idxs),
+            "representative_event_ids": reps,
+            "subclusters": [],                               # optional: agent may split further
+        })
+
+    # --- Outliers: HDBSCAN noise points. Kept as a first-class bucket. ---
+    outliers = []
+    for i, l in enumerate(labels):
+        if l == -1:
+            outliers.append({"event_id": ids[i],
+                             "why": "no dense topical neighborhood in this program (HDBSCAN noise)"})
+
+    # --- Soft affinities: cosine to every theme centroid, top-k, for EVERY event. ---
+    affinities = {}
+    for i in range(n):
+        sims = []
+        for cl in unique:
+            sims.append((theme_id_of_cluster[cl], cosine(emb[i], centroids[cl])))
+        sims.sort(key=lambda x: -x[1])
+        top = sims[:args.top_k] if sims else []
+        # rescale cosine [-1,1] -> [0,1] so affinities read as memberships
+        affinities[ids[i]] = [{"theme_id": t, "affinity": round((s + 1) / 2, 3)} for t, s in top]
+
+    today = date.today().isoformat()
+    clusters_doc = {
+        "method": "embed-hdbscan",
+        "generated_on": today,
+        "stability_note": (f"embed({args.model}) -> UMAP -> HDBSCAN(min_cluster_size="
+                           f"{min_cluster_size}); {len(unique)} coarse themes, "
+                           f"{len(outliers)} outliers. Labels are provisional pending LLM relabel. "
+                           "Re-running with the same inputs is reproducible (random_state fixed)."),
+        "coarse_themes": coarse_themes,
+        "outliers": outliers,
+    }
+    affinities_doc = {"generated_on": today, "top_k": args.top_k, "affinities": affinities}
+
+    import os
+    os.makedirs(args.out_dir, exist_ok=True)
+    with open(os.path.join(args.out_dir, "clusters.json"), "w") as f:
+        json.dump(clusters_doc, f, indent=2)
+    with open(os.path.join(args.out_dir, "affinities.json"), "w") as f:
+        json.dump(affinities_doc, f, indent=2)
+
+    sys.stderr.write(
+        f"conf-theme-clustering: wrote {len(coarse_themes)} coarse themes + "
+        f"{len(outliers)} outliers to {args.out_dir}.\n"
+        "NOTE: theme labels/glosses are provisional — the conf-theme-cartographer agent "
+        "must relabel them from the representative members before the map is used.\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

A conference-agnostic toolkit for building a personalized conference schedule, added to the plugin.

**6 agents** — `conf-director` (opus orchestrator) + 5 specialists:
- `conf-program-ingestor` — Stage 1: program → confidence-scored event records + independent axes; fans out enrichment
- `conf-enrichment-researcher` — isolated web-research sub-worker that turns thin abstracts into provenance-backed signal
- `conf-theme-cartographer` — Stage 2: embed-then-label clustering → 6–8 themes + outlier bucket + soft multi-membership affinities
- `conf-preference-elicitor` — Stage 3 (interactive): a few grounded, choice-based questions over a preference region, with deliberate outlier probes
- `conf-schedule-optimizer` — Stage 4: constraint optimization under user-owned weights; protects contiguous free time; surfaces conflicts
- `conf-director` — runs the 4-stage state machine, gates on per-stage confidence, guards frozen invariants, never auto-commits

**6 skills** (+ two no-/optional-dependency scripts): `conf-program-extraction`, `conf-abstract-enrichment`, `conf-theme-clustering` (+ `cluster.py`), `conf-preference-elicitation`, `conf-schedule-optimization` (+ `schedule.py`), `conf-pipeline-orchestration`.

## Design

- Pipeline: **ingest → cluster → elicit (interactive) → schedule.**
- Explicit per-stage uncertainty: confidence travels with the data and governs each stage gate.
- Agents communicate only through schema-shaped JSON artifacts (no free-text handoffs).
- The orchestrator is an aggregator-with-recurrence: it guards frozen safety invariants (stuck-detector, kill-switch, escalation thresholds), holds a diversity floor (mandatory outlier probes), concentrates hardening on the fragile elicit→schedule handoff, and surfaces conflicts + trade-offs rather than auto-committing (Goodhart-aware).
- **Conference-agnostic:** every conference specific (config, data-flow dirs, state machine, runbook) lives in a separate per-conference workflow folder, never in these agents.

## README

Grouped the new agents and skills into appropriate places: a quickstart row, an architecture-diagram node, the Orchestrating Agents rows, and a new **Conference scheduling (6)** pack in the Skills Index (skill counts updated).

## Conformance

- Agents use consistent XML-tagged sections (`<role>` / `<inputs>` / `<outputs>` / `<returns>` / `<methodology>` / `<must_nots>`), scoped tools, and `model` set per role (opus for the two reasoning agents, inherit for workers).
- Skills pass the authoring rules (name, description ≤ 1024 chars, body < 500 lines).
- Python and JSON syntax-checked; no personal absolute paths and no conference specifics in the library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
