### PR TITLE
Add readability-check skill + wire prose-quality skills into agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Claude Code Skills Collection
 
-![Skills](https://img.shields.io/badge/skills-241-blue) ![Agents](https://img.shields.io/badge/agents-62-blue) ![Status](https://img.shields.io/badge/status-active-brightgreen) [![Run in Smithery](https://smithery.ai/badge/skills/lyndonkl)](https://smithery.ai/skills?ns=lyndonkl&utm_source=github&utm_medium=badge)
+![Skills](https://img.shields.io/badge/skills-248-blue) ![Agents](https://img.shields.io/badge/agents-68-blue) ![Status](https://img.shields.io/badge/status-active-brightgreen) [![Run in Smithery](https://smithery.ai/badge/skills/lyndonkl)](https://smithery.ai/skills?ns=lyndonkl&utm_source=github&utm_medium=badge)
 
-A production-ready library of **241 skills** and **62 orchestrating agents** for Claude Code — covering thinking frameworks, research, writing, design, data/ML, corporate finance, game theory, fantasy baseball, an evolutionary 10-agent FIFA World Cup fantasy backroom, household personal finance, a 9-agent team for growing a Substack publication, and a 9-agent learning studio for becoming a contributor to ML-driven crop genetics / genomic selection.
+A production-ready library of **248 skills** and **68 orchestrating agents** for Claude Code — covering thinking frameworks, research, writing, design, data/ML, corporate finance, game theory, fantasy baseball, an evolutionary 10-agent FIFA World Cup fantasy backroom, household personal finance, a 9-agent team for growing a Substack publication, and a 9-agent learning studio for becoming a contributor to ML-driven crop genetics / genomic selection.
 
 **Install in 30 seconds:**
 
@@ -11,7 +11,7 @@ A production-ready library of **241 skills** and **62 orchestrating agents** for
 /plugin install thinking-frameworks-skills
 ```
 
-> **Note:** A small number of skills wrap native CLI tools (currently only [`markdown-to-pdf`](skills/markdown-to-pdf/SKILL.md), which needs `pandoc` and a LaTeX engine). Those tools must be installed separately. See [Optional native dependencies](#optional-native-dependencies) below. **All other skills work out of the box.**
+> **Note:** Two skills need something installed separately: [`markdown-to-pdf`](skills/markdown-to-pdf/SKILL.md) needs `pandoc` and a LaTeX engine, and [`readability-check`](skills/readability-check/SKILL.md) needs the `textstat` Python package. See [Optional dependencies](#optional-native-dependencies) below. **Every other skill works out of the box.**
 
 ---
 
@@ -61,7 +61,7 @@ flowchart LR
     D -->|Learn crop genomics| BIO[biostat-tutor<br/>+ 8 specialists]
     D -->|Plan a conference| CONF[conf-director<br/>+ 5 specialists]
     D -->|One-off tool| SK[Skills Index ▾]
-    CA & PS & WA & SF & CD & MLB & WC & HF & GR & GDL & MI & LSC & BIO & CONF --> S[(247 skills)]
+    CA & PS & WA & SF & CD & MLB & WC & HF & GR & GDL & MI & LSC & BIO & CONF --> S[(248 skills)]
     SK --> S
 ```
 
@@ -154,6 +154,7 @@ If you do not want to install the tools below, simply do not invoke the skills t
 | Skill | Native dependency | Why it's needed | Install (macOS) | Install (Linux / Debian) |
 |---|---|---|---|---|
 | [`markdown-to-pdf`](skills/markdown-to-pdf/SKILL.md) | `pandoc` and a LaTeX engine (`xelatex`) | Renders a finished markdown report to an analyst-style PDF. The LaTeX engine produces the typography. Without these tools the skill cannot run; it has no fallback rendering path. | `brew install pandoc basictex`<br/>`sudo tlmgr update --self`<br/>`sudo tlmgr install xetex` | `sudo apt install pandoc texlive-xetex texlive-fonts-recommended` |
+| [`readability-check`](skills/readability-check/SKILL.md) | `textstat` (Python package) | Computes the five readability formulas. Without it the skill prints the exact install command and exits; it does not guess scores. | `python3 -m pip install --user textstat` | `python3 -m pip install --user textstat` |
 
 `basictex` on macOS is about 90 MB. Do not install `mactex` unless you specifically need the full LaTeX stack (~5 GB).
 
@@ -169,7 +170,7 @@ If you run `product-strategist` without `pandoc` or `xelatex` installed, the age
 
 ## Skills Index
 
-**247 skills** across 8 super-categories. Every skill's full methodology, templates, and evaluation rubric live in its `SKILL.md` — click any entry to drill in.
+**248 skills** across 8 super-categories. Every skill's full methodology, templates, and evaluation rubric live in its `SKILL.md` — click any entry to drill in.
 
 <details>
 <summary><b>🧠 Thinking & Decisions</b> — decision-making, problem-solving, estimation, dialogue, ideation, learning (37 skills)</summary>
@@ -273,6 +274,7 @@ Domain-neutral primitives for any weekly paper-digest workflow. Powers the `lite
 - **[writing-revision](skills/writing-revision/SKILL.md)** — Run the three-pass revision: clutter, cognitive load, rhythm.
 - **[writing-stickiness](skills/writing-stickiness/SKILL.md)** — Make messages memorable using the Heath SUCCESs framework.
 - **[writing-pre-publish-checklist](skills/writing-pre-publish-checklist/SKILL.md)** — Final 6-section quality gate before publishing.
+- **[readability-check](skills/readability-check/SKILL.md)** — Score prose on Flesch, Flesch-Kincaid, SMOG, Gunning Fog, and Dale-Chall; rewrite the sentences that fail.
 - **[communication-storytelling](skills/communication-storytelling/SKILL.md)** — Craft narratives using arcs, tension, and audience framing.
 - **[translation-reframing-audience-shift](skills/translation-reframing-audience-shift/SKILL.md)** — Adapt content for a new audience without losing accuracy.
 - **[one-pager-prd](skills/one-pager-prd/SKILL.md)** — Write concise one-pagers and PRDs for stakeholder alignment.
@@ -595,7 +597,7 @@ Pairs with a companion learning vault (Kolb curriculum, Zettelkasten evergreen n
 /plugin install thinking-frameworks-skills
 ```
 
-All 241 skills become available immediately. Claude invokes them automatically based on your request and each skill's trigger description.
+All 248 skills become available immediately. Claude invokes them automatically based on your request and each skill's trigger description.
 
 <details>
 <summary><b>Option 2 — Manual install</b></summary>

--- a/agents/acquisition-analyst.md
+++ b/agents/acquisition-analyst.md
@@ -2,7 +2,7 @@
 name: acquisition-analyst
 description: Evaluates M&A targets by computing standalone value, synergy value, and maximum acquisition price. Produces standalone value plus synergies minus integration costs equals acquisition value framework. Use when evaluating acquisition targets, computing synergy value, determining bid price, analyzing mergers, or when user mentions M&A, acquisition valuation, synergy analysis, merger premium, or target valuation.
 tools: Read, Grep, Glob, WebSearch, WebFetch
-skills: business-narrative-builder, financial-statement-analyzer, cost-of-capital-estimator, intrinsic-valuation-dcf, relative-valuation-multiples, project-investment-analyzer, special-situations-valuation, valuation-reconciler
+skills: business-narrative-builder, financial-statement-analyzer, cost-of-capital-estimator, intrinsic-valuation-dcf, relative-valuation-multiples, project-investment-analyzer, special-situations-valuation, valuation-reconciler, slop-detector, readability-check, strategist-voice
 model: opus
 ---
 

--- a/agents/biostat-coach.md
+++ b/agents/biostat-coach.md
@@ -1,6 +1,7 @@
 ---
 name: biostat-coach
 description: Curriculum coach for the learnbiostats studio. Holds the whole-program view — tracks the learner's position across phases and modules (`curriculum/`, `progress/`), decides what to study next given prerequisites and mastery, paces the plan against a daily cadence, and surfaces the spaced-repetition queue (the evergreen notes and modules whose review-due date has arrived). Reads the trackers and proposes updates to the status board, skills matrix, and journal. Use to plan the week, ask "what's next?", check pacing, or pull today's review queue. Proposes the plan and the tracker edits; the human approves, and nothing is committed to git or published autonomously.
+skills: slop-detector, readability-check
 tools: Read, Grep, Glob, Write, Edit, Skill
 model: inherit
 ---

--- a/agents/biostat-editor.md
+++ b/agents/biostat-editor.md
@@ -1,6 +1,7 @@
 ---
 name: biostat-editor
 description: Advisory-only editor for spoken-out, dictated essays in the learnbiostats studio. Directs STRUCTURE, flags grammar, and suggests strategic language — but never modifies the writer's text unless the writer explicitly says "apply"/"rewrite this." Deliberately has no Write/Edit/Bash tools, so it physically cannot alter a draft; it returns a line-referenced, suggestion-only critique. Use to review a draft (writing/drafts/*.md), critique a spoken article, run a structural/line/voice pass, or do a pre-publish check. Grounded in the advisory-edit and learning-in-public-voice skills.
+skills: slop-detector, readability-check, voice-check
 tools: Read, Grep, Glob, WebSearch, Skill
 model: inherit
 ---

--- a/agents/biostat-emergence.md
+++ b/agents/biostat-emergence.md
@@ -1,6 +1,7 @@
 ---
 name: biostat-emergence
 description: Bottom-up cluster-finder for the learnbiostats vault. Reads the evergreen/ knowledge graph and proposes structure notes when a real cluster has formed — a minimum of 4 related evergreen notes before a cluster is "ready," and flags over-large clusters (>12 notes) for splitting. Mirrors the reference vault's Emergence agent: structure is discovered from the notes, never imposed a priori. Use when the writer asks "find clusters", "what structure notes are ready?", "is this idea solid enough to write up?", or runs the periodic emergence scan. Proposes structure-note drafts; the writer approves before anything is saved.
+skills: slop-detector, readability-check
 tools: Read, Grep, Glob, Write, Skill
 model: inherit
 ---

--- a/agents/biostat-lab.md
+++ b/agents/biostat-lab.md
@@ -1,6 +1,7 @@
 ---
 name: biostat-lab
 description: Lab and project mentor for the learnbiostats studio. Designs and reviews the experiential projects and capstones (`projects/`, `projects/capstone/`), scaffolds and runs analysis code against real genomics/phenotype data, and enforces the two disciplines that keep an ML genetics result honest: cross-validation (no leakage across folds, families, or environments) and predict-then-check (state the expected result before running). Grounded in the design-of-experiments and code-data-analysis-scaffolds skills. Use to spec a new project, review a learner's analysis, debug a pipeline, or pressure-test a model's evaluation. Scaffolds and runs code in the project workspace; proposes deliverables and claims, but never commits to git or publishes autonomously — the human approves and ships.
+skills: slop-detector, readability-check
 tools: Read, Grep, Glob, Write, Edit, Bash, WebSearch, Skill
 model: inherit
 ---

--- a/agents/biostat-scribe.md
+++ b/agents/biostat-scribe.md
@@ -1,6 +1,7 @@
 ---
 name: biostat-scribe
 description: Generative note/post writer for the learnbiostats studio. Assembles publish-ready, Obsidian-vault-style notes and Substack-ready posts FROM the writer's own evergreen claims — composition from existing material, never invention of claims the writer has not made. Writes in the writer's voice (learning-in-public-voice lens, overridden by writing/voice-profile.md). Every sentence traces to an evergreen note (provenance recorded). Use to turn a cluster of evergreen notes into a post draft, draft a vault note from a reading, or scaffold a post the writer will then speak/refine. NOT an editor of the writer's prose — that boundary belongs to biostat-editor.
+skills: slop-detector, readability-check, voice-check
 tools: Read, Grep, Glob, Write, WebSearch, Skill
 model: inherit
 ---

--- a/agents/biostat-tutor.md
+++ b/agents/biostat-tutor.md
@@ -1,6 +1,7 @@
 ---
 name: biostat-tutor
 description: Socratic, experiential tutor for the learnbiostats studio. Runs a single learning module as a live session through the full Kolb cycle (Concrete Experience → Reflective Observation → Abstract Conceptualization → Active Experimentation), grounded in the experiential-kolb-teaching skill. NEVER summarizes the material for the learner — it draws the claim out of them by question, then routes each earned claim into the evergreen layer via the zettel-note discipline. Use to start or continue a module session (`curriculum/modules/pNmM-*.md`), to teach a concept the learner is stuck on, or to turn a reading into earned understanding. Proposes a session note and candidate evergreen notes; never writes to the vault, commits, or publishes without the human's go-ahead.
+skills: slop-detector, readability-check
 tools: Read, Grep, Glob, Write, WebSearch, WebFetch, Skill
 model: inherit
 ---

--- a/agents/capital-allocation-strategist.md
+++ b/agents/capital-allocation-strategist.md
@@ -2,7 +2,7 @@
 name: capital-allocation-strategist
 description: Advises on capital allocation decisions including financing mix (debt vs equity), dividend policy, share buybacks, and project investment evaluation. Integrates financial analysis, cost of capital, capital structure optimization, dividend/buyback policy, and project NPV/IRR analysis into a unified recommendation. Use when user asks about capital allocation strategy, optimal debt level, dividend policy, project investment decisions, whether to raise debt or equity, or how to deploy excess cash.
 tools: Read, Grep, Glob, WebSearch, WebFetch
-skills: financial-statement-analyzer, cost-of-capital-estimator, capital-structure-optimizer, dividend-buyback-analyzer, project-investment-analyzer
+skills: financial-statement-analyzer, cost-of-capital-estimator, capital-structure-optimizer, dividend-buyback-analyzer, project-investment-analyzer, slop-detector, readability-check, strategist-voice
 model: sonnet
 ---
 

--- a/agents/cognitive-design-architect.md
+++ b/agents/cognitive-design-architect.md
@@ -2,7 +2,7 @@
 name: cognitive-design-architect
 description: An orchestrating agent that collaboratively helps designers apply cognitive science principles to create effective visual interfaces, data visualizations, educational content, and presentations. Guides users through cognitive foundations, information architecture, D3 visualization implementation, storytelling, design evaluation, and fallacy prevention. Use when user mentions cognitive design, visual hierarchy, dashboard design, data visualization, design review, cognitive load, or creating cognitively aligned interfaces.
 tools: Read, Grep, Glob, WebSearch, WebFetch
-skills: cognitive-design, information-architecture, d3-visualization, visual-storytelling-design, design-evaluation-audit, cognitive-fallacies-guard
+skills: cognitive-design, information-architecture, d3-visualization, visual-storytelling-design, design-evaluation-audit, cognitive-fallacies-guard, slop-detector, readability-check
 model: inherit
 ---
 

--- a/agents/company-analyst.md
+++ b/agents/company-analyst.md
@@ -2,7 +2,7 @@
 name: company-analyst
 description: End-to-end company analysis pipeline for standard, profitable companies. Orchestrates business narrative, financial statement cleanup, cost of capital estimation, intrinsic (DCF) and relative (multiples) valuation, capital structure optimization, dividend/buyback policy assessment, and final valuation reconciliation into an investment recommendation. Use when user asks for a complete company analysis, equity valuation, fair value estimate, or investment recommendation for a publicly traded, profitable company.
 tools: Read, Write, Grep, Glob, WebSearch, WebFetch
-skills: business-narrative-builder, financial-statement-analyzer, cost-of-capital-estimator, intrinsic-valuation-dcf, relative-valuation-multiples, capital-structure-optimizer, dividend-buyback-analyzer, valuation-reconciler
+skills: business-narrative-builder, financial-statement-analyzer, cost-of-capital-estimator, intrinsic-valuation-dcf, relative-valuation-multiples, capital-structure-optimizer, dividend-buyback-analyzer, valuation-reconciler, slop-detector, readability-check, strategist-voice
 model: opus
 ---
 

--- a/agents/conf-director.md
+++ b/agents/conf-director.md
@@ -2,7 +2,7 @@
 name: conf-director
 description: Master orchestrator for the conference-scheduling pipeline. Runs the four-stage state machine (ingest -> cluster -> elicit -> schedule) across a team of specialist agents, talking to them only through schema-shaped artifacts, verifying each stage's confidence at a gate before advancing, holding and integrating outputs rather than passing them through, freezing its own safety logic against an invariants lock, enforcing the elicitor's outlier-probe diversity floor, surfacing conflicts to the human, and never auto-committing a schedule. Reusable across conferences — takes the conference config and data root as inputs and hardcodes no conference specifics. Use as the entry point for building a personalized conference schedule, or to resume a partially-run pipeline. Trigger keywords - plan my conference, build my schedule, run the conference pipeline, schedule orchestrator.
 tools: Read, Write, Edit, Bash, Grep, Glob, Agent(conf-program-ingestor, conf-enrichment-researcher, conf-theme-cartographer, conf-preference-elicitor, conf-schedule-optimizer)
-skills: conf-pipeline-orchestration, systems-thinking-leverage, deliberation-debate-red-teaming, dialectical-mapping-steelmanning, communication-storytelling
+skills: conf-pipeline-orchestration, systems-thinking-leverage, deliberation-debate-red-teaming, dialectical-mapping-steelmanning, communication-storytelling, slop-detector, readability-check, strategist-voice
 model: opus
 ---
 

--- a/agents/curator.md
+++ b/agents/curator.md
@@ -2,7 +2,7 @@
 name: curator
 description: Shape-watcher for the substacker publication. Every 4-6 weeks reads the accumulating corpus, proposes emerging sections (when active-launch is not pre-planned), audits drift on existing sections, maintains section-map.md and per-section profiles. Also handles active mode — classifies drafts into sections, derives per-section voice overlays once a section has 3+ posts, hands off visual identity to cognitive-design-architect. Use every 4-6 weeks for the standard cycle, or on-demand when launching a section. Trigger keywords: curator, sections, section map, section cluster, drift audit, prune, section launch, classify post.
 tools: Read, Write, Edit, Grep, Glob
-skills: check-corpus-readiness, cluster-corpus-by-theme, propose-section, write-section-promise, audit-drift, recommend-prune, update-section-map, classify-post-to-section, derive-section-voice-overlay
+skills: check-corpus-readiness, cluster-corpus-by-theme, propose-section, write-section-promise, audit-drift, recommend-prune, update-section-map, classify-post-to-section, derive-section-voice-overlay, slop-detector, readability-check, voice-check
 model: inherit
 ---
 

--- a/agents/distribution-translator.md
+++ b/agents/distribution-translator.md
@@ -2,7 +2,7 @@
 name: distribution-translator
 description: Turns each published substacker essay into platform-native rewrites. Primary platforms: LinkedIn post + Substack Note + cross-poster blurb (writer's preferred distribution surface). Optional: X thread (generated only if the essay translates well to X; otherwise skipped cleanly). Platform-native reshaping, not paste-same-text-everywhere. Preserves the writer's voice. User posts manually — no auto-posting. Use within 24h of any published post or on specific-platform re-translation requests. Trigger keywords: distribution, translate, LinkedIn post, Substack Note, cross-post, social distribution, amplify, X thread optional.
 tools: Read, Write, Grep, Glob
-skills: extract-thread-spine, hook-generator, linkedin-post-rewrite, substack-note-rewrite, cross-poster-blurb, x-thread-rewrite, platform-voice-check
+skills: extract-thread-spine, hook-generator, linkedin-post-rewrite, substack-note-rewrite, cross-poster-blurb, x-thread-rewrite, platform-voice-check, slop-detector, readability-check, voice-check
 model: inherit
 ---
 

--- a/agents/editor.md
+++ b/agents/editor.md
@@ -2,7 +2,7 @@
 name: editor
 description: Two-pass review (structural + voice) on substacker drafts. Produces marked-up critique, never a replacement draft. Flags voice-don'ts (delve, unpack, paradigm shift, generic opener), catches hedges that weaken rather than specify, blocks AI-explainer slop, verifies opener/closer/analogy-weight/rhythm/citation-form/section-breaks. Loads global voice-profile + per-section voice overlay. Use before publishing any draft. Trigger keywords: edit, review, voice check, structural pass, critique, pre-publish, does this sound like me, slop check.
 tools: Read, Grep, Glob, Write
-skills: structural-review, voice-check, hedge-detector, slop-detector, opener-critique, closer-critique, analogy-weight-check, paragraph-rhythm-check, citation-form-check, section-break-check
+skills: structural-review, voice-check, hedge-detector, slop-detector, opener-critique, closer-critique, analogy-weight-check, paragraph-rhythm-check, citation-form-check, section-break-check, readability-check
 model: inherit
 ---
 

--- a/agents/geometric-deep-learning-architect.md
+++ b/agents/geometric-deep-learning-architect.md
@@ -2,7 +2,7 @@
 name: geometric-deep-learning-architect
 description: An orchestrating agent that collaboratively helps ML engineers apply group theory and symmetry principles to neural network design. Guides users through symmetry discovery, validation, group identification, equivariant architecture design, and model verification. Use when user mentions symmetry, invariance, equivariance, group theory in ML, or geometric deep learning.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
-skills: symmetry-discovery-questionnaire, symmetry-group-identifier, symmetry-validation-suite, equivariant-architecture-designer, model-equivariance-auditor
+skills: symmetry-discovery-questionnaire, symmetry-group-identifier, symmetry-validation-suite, equivariant-architecture-designer, model-equivariance-auditor, slop-detector, readability-check
 model: inherit
 ---
 

--- a/agents/graphrag-specialist.md
+++ b/agents/graphrag-specialist.md
@@ -2,7 +2,7 @@
 name: graphrag-specialist
 description: An orchestrating agent that collaboratively helps engineers build graph-based retrieval-augmented generation systems. Guides users through knowledge graph construction, embedding strategy design, retrieval orchestration, system integration, and evaluation. Use when user mentions knowledge graph, GraphRAG, graph retrieval, entity extraction for RAG, Neo4j with LLM, or building graph-augmented AI systems.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
-skills: knowledge-graph-construction, embedding-fusion-strategy, retrieval-search-orchestration, graphrag-system-design, graphrag-evaluation
+skills: knowledge-graph-construction, embedding-fusion-strategy, retrieval-search-orchestration, graphrag-system-design, graphrag-evaluation, slop-detector, readability-check
 model: inherit
 ---
 

--- a/agents/growth-analyst.md
+++ b/agents/growth-analyst.md
@@ -2,7 +2,7 @@
 name: growth-analyst
 description: Weekly Substack performance analyzer for substacker. Pulls stats directly from the Substack dashboard via Claude-in-Chrome browser automation (primary) or ingests a manual CSV export (fallback). Computes rolling 4-week baseline, attributes over/under-performance in plain English with calibrated confidence, tracks per-section metrics once sections exist, produces a 400-800 word weekly report. Feeds Curator (section pruning) and Growth Strategist (quarterly rollups). Use Monday mornings. Trigger keywords: growth, stats, weekly report, Substack analytics, subscribers, open rate, per-section performance, Chrome stats, auto fetch.
 tools: Read, Write, Edit, Grep, Glob, Bash, WebFetch, mcp__claude-in-chrome__tabs_context_mcp, mcp__claude-in-chrome__tabs_create_mcp, mcp__claude-in-chrome__navigate, mcp__claude-in-chrome__get_page_text, mcp__claude-in-chrome__read_page, mcp__claude-in-chrome__find, mcp__claude-in-chrome__javascript_tool
-skills: fetch-substack-stats, ingest-substack-csv, compute-baseline, attribute-performance, per-section-tracking, fetch-public-page-stats, write-weekly-report, update-audience-notes
+skills: fetch-substack-stats, ingest-substack-csv, compute-baseline, attribute-performance, per-section-tracking, fetch-public-page-stats, write-weekly-report, update-audience-notes, slop-detector, readability-check, voice-check
 model: inherit
 ---
 

--- a/agents/growth-strategist.md
+++ b/agents/growth-strategist.md
@@ -2,7 +2,7 @@
 name: growth-strategist
 description: Quarterly strategic advisor for substacker. Synthesizes the corpus, Curator's section map, Growth Analyst's rolled-up weekly data, and writer's stated goals into a 1500-3000 word review. Surfaces three uncomfortable questions (evidence + reasoning + downside), assesses section portfolio, proposes goal diffs, names one bet for the next quarter, identifies kill list. Rolling 13-week windows, NOT calendar quarters. Use quarterly or on-demand when a specific strategic decision is pending (e.g., "should I launch paid?"). Trigger keywords: quarterly, strategic review, zoomout, uncomfortable questions, paid tier, product hiding, kill list, goals reset.
 tools: Read, Write, Edit, Grep, Glob
-skills: quarterly-zoomout, answer-uncomfortable-question, section-portfolio-assessment, product-hiding-scan, paid-tier-readiness-check, goal-reset-proposal, identify-kill-list
+skills: quarterly-zoomout, answer-uncomfortable-question, section-portfolio-assessment, product-hiding-scan, paid-tier-readiness-check, goal-reset-proposal, identify-kill-list, slop-detector, readability-check, strategist-voice
 model: inherit
 ---
 

--- a/agents/household-cfo.md
+++ b/agents/household-cfo.md
@@ -2,7 +2,7 @@
 name: household-cfo
 description: Master orchestrator and synthesizer for the household finance team. Runs the per-drop pipeline (intake → bookkeeper → spending/vigilance/savings/investments/tax in parallel → CFO synthesis), the monthly briefing pipeline, the weekly dashboard generation, and the on-demand chat mode where the user asks ad-hoc finance questions. Produces the one-page monthly briefing the household actually reads — net-worth snapshot, four numbers (income / spend / savings rate / Δ net worth), three wins, three issues with owners and actions, goals dashboard, and a 30-day look-ahead. Always grounds in data, never executes financial actions. Use as the entry point for any household finance interaction — drops, monthly briefs, weekly dashboards, or ad-hoc questions.
 tools: Read, Grep, Glob, Bash, Write, Edit
-skills: communication-storytelling, dialectical-mapping-steelmanning, deliberation-debate-red-teaming
+skills: communication-storytelling, dialectical-mapping-steelmanning, deliberation-debate-red-teaming, slop-detector, readability-check, strategist-voice
 model: opus
 ---
 

--- a/agents/intuition-builder.md
+++ b/agents/intuition-builder.md
@@ -2,7 +2,7 @@
 name: intuition-builder
 description: Generates 5 distinct intuitive framings for a technical topic the writer wants to explain — everyday analogy, physical metaphor, contrarian, historical, counterfactual. Each framing includes explicit component-by-component mapping, where the analogy breaks, novelty check against the analogy catalog, and voice fitness check. Produces seeds the writer picks from, never finished drafts. Use when the writer asks for framings for a topic, wants candidate analogies, or mentions "intuition", "analogy", "metaphor", "framings", "explain X intuitively".
 tools: Read, Grep, Glob, Write
-skills: generate-analogy-set, check-analogy-novelty, stress-test-analogy, map-analogy-to-concept, propose-counterfactual, update-analogy-catalog, voice-fitness-check
+skills: generate-analogy-set, check-analogy-novelty, stress-test-analogy, map-analogy-to-concept, propose-counterfactual, update-analogy-catalog, voice-fitness-check, slop-detector, readability-check, voice-check
 model: inherit
 ---
 

--- a/agents/ipo-strategist.md
+++ b/agents/ipo-strategist.md
@@ -2,7 +2,7 @@
 name: ipo-strategist
 description: Guides private-to-public transition valuation and IPO pricing strategy. Transitions from total beta to market beta, removes illiquidity discount, uses public comparable multiples for pricing, and optimizes capital structure for public markets. Produces pre-IPO valuation, post-IPO fair value, and recommended pricing range. Use when planning an IPO, pricing a public offering, transitioning from private to public valuation, or when user mentions IPO valuation, IPO pricing, going public, or pre-IPO vs post-IPO value.
 tools: Read, Grep, Glob, WebSearch, WebFetch
-skills: business-narrative-builder, financial-statement-analyzer, cost-of-capital-estimator, special-situations-valuation, relative-valuation-multiples, capital-structure-optimizer, valuation-reconciler
+skills: business-narrative-builder, financial-statement-analyzer, cost-of-capital-estimator, special-situations-valuation, relative-valuation-multiples, capital-structure-optimizer, valuation-reconciler, slop-detector, readability-check, strategist-voice
 model: opus
 ---
 

--- a/agents/literature-scan-coach.md
+++ b/agents/literature-scan-coach.md
@@ -2,7 +2,7 @@
 name: literature-scan-coach
 description: Search worker for one keyword query across bioRxiv, medRxiv, PubMed, and arXiv. Spawned by an orchestrator that's running a fan-out (one coach per expanded query). Receives a date window, a single query, and an arXiv category list; fetches all four sources in parallel via the fetch-* skills; dedupes within the four sources for this one query (DOI first, then normalized title + first-author surname); returns the deduped paper-records list as a JSON array directly in the response. Writes no files. Does not extract, summarize, cluster, synthesize, or filter — those belong to other agents in the pipeline. Use when an orchestrator needs a search-only subagent for one query at a time. Trigger keywords - search papers, fetch papers for query, single-query literature search, paper search subagent.
 tools: WebFetch
-skills: fetch-preprint-recent, fetch-pubmed-recent, fetch-arxiv-recent
+skills: fetch-preprint-recent, fetch-pubmed-recent, fetch-arxiv-recent, slop-detector, readability-check
 model: inherit
 ---
 

--- a/agents/macroeconomic-analyst.md
+++ b/agents/macroeconomic-analyst.md
@@ -1,6 +1,7 @@
 ---
 name: macroeconomic-analyst
 description: Researches a single assigned trend category in depth via web search and produces a structured trend report covering sub-trends, value chains, beneficiary archetypes, pricing-in assessment, risks, and watch-indicators. Receives the trend category, anchor questions, and an output path as inputs, and writes its report to that path. Use when deep, sourced research is needed on a specific thematic trend cluster — secular technological shifts, demographic transitions, geopolitical realignments, regulatory regime changes, monetary or fiscal regime shifts, climate and resource constraints, or asset class concentration cycles.
+skills: slop-detector, readability-check, strategist-voice
 tools: Read, Write, WebSearch, WebFetch
 model: opus
 ---

--- a/agents/math-intuition-coach.md
+++ b/agents/math-intuition-coach.md
@@ -2,7 +2,7 @@
 name: math-intuition-coach
 description: An ML/data math intuition coach that explains anything involving vectors, matrices, transformations, or high-dimensional spaces in the style of 3Blue1Brown — geometric first, algebraic second, with an explicit bridge between them. Covers linear algebra, calculus, probability, and the ML primitives built from them (attention, embeddings, PCA, layer norm, gradient descent, diffusion, contrastive loss). Use when user wants intuitive understanding of an ML or math concept, asks "why does X work geometrically", needs the picture behind an equation, or mentions eigenvectors, attention, covariance, Jacobian, gradient, embeddings, softmax, or high-dimensional spaces.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch, Skill
-skills: concept-rediscovery-walk, geometric-algebraic-bridge, ml-primitive-decoder, high-dim-intuition-rebuild, worked-example-walkthrough
+skills: concept-rediscovery-walk, geometric-algebraic-bridge, ml-primitive-decoder, high-dim-intuition-rebuild, worked-example-walkthrough, slop-detector, readability-check
 model: inherit
 ---
 

--- a/agents/mlb-fantasy-coach.md
+++ b/agents/mlb-fantasy-coach.md
@@ -2,7 +2,7 @@
 name: mlb-fantasy-coach
 description: Orchestrates a multi-agent team for Yahoo Fantasy Baseball management. Spawns specialists (lineup, waiver, streaming, trade, category, playoff) each in advocate + critic variants, runs dialectical-mapping-steelmanning synthesis, deliberation-debate-red-teaming stress tests, and produces plain-English morning briefs for a user with zero baseball knowledge. Use when running morning brief, weekly kickoff, evaluating trades, or any Yahoo Fantasy Baseball decision for the user's league.
 tools: Read, Grep, Glob, Write, Edit, WebSearch, WebFetch, Bash
-skills: communication-storytelling, dialectical-mapping-steelmanning, deliberation-debate-red-teaming, mlb-league-state-reader, mlb-decision-logger, mlb-beginner-translator, mlb-opponent-profiler, opponent-archetype-classifier
+skills: communication-storytelling, dialectical-mapping-steelmanning, deliberation-debate-red-teaming, mlb-league-state-reader, mlb-decision-logger, mlb-beginner-translator, mlb-opponent-profiler, opponent-archetype-classifier, slop-detector, readability-check
 model: opus
 ---
 

--- a/agents/paper-synthesizer.md
+++ b/agents/paper-synthesizer.md
@@ -2,7 +2,7 @@
 name: paper-synthesizer
 description: Two-mode synthesis worker for paper digests. The orchestrator picks the mode per invocation; you do not know whether other invocations have run before or after you. **Mode A** reads one paper's extraction notes and writes a reader-facing per-paper summary (headline + summary + specifics, with all hedging preserved) to a markdown file. **Mode B** reads a folder of per-paper summaries, clusters them by theme, writes the final digest as a reader-facing document (headline + themes with per-paper bullets nested in + outliers), writes the kept+dropped papers list, and appends a one-line context note to each per-paper summary file. Both modes ground their writing in the operator's stated topics and report-shape, which the orchestrator passes in as file paths (watchlist + standing style, with optional per-run overrides). Returns just the file path; status fields live in the file's frontmatter. Does not extract papers, fetch papers, or run a relevance filter — those are upstream agents. Trigger keywords - paper synthesis, paper digest, single-paper translation, clustered paper digest, cluster papers and write digest.
 tools: Read, Write, Edit, Glob
-skills: layered-reasoning, translation-reframing-audience-shift, paper-cluster-by-theme
+skills: layered-reasoning, translation-reframing-audience-shift, paper-cluster-by-theme, slop-detector, readability-check
 model: inherit
 ---
 

--- a/agents/product-strategist.md
+++ b/agents/product-strategist.md
@@ -2,7 +2,7 @@
 name: product-strategist
 description: Reverse-engineers a product from the outside to produce a layered strategist analysis of its vision, competitive strategy, tactical initiatives, operational surface, and the ML and systems architecture likely sitting behind its key features. Captures freeform per-step reasoning as analyst working notes in a scratchpad directory, consolidates those notes into a structured analyst-style markdown report following the strategist-voice house style, and renders that report to PDF via the markdown-to-pdf skill. Receives a product or company name, an optional focusing directive, and an output path. Use when building a holistic mental model of a real product, mapping how a company's vision flows down into its tactics and system architecture, or producing an opinionated strategist read on a product's metrics and system decomposition from publicly available material. PDF rendering requires pandoc and a LaTeX engine on the user's machine.
 tools: Read, Write, Bash, WebSearch, WebFetch
-skills: business-narrative-builder, strategy-and-competitive-analysis, layered-reasoning, metrics-tree, retrieval-search-orchestration, mapping-visualization-scaffolds, systems-thinking-leverage, communication-storytelling, strategist-voice, markdown-to-pdf
+skills: business-narrative-builder, strategy-and-competitive-analysis, layered-reasoning, metrics-tree, retrieval-search-orchestration, mapping-visualization-scaffolds, systems-thinking-leverage, communication-storytelling, strategist-voice, markdown-to-pdf, slop-detector, readability-check
 model: opus
 ---
 

--- a/agents/scientific-writing-editor.md
+++ b/agents/scientific-writing-editor.md
@@ -2,7 +2,7 @@
 name: scientific-writing-editor
 description: An orchestrating agent for scientific writing that routes requests to specialized skills for manuscripts, grants, letters, emails, career documents, and cross-cutting clarity review. Provides multi-pass editing following structured workflows with document-type-specific frameworks. Use when user needs help with scientific or academic writing.
 tools: Read, Edit, Grep, Glob, WebSearch, WebFetch
-skills: scientific-manuscript-review, grant-proposal-assistant, academic-letter-architect, scientific-email-polishing, career-document-architect, scientific-clarity-checker
+skills: scientific-manuscript-review, grant-proposal-assistant, academic-letter-architect, scientific-email-polishing, career-document-architect, scientific-clarity-checker, slop-detector, readability-check, voice-check
 model: inherit
 ---
 

--- a/agents/special-situations-analyst.md
+++ b/agents/special-situations-analyst.md
@@ -2,7 +2,7 @@
 name: special-situations-analyst
 description: Handles edge-case valuations for companies that break standard DCF assumptions. Covers four situation types: high-growth firms with negative earnings (revenue-based DCF with failure adjustment), distressed firms (equity-as-call-option via Black-Scholes), private companies (total beta and liquidity discount), and financial services firms (excess return model). Use when valuing unprofitable startups, distressed companies, private firms, banks, insurance companies, or companies with negative earnings.
 tools: Read, Grep, Glob, WebSearch, WebFetch
-skills: business-narrative-builder, financial-statement-analyzer, cost-of-capital-estimator, special-situations-valuation, relative-valuation-multiples, valuation-reconciler
+skills: business-narrative-builder, financial-statement-analyzer, cost-of-capital-estimator, special-situations-valuation, relative-valuation-multiples, valuation-reconciler, slop-detector, readability-check, strategist-voice
 model: opus
 ---
 

--- a/agents/superforecaster.md
+++ b/agents/superforecaster.md
@@ -2,7 +2,7 @@
 name: superforecaster
 description: An elite forecasting agent that orchestrates reference class forecasting, Fermi decomposition, Bayesian updating, premortems, and bias checking. Adheres to the "Outside View First" principle and generates granular, calibrated probabilities with comprehensive analysis. Use when user asks for forecast, prediction, or probability estimate.
 tools: Read, Grep, Glob, WebSearch, WebFetch
-skills: reference-class-forecasting, estimation-fermi, bayesian-reasoning-calibration, forecast-premortem, scout-mindset-bias-check
+skills: reference-class-forecasting, estimation-fermi, bayesian-reasoning-calibration, forecast-premortem, scout-mindset-bias-check, slop-detector, readability-check, strategist-voice
 model: inherit
 ---
 

--- a/agents/technical-reviewer.md
+++ b/agents/technical-reviewer.md
@@ -2,7 +2,7 @@
 name: technical-reviewer
 description: Pre-publish ML/systems claim check for substacker drafts. Extracts atomic technical claims from prose, classifies each as simplified-correct / simplified-boundary / wrong / contested / overclaim, cross-references primary sources (arXiv, RFC, textbooks — never blog posts), flags boundary-breaks as teaching opportunities to fold into the post. Never rewrites the draft. 48h research cap per draft. Use after Editor approves voice and before the writer publishes a post that makes technical claims (especially Agent Workshop posts). Trigger keywords: technical review, fact-check, claim check, ML claim, simplified vs wrong, boundary break, cross-reference paper.
 tools: Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
-skills: claim-extractor, classify-claim, cross-reference-claim, flag-boundary-break, write-review-artifact, glossary-alignment-check
+skills: claim-extractor, classify-claim, cross-reference-claim, flag-boundary-break, write-review-artifact, glossary-alignment-check, slop-detector, readability-check, voice-check
 model: inherit
 ---
 

--- a/agents/trend-scout.md
+++ b/agents/trend-scout.md
@@ -2,7 +2,7 @@
 name: trend-scout
 description: Weekly ML/systems signal radar for substacker. Scans ~30-50 curated intuition-first sources (Olah, Weng, Karpathy, Jay Alammar, Raschka, Willison, Transformer Circuits, Interconnects, arXiv cs.LG, Hugging Face papers, etc.) for signal-not-noise items, cross-references against topic-ledger, produces a lean digest of ≤10 items. Weekly Friday evening. Not daily. Trigger keywords: trends, ML news, weekly digest, signal, watchlist, external signal, what's new in ML.
 tools: Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
-skills: fetch-watchlist-sources, summarize-signal, cross-ref-topic-ledger, rank-by-user-fit, write-weekly-digest, update-watchlist
+skills: fetch-watchlist-sources, summarize-signal, cross-ref-topic-ledger, rank-by-user-fit, write-weekly-digest, update-watchlist, slop-detector, readability-check, voice-check
 model: inherit
 ---
 

--- a/agents/wc-director.md
+++ b/agents/wc-director.md
@@ -2,7 +2,7 @@
 name: wc-director
 description: User-facing orchestrator for FIFA World Cup Fantasy. Runs the evolutionary generation loop — spawns archetype strategist teams in parallel, drives fitness/selection/recombination via wc-evolution-engine, has specialists adversarially verify the offspring, then presents a DECISION BOARD of 2-4 weighted options and STOPS for the expert manager to choose. Advisory not prescriptive: surfaces options with full reasoning and dissent, never auto-commits a squad/XI/captain/transfer/chip. Manages the tournament state machine. Use to build the matchday board, build/rebuild a squad, plan a transfer window, decide a chip, or review a round.
 tools: Read, Grep, Glob, Write, Edit, Bash, WebSearch, WebFetch, Agent(wc-strategist, wc-evolution-engine, wc-synthesis, wc-scout, wc-fixture-analyst, wc-ownership-analyst, wc-squad-architect, wc-matchday-tactician, wc-chip-strategist)
-skills: wc-tournament-state, wc-decision-board, wc-decision-logger, wc-signal-emitter, communication-storytelling, dialectical-mapping-steelmanning, deliberation-debate-red-teaming
+skills: wc-tournament-state, wc-decision-board, wc-decision-logger, wc-signal-emitter, communication-storytelling, dialectical-mapping-steelmanning, deliberation-debate-red-teaming, slop-detector, readability-check
 model: opus
 ---
 

--- a/agents/writing-assistant.md
+++ b/agents/writing-assistant.md
@@ -2,7 +2,7 @@
 name: writing-assistant
 description: An orchestrating agent for writing that routes requests to specialized skills for structure planning, revision, stickiness enhancement, and pre-publishing checks. Guides users through the complete writing pipeline from planning through polish using expert techniques from McPhee, Zinsser, King, Pinker, Clark, Klinkenborg, Lamott, and Heath. Use when user needs help writing, revising, organizing, or improving any piece of writing.
 tools: Read, Edit, Grep, Glob, WebSearch, WebFetch
-skills: writing-structure-planner, writing-revision, writing-stickiness, writing-pre-publish-checklist
+skills: writing-structure-planner, writing-revision, writing-stickiness, writing-pre-publish-checklist, slop-detector, readability-check, voice-check
 model: inherit
 ---
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,29 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}\"/skills/readability-check/hooks/readability_hook.py",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}\"/skills/readability-check/hooks/readability_hook.py",
+            "timeout": 15,
+            "statusMessage": "Checking readability..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/skills/readability-check/SKILL.md
+++ b/skills/readability-check/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: readability-check
+description: Scores prose with Flesch Reading Ease, Flesch-Kincaid Grade, SMOG, Gunning Fog, and Dale-Chall, reports every score on one shared grade-band scale, and rewrites the sentences that fail. Runs on markdown files or on piped draft text before it is sent, and can run automatically through Claude Code hooks. Use before delivering any substantial written output, when a draft reads as convoluted or bloated, when a document must hit a reading-level target, or when checking a folder of documents for prose quality. Trigger keywords: readability, reading level, Flesch, Flesch-Kincaid, SMOG, Gunning Fog, Dale-Chall, grade level, hard to read, convoluted, dense prose, plain language, reading ease.
+---
+
+# Readability Check
+
+## Contents
+
+- [Quick start](#quick-start)
+- [Profiles](#profiles)
+- [Workflow](#workflow)
+- [Revision moves](#revision-moves)
+- [Reading the five formulas together](#reading-the-five-formulas-together)
+- [Run it automatically](#run-it-automatically)
+- [Guardrails](#guardrails)
+- [Reference files](#reference-files)
+
+**Related skills:** `slop-detector` catches AI-explainer patterns, `hedge-detector` catches weak hedging, `voice-check` and `strategist-voice` catch voice violations. This skill catches *structural* unreadability — sentence length and word difficulty — which the others do not measure. Run this last, after voice and slop passes.
+
+## Quick start
+
+Requires `textstat`. If missing, the script prints the install line and exits 3:
+
+```bash
+python3 -m pip install --user textstat
+```
+
+**Check draft prose before sending it** — the most common use:
+
+```bash
+cat <<'EOF' | python3 resources/readability.py --stdin --profile general
+[the draft text]
+EOF
+```
+
+**Check files:**
+
+```bash
+python3 resources/readability.py doc.md --profile technical
+python3 resources/readability.py docs/ --recursive --profile general
+python3 resources/readability.py doc.md --json          # machine-readable
+```
+
+Exit code is 0 on pass, 1 on fail, 3 if textstat is missing. The script strips code fences, tables, headings, and link URLs before scoring, because readability formulas are only valid on continuous prose.
+
+Output reports each formula with its raw score **and a grade band**, plus the band most of them agree on:
+
+```
+FAIL  primer.md
+      4934 words / 297 sentences of prose   →  reads at: college
+      Flesch Reading Ease 39.8 (college)
+      Flesch-Kincaid      11.7 (high school)
+      Gunning Fog         14.6 (college)
+      Dale-Chall          12.4 (college)
+      SMOG                13.6 (college)
+      ✗ Flesch Reading Ease 39.8 < 40.0
+      ✗ 12 sentence(s) over 40 words
+```
+
+## Profiles
+
+| Profile | Reading Ease ≥ | FK ≤ | Fog ≤ | SMOG ≤ | Dale-Chall ≤ | Sentence words ≤ | Use for |
+|---|---|---|---|---|---|---|---|
+| `technical` | 40 | 14 | 16 | 14 | 12.9 | 40 | Engineering or scientific prose where terminology is load-bearing |
+| `general` (default) | 50 | 12 | 14 | 12 | 8.9 | 35 | Explanatory writing for a competent non-specialist |
+| `public` | 60 | 9 | 11 | 10 | 6.9 | 25 | Public-facing copy |
+
+Pick by audience, not by what the draft happens to score. Threshold rationale and the shared band scale are in [methodology.md](resources/methodology.md).
+
+## Workflow
+
+Copy this checklist and work through it:
+
+```
+Readability pass:
+- [ ] Step 1: Pick the profile from the audience
+- [ ] Step 2: Score the text
+- [ ] Step 3: Rewrite the flagged sentences
+- [ ] Step 4: Re-score
+- [ ] Step 5: Repeat 3-4 until it passes, or justify the exception
+```
+
+**Step 1: Pick the profile.** Audience decides. A design doc for engineers is `technical`; a launch announcement is `public`.
+
+**Step 2: Score.** Run the script. Read the **long-sentence list first** — sentence length dominates every formula here, and over-long sentences are what make prose feel incoherent. The aggregate scores only tell you whether to act; the sentence list tells you where.
+
+**Step 3: Rewrite the flagged sentences.** Apply the [revision moves](#revision-moves). Fix the longest sentences first; a single 60-word sentence can fail a whole document.
+
+**Step 4: Re-score.** Run the same command again.
+
+**Step 5: Loop.** If it still fails, return to Step 3. Two rounds usually suffice. If a document cannot pass without losing meaning, say so explicitly and name which threshold you are missing and why — see [Guardrails](#guardrails).
+
+## Revision moves
+
+Ordered by impact. The first three fix most failures.
+
+Generated prose fails in two characteristic ways, and both are fixed by splitting rather than by simplifying vocabulary. Moves 1 and 2 handle almost every real failure.
+
+**1. Break the packed list out of the sentence.** The dominant failure mode: a list joined by semicolons with a parenthetical gloss on each item. Three or more parallel items inside one sentence belong in a bulleted list. Measured effect on a real 102-word example: Reading Ease −51.0 → 43.7, Fog 48.3 → 11.9, with the content unchanged. See [before-after.md](resources/examples/before-after.md) §1.
+
+**2. Stop qualifying mid-sentence.** The other characteristic failure: em-dash asides and subordinate clauses stacked onto a claim instead of finishing the sentence and starting another. Give each move in the argument its own sentence. Measured: Reading Ease 2.4 → 73.9. See §2.
+
+**3. Split at the conjunction.** Any remaining sentence with `and`, `but`, `which`, or `because` mid-clause is usually two sentences.
+
+**4. Cut the throat-clearing.** "It is important to note that", "In order to", "The fact that". Delete and start at the verb.
+
+**5. Un-nominalize.** "perform an evaluation of" → "evaluate". "make a determination" → "decide". Prefer the shorter synonym when both are exact — but not when the longer word is more precise.
+
+## Reading the five formulas together
+
+Four formulas define word difficulty by **syllables**. Dale-Chall defines it by **absence from a familiar-word list**. That difference is why both are worth running, and **their disagreement is the diagnosis**:
+
+| Pattern | Means | Fix |
+|---|---|---|
+| High FK/Fog, low Dale-Chall | Long sentences of ordinary words | Split sentences |
+| Low FK/Fog, high Dale-Chall | Short sentences of dense jargon | Define terms on first use — **not** shorter sentences |
+| Both high | Long sentences *and* dense vocabulary | Split first, then reassess |
+| Both pass | Structurally fine | Stop. Check meaning, not readability |
+
+Expect Dale-Chall to read one band harder than the others on domain writing. That is the formula working as designed, not a defect. When the audience genuinely knows the vocabulary, say so and accept the score rather than dumbing down the terms.
+
+## Run it automatically
+
+Optional Claude Code hooks score long prose without anyone asking: a `Stop` hook checks Claude's own output, and a `PostToolUse` hook checks documents as they are written. Both skip anything under 300 words.
+
+Setup, configuration, and safety properties are in **[hooks/README.md](hooks/README.md)**. The hook fails open by design — if anything goes wrong it exits silently rather than disturbing the session.
+
+## Guardrails
+
+1. **Never strip a technical term to hit a score.** Terms like `eventual consistency`, `backpressure`, or a cited standard's exact wording are load-bearing. Simplify the sentence around the term, not the term.
+2. **Never optimize tables, code, or headings.** The script already excludes them. If a table scores badly, that is a formatting question, not a readability one.
+3. **Formulas measure structure, not sense.** A document can pass every threshold and still be wrong or incoherent. Passing is necessary, not sufficient.
+4. **SMOG needs 30+ sentences.** Below that the script omits it rather than reporting a meaningless number. Do not treat its absence as a pass.
+4b. **A high Dale-Chall alone is not a rewrite order.** It flags unfamiliar vocabulary, which is often correct and necessary. Diagnose before revising — see [Reading the five formulas together](#reading-the-five-formulas-together).
+5. **Under 40 words of prose, nothing is scored.** Short outputs are exempt; do not force a score on them.
+6. **Quoted material is not yours to edit.** If a long sentence sits inside a quotation, leave it and note the exception.
+7. **State exceptions out loud.** When a document cannot pass without losing meaning, report the score, name the threshold missed, and explain the trade-off. Do not silently ship a failing document or quietly lower the profile.
+
+## Reference files
+
+- **[methodology.md](resources/methodology.md)** — what each formula measures, the shared band scale, why the thresholds sit where they do, the Dale-Chall banding decision, and known limits
+- **[template.md](resources/template.md)** — the report format for presenting scores and revisions
+- **[examples/before-after.md](resources/examples/before-after.md)** — six worked rewrites, including one showing when *not* to rewrite
+- **[hooks/README.md](hooks/README.md)** — automatic checking via Claude Code hooks
+- **[evaluators/rubric_readability_check.json](resources/evaluators/rubric_readability_check.json)** — scoring rubric and four evaluation scenarios
+
+## Quick reference
+
+- Input: markdown file, directory, or piped text.
+- Output: five scores per input, each with a grade band, a consensus band, pass/fail against the profile, and the long sentences to rewrite.
+- Loop: score → rewrite → re-score until pass.
+- The long-sentence list is the actionable output. Start there.
+- Formula disagreement is a diagnosis, not noise.

--- a/skills/readability-check/hooks/README.md
+++ b/skills/readability-check/hooks/README.md
@@ -1,0 +1,172 @@
+# Automatic readability checks via Claude Code hooks
+
+Optional. The skill works without hooks; these make it run on its own so long prose gets checked whether or not anyone remembers to ask.
+
+## Contents
+
+- [What it does](#what-it-does)
+- [Install](#install)
+- [Configuration](#configuration)
+- [Advisory vs blocking](#advisory-vs-blocking)
+- [Safety properties](#safety-properties)
+- [Troubleshooting](#troubleshooting)
+
+## What it does
+
+One script, `readability_hook.py`, handles two events and branches on `hook_event_name`:
+
+| Event | Fires when | Checks |
+|---|---|---|
+| `Stop` | Claude finishes a turn | `last_assistant_message`, if it is long enough |
+| `PostToolUse` | after `Write` or `Edit` | the file just written, if its extension matches |
+
+Both are gated on a **300-word minimum**. Short replies and small files are skipped, because readability formulas are unstable on short text and the advice would be noise.
+
+When prose fails, the hook returns the failing metrics plus the specific over-length sentences. Claude sees that on its next turn and can act on it.
+
+## Install
+
+### If you installed the plugin — already wired, still off
+
+The plugin ships `hooks/hooks.json` at its root, so both hooks register automatically on install. They use `${CLAUDE_PLUGIN_ROOT}`, so the paths survive plugin updates.
+
+**They do nothing until you opt in.** Installing a plugin should not silently change how your sessions behave. Two steps to turn it on:
+
+```bash
+python3 -m pip install --user textstat
+```
+
+Then set the flag in `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "READABILITY_HOOK_ENABLED": "1"
+  }
+}
+```
+
+That is the whole setup. To turn it off again, remove the variable.
+
+### If you are not using the plugin
+
+Add the hooks yourself, pointing at your clone. Replace `/ABSOLUTE/PATH/TO/claude` with the real path:
+
+```json
+{
+  "env": {
+    "READABILITY_HOOK_ENABLED": "1"
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"/ABSOLUTE/PATH/TO/claude/skills/readability-check/hooks/readability_hook.py\"",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"/ABSOLUTE/PATH/TO/claude/skills/readability-check/hooks/readability_hook.py\"",
+            "timeout": 15,
+            "statusMessage": "Checking readability..."
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Only want one of the two?** Keep just that block. Checking written documents is the higher-value half if you pick one.
+
+### Verify
+
+Test the script directly, without a session:
+
+```bash
+READABILITY_HOOK_ENABLED=1 python3 -c "
+import json
+print(json.dumps({
+  'hook_event_name': 'Stop', 'session_id': 't', 'prompt_id': 't',
+  'last_assistant_message': 'The service handles validation and dedup and enrichment ' * 40
+}))" | READABILITY_HOOK_ENABLED=1 python3 readability_hook.py
+```
+
+Expect JSON with a report. Silence with exit 0 means the hook ran and had nothing to say — which is also what you get if the flag is unset, so check the flag first when debugging.
+
+## Configuration
+
+Set environment variables in the `env` block of `settings.json`, or export them before launching:
+
+| Variable | Default | Effect |
+|---|---|---|
+| `READABILITY_HOOK_ENABLED` | *(off)* | **Master switch.** `1`, `true`, `yes`, or `on` to run at all |
+| `READABILITY_HOOK_PROFILE` | `general` | `technical`, `general`, or `public` |
+| `READABILITY_HOOK_MIN_WORDS` | `300` | Word floor below which nothing is checked |
+| `READABILITY_HOOK_MODE` | `advisory` | `advisory` or `block` |
+| `READABILITY_HOOK_EXTENSIONS` | `.md,.txt,.mdx` | Extensions checked by the `PostToolUse` half |
+
+Example — check engineering docs against the technical profile, only for markdown:
+
+```json
+{
+  "env": {
+    "READABILITY_HOOK_PROFILE": "technical",
+    "READABILITY_HOOK_EXTENSIONS": ".md"
+  }
+}
+```
+
+## Advisory vs blocking
+
+**`advisory` (default)** — exits 0 and returns the report through `additionalContext`. Claude sees it next turn. Nothing is interrupted.
+
+**`block`** — exits 2, which feeds the report to Claude and prevents the turn from completing until it responds. Stronger, and riskier: a `Stop` hook that blocks every failing draft can loop, because the rewrite may also fail.
+
+The loop guard makes blocking safe: **the hook blocks at most once per turn.** It writes a marker keyed on `session_id` + `prompt_id` to the system temp directory, and any second failure in the same turn falls back to advisory. If the marker cannot be written, it treats that as "already blocked" and stays advisory — failing toward the safer behavior.
+
+Start with `advisory`. Move to `block` only if advisory findings are being ignored.
+
+## Safety properties
+
+The hook is built to be boring in every failure case:
+
+1. **Off until asked.** Registered on plugin install, inert until `READABILITY_HOOK_ENABLED` is set. The flag is checked before stdin is even read.
+2. **Fails open.** Missing `textstat`, unreadable file, malformed payload, unexpected exception — every path exits 0 silently. A broken check is acceptable; a broken session is not.
+3. **Never blocks more than once per turn**, even in blocking mode.
+4. **Reads only.** It scores text and prints a report. It does not edit files.
+5. **Skips short text**, so ordinary conversation is untouched.
+6. **Bounded output.** At most three quoted sentences, each truncated at 200 characters.
+7. **No network.** Everything runs locally.
+
+## Troubleshooting
+
+**Nothing happens.** Usually correct: the text was under 300 words, or it passed. Check with `--stdin` directly:
+
+```bash
+cat draft.md | python3 ../resources/readability.py --stdin --profile general
+```
+
+**Nothing happens even on long failing prose.** Confirm `textstat` is installed for the *same* interpreter the hook uses:
+
+```bash
+python3 -c "import textstat; print(textstat.__version__)"
+```
+
+If that fails, the hook is silently failing open by design. Install the package.
+
+**Too noisy.** Raise `READABILITY_HOOK_MIN_WORDS`, or switch the profile to `technical`.
+
+**Firing on files it should not.** Narrow `READABILITY_HOOK_EXTENSIONS`, or drop the `PostToolUse` block and keep only `Stop`.
+
+**Want it off temporarily.** Unset `READABILITY_HOOK_ENABLED`. That is the master switch and it disables both hooks immediately.

--- a/skills/readability-check/hooks/readability_hook.py
+++ b/skills/readability-check/hooks/readability_hook.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+readability_hook.py — Claude Code hook that scores long prose and reports what to fix.
+
+Handles two hook events from one command; it branches on hook_event_name in the payload:
+
+  Stop          scores Claude's final message when it is long enough to be worth checking
+  PostToolUse   scores a document Claude just wrote or edited (Write / Edit matcher)
+
+FAILS OPEN, ALWAYS
+  A hook that crashes takes the session with it. Every failure path here exits 0 and stays
+  quiet: missing textstat, unreadable file, malformed payload, unexpected exception. The
+  worst case is that a check silently does not happen, never that a session breaks.
+
+ADVISORY BY DEFAULT
+  Default mode reports through additionalContext, so Claude sees the finding on its next
+  turn and can act on it. Blocking mode (exit 2) is opt-in, because a Stop hook that blocks
+  on every failing draft can loop: Claude rewrites, the rewrite still fails, the hook blocks
+  again. Blocking mode therefore fires at most once per turn, tracked by a marker file.
+
+OFF BY DEFAULT
+  This ships wired into the plugin's hooks/hooks.json, so it is registered the moment the
+  plugin installs. It does nothing until READABILITY_HOOK_ENABLED is set. Installing a
+  plugin should not silently change how someone's sessions behave; enabling is one line.
+
+INSTALL
+  See hooks/README.md for both paths: plugin install (already wired) and manual
+  settings.json configuration for people not using the plugin.
+
+ENVIRONMENT
+  READABILITY_HOOK_ENABLED     1 | true | yes to turn it on    (default: off)
+  READABILITY_HOOK_PROFILE     technical | general | public    (default: general)
+  READABILITY_HOOK_MIN_WORDS   skip anything shorter           (default: 300)
+  READABILITY_HOOK_MODE        advisory | block                (default: advisory)
+  READABILITY_HOOK_EXTENSIONS  comma-separated, for PostToolUse (default: .md,.txt,.mdx)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# The user asked for a 300-word floor: below that, formulas are unstable and the advice is
+# noise. Everything else is a plain default the operator can override.
+DEFAULT_MIN_WORDS = 300
+DEFAULT_PROFILE = "general"
+DEFAULT_EXTENSIONS = ".md,.txt,.mdx"
+
+# How many failing sentences to quote back. More than three buries the signal.
+MAX_QUOTED_SENTENCES = 3
+
+
+def quiet_exit() -> None:
+    """Every unexpected path ends here. A hook must not break the session."""
+    sys.exit(0)
+
+
+def load_scorer():
+    """Import readability.py as a sibling module. Returns None if unavailable."""
+    path = Path(__file__).resolve().parent.parent / "resources" / "readability.py"
+    if not path.exists():
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location("_readability", path)
+        if spec is None or spec.loader is None:
+            return None
+        module = importlib.util.module_from_spec(spec)
+        # dataclasses resolves field types through sys.modules[cls.__module__], so the
+        # module must be registered before exec_module or the @dataclass calls fail.
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    except SystemExit:
+        # readability.py exits 3 when textstat is missing. That is not our problem to
+        # report: the operator sees it the first time they run the skill directly.
+        return None
+    except Exception:
+        return None
+
+
+def already_blocked_this_turn(session_id: str, prompt_id: str) -> bool:
+    """Loop guard: blocking mode fires at most once per turn."""
+    key = hashlib.sha256(f"{session_id}:{prompt_id}".encode()).hexdigest()[:16]
+    marker = Path(tempfile.gettempdir()) / f"readability-hook-{key}"
+    if marker.exists():
+        return True
+    try:
+        marker.touch()
+    except OSError:
+        # If we cannot write the marker we cannot guarantee loop safety, so report that
+        # we already blocked and fall through to advisory.
+        return True
+    return False
+
+
+def build_report(result, profile: str) -> str:
+    lines = [
+        f"Readability check ({profile} profile) — this draft does not pass.",
+        f"Reads at: {result.consensus_band}. "
+        f"Flesch Reading Ease {result.flesch_reading_ease}, "
+        f"Flesch-Kincaid {result.flesch_kincaid_grade}, "
+        f"Gunning Fog {result.gunning_fog}, "
+        f"Dale-Chall {result.dale_chall}"
+        + (f", SMOG {result.smog_index}" if result.smog_index is not None else ""),
+    ]
+    for f in result.failures:
+        lines.append(f"  - {f}")
+    if result.long_sentences:
+        lines.append("Rewrite these sentences first:")
+        for o in result.long_sentences[:MAX_QUOTED_SENTENCES]:
+            text = o.text if len(o.text) <= 200 else o.text[:197] + "..."
+            lines.append(f'  [{o.words} words] "{text}"')
+    lines.append(
+        "Split at conjunctions, cut throat-clearing openers, and un-nominalize. "
+        "Keep technical terms exactly as they are."
+    )
+    return "\n".join(lines)
+
+
+def emit_advisory(report: str) -> None:
+    print(json.dumps({
+        "systemMessage": "Readability check failed on this draft.",
+        "hookSpecificOutput": {"additionalContext": report},
+    }))
+    sys.exit(0)
+
+
+def emit_block(report: str) -> None:
+    print(report, file=sys.stderr)
+    sys.exit(2)
+
+
+def text_for_event(payload: dict, extensions: list[str]) -> str | None:
+    event = payload.get("hook_event_name")
+
+    if event == "Stop":
+        return payload.get("last_assistant_message") or None
+
+    if event == "PostToolUse":
+        if payload.get("tool_name") not in ("Write", "Edit"):
+            return None
+        raw_path = (payload.get("tool_input") or {}).get("file_path")
+        if not raw_path:
+            return None
+        path = Path(raw_path)
+        if path.suffix.lower() not in extensions:
+            return None
+        try:
+            return path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None
+
+    return None
+
+
+ENABLED_VALUES = {"1", "true", "yes", "on"}
+
+
+def main() -> None:
+    # Opt-in gate. The plugin registers this hook on install, so it must stay inert until
+    # the operator asks for it. Checked before anything else, including reading stdin.
+    if os.environ.get("READABILITY_HOOK_ENABLED", "").strip().lower() not in ENABLED_VALUES:
+        quiet_exit()
+
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        quiet_exit()
+
+    profile = os.environ.get("READABILITY_HOOK_PROFILE", DEFAULT_PROFILE)
+    mode = os.environ.get("READABILITY_HOOK_MODE", "advisory")
+    extensions = [
+        e.strip().lower() if e.strip().startswith(".") else "." + e.strip().lower()
+        for e in os.environ.get("READABILITY_HOOK_EXTENSIONS", DEFAULT_EXTENSIONS).split(",")
+        if e.strip()
+    ]
+    try:
+        min_words = int(os.environ.get("READABILITY_HOOK_MIN_WORDS", DEFAULT_MIN_WORDS))
+    except ValueError:
+        min_words = DEFAULT_MIN_WORDS
+
+    scorer = load_scorer()
+    if scorer is None or profile not in scorer.PROFILES:
+        quiet_exit()
+
+    raw = text_for_event(payload, extensions)
+    if not raw:
+        quiet_exit()
+
+    try:
+        prose = scorer.markdown_to_prose(raw)
+        if scorer.word_count(prose) < min_words:
+            quiet_exit()
+        result = scorer.score(prose, payload.get("hook_event_name", "draft"), profile)
+    except Exception:
+        quiet_exit()
+
+    if not result.scored or result.passed:
+        quiet_exit()
+
+    report = build_report(result, profile)
+
+    if mode == "block" and not already_blocked_this_turn(
+        str(payload.get("session_id", "")), str(payload.get("prompt_id", ""))
+    ):
+        emit_block(report)
+
+    emit_advisory(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/readability-check/resources/evaluators/rubric_readability_check.json
+++ b/skills/readability-check/resources/evaluators/rubric_readability_check.json
@@ -1,0 +1,125 @@
+{
+  "name": "Readability Check Quality Rubric",
+  "scale": {
+    "min": 1,
+    "max": 5,
+    "description": "1=Poor, 2=Fair, 3=Good, 4=Very Good, 5=Excellent"
+  },
+  "criteria": [
+    {
+      "name": "Tool Usage",
+      "description": "Ran readability.py rather than estimating scores from inspection",
+      "scoring": {
+        "1": "Claimed scores without running the script",
+        "2": "Ran the script but ignored its output",
+        "3": "Ran the script and reported the scores",
+        "4": "Ran the script, reported scores, and used the long-sentence list to drive revision",
+        "5": "Ran the script, revised, and re-ran to verify the fix landed"
+      }
+    },
+    {
+      "name": "Profile Selection",
+      "description": "Chose the profile from the audience, not from what the draft happened to score",
+      "scoring": {
+        "1": "No profile named, or lowered the profile to manufacture a pass",
+        "2": "Profile named but unjustified",
+        "3": "Reasonable profile for the audience",
+        "4": "Profile named with a one-line justification tied to the reader",
+        "5": "Profile justified, and the choice is defended when the draft would pass a looser one"
+      }
+    },
+    {
+      "name": "Revision Quality",
+      "description": "Applied the revision moves without damaging meaning",
+      "scoring": {
+        "1": "Deleted content or stripped technical terms to hit a number",
+        "2": "Mechanical shortening that left the prose choppy or ambiguous",
+        "3": "Sentences split cleanly, meaning preserved",
+        "4": "Moves applied deliberately (split, cut throat-clearing, un-nominalize) with meaning intact",
+        "5": "Revision improves clarity beyond the score; a reader would prefer the new version on its own merits"
+      }
+    },
+    {
+      "name": "Terminology Preservation",
+      "description": "Load-bearing technical terms survived the rewrite",
+      "scoring": {
+        "1": "Replaced precise terms with vague ones to improve the score",
+        "2": "Some terms weakened or dropped",
+        "3": "Terms preserved",
+        "4": "Terms preserved and the surrounding sentence simplified instead",
+        "5": "Terms preserved, sentence simplified, and any unavoidable score cost is stated explicitly"
+      }
+    },
+    {
+      "name": "Exception Honesty",
+      "description": "Reported what could not be fixed rather than silently shipping or quietly relaxing the target",
+      "scoring": {
+        "1": "Shipped a failing document with no mention, or silently switched to a looser profile",
+        "2": "Mentioned failure vaguely",
+        "3": "Named the failing metric",
+        "4": "Named the metric, the reason, and the trade-off",
+        "5": "Named metric, reason, trade-off, and what would have to change for it to pass"
+      }
+    },
+    {
+      "name": "Formula Disagreement Handling",
+      "description": "Interpreted divergence between the five formulas rather than averaging it away",
+      "scoring": {
+        "1": "Reported one formula only",
+        "2": "Reported all five with no interpretation",
+        "3": "Noted that formulas disagreed",
+        "4": "Diagnosed the cause of disagreement (e.g. short sentences with dense vocabulary)",
+        "5": "Diagnosed the cause and chose the right remedy for it, including deciding not to rewrite when the vocabulary is appropriate for the audience"
+      }
+    }
+  ],
+  "evaluations": [
+    {
+      "skills": ["readability-check"],
+      "query": "Check this design doc for readability and fix anything that fails. The audience is the engineering team.",
+      "files": ["test-files/design-doc.md"],
+      "expected_behavior": [
+        "Runs resources/readability.py against the file rather than estimating scores by reading it",
+        "Selects the technical profile and states that the audience is engineers",
+        "Reports all five formulas with their grade bands and the consensus band",
+        "Rewrites the sentences flagged as over-length, starting with the longest",
+        "Preserves domain terminology exactly while simplifying the surrounding sentences",
+        "Re-runs the script after revising and reports the before and after scores"
+      ]
+    },
+    {
+      "skills": ["readability-check"],
+      "query": "This announcement goes on the public website. Make sure it reads at a general-public level.",
+      "files": ["test-files/announcement.md"],
+      "expected_behavior": [
+        "Selects the public profile because the audience is the general population",
+        "Reports the failure against the stricter public thresholds rather than the default general ones",
+        "Applies the revision moves in impact order, splitting long sentences before swapping synonyms",
+        "Does not silently fall back to a looser profile when the draft fails public",
+        "Verifies the fix by re-running the script"
+      ]
+    },
+    {
+      "skills": ["readability-check"],
+      "query": "Score this paragraph. It has short sentences but our reviewers still say it is hard to follow.",
+      "files": ["test-files/jargon-dense.md"],
+      "expected_behavior": [
+        "Notices that syllable-based formulas score easy while Dale-Chall scores hard",
+        "Diagnoses the cause as unfamiliar vocabulary rather than sentence length",
+        "Recommends defining terms on first use instead of shortening already-short sentences",
+        "Does not recommend replacing precise technical terms with vague alternatives"
+      ]
+    },
+    {
+      "skills": ["readability-check"],
+      "query": "Run the readability check over every document in docs/ and tell me which ones need work.",
+      "files": ["test-files/docs/"],
+      "expected_behavior": [
+        "Uses the directory form with --recursive rather than checking files one at a time",
+        "Reports a pass/fail summary across the set",
+        "Ranks the failing documents by severity so the worst is addressed first",
+        "Correctly skips files with too little prose to score rather than reporting a misleading number"
+      ]
+    }
+  ]
+}

--- a/skills/readability-check/resources/examples/before-after.md
+++ b/skills/readability-check/resources/examples/before-after.md
@@ -1,0 +1,109 @@
+# Worked rewrites
+
+Every score here was produced by running `readability.py` on the text shown, at the `general` profile. The failure modes are the ones that actually show up in generated prose, not textbook bad writing.
+
+## Contents
+
+- [1. The semicolon-chained list](#1-the-semicolon-chained-list)
+- [2. The single sentence that keeps qualifying itself](#2-the-single-sentence-that-keeps-qualifying-itself)
+- [3. When Dale-Chall disagrees with everything else](#3-when-dale-chall-disagrees-with-everything-else)
+- [4. When not to rewrite](#4-when-not-to-rewrite)
+
+## What generated prose actually gets wrong
+
+Model output is rarely ungrammatical and almost never bureaucratic. It fails in two specific ways:
+
+1. **It packs a list into one sentence**, joined by semicolons, with a parenthetical gloss on each item.
+2. **It qualifies mid-sentence**, stacking em-dash asides and subordinate clauses onto a claim instead of finishing the sentence and starting another.
+
+Both produce text that is correct, dense, and exhausting. Both are fixed by splitting, not by simplifying vocabulary.
+
+## 1. The semicolon-chained list
+
+**Before** — 102 words, one sentence:
+
+> The ingestion service handles several concerns at once: schema validation against the registry (rejecting any payload whose version is unknown, and emitting a metric so drift is visible); deduplication on the event key, which matters because the upstream producer retries aggressively and duplicates are common; enrichment from the customer dimension table, joined on account id and effective-dated so historical replays resolve correctly; partitioning by ingest date rather than event date, since late-arriving events would otherwise rewrite closed partitions; and finally a dead-letter path for anything that fails, with the original payload preserved so it can be replayed once the defect is fixed.
+
+**After** — 93 words, eleven sentences:
+
+> The ingestion service handles five concerns:
+>
+> - **Schema validation** against the registry. Payloads with unknown versions are rejected, and a metric is emitted so drift stays visible.
+> - **Deduplication** on the event key. The upstream producer retries aggressively, so duplicates are common.
+> - **Enrichment** from the customer dimension table. The join is on account id and effective-dated, so historical replays resolve correctly.
+> - **Partitioning by ingest date**, not event date. Late-arriving events would otherwise rewrite closed partitions.
+> - **A dead-letter path** for failures. The original payload is preserved so it can be replayed once the defect is fixed.
+
+| Formula | Before | After |
+|---|---|---|
+| Flesch Reading Ease | **−51.0** | 43.7 |
+| Flesch-Kincaid | 45.7 | 9.5 |
+| Gunning Fog | 48.3 | 11.9 |
+| Dale-Chall | 15.8 | 11.7 |
+| Band | college graduate | college |
+
+A Reading Ease of −51 is not a typo. The scale runs 0–100 and goes negative when a sentence is long enough; that is what one 102-word sentence does to a document.
+
+**Nothing was cut.** The content is identical and nine words shorter. The list was always a list — it was only punctuated as a sentence.
+
+## 2. The single sentence that keeps qualifying itself
+
+**Before** — 79 words, one sentence:
+
+> The caching layer is worth adding here — not because read volume is especially high, though it has grown steadily since the last quarter, but because the downstream pricing service has a hard rate limit that we are now brushing against during peak hours, which means that without a cache the checkout path will start returning errors under exactly the conditions where errors are most expensive, and that is a failure mode we should design out rather than monitor for.
+
+**After** — 69 words, five sentences:
+
+> The caching layer is worth adding, though not for the obvious reason. Read volume has grown, but it is not the problem. The problem is that the downstream pricing service has a hard rate limit, and we are brushing against it at peak hours.
+>
+> Without a cache, the checkout path starts returning errors exactly when errors cost the most. That failure mode should be designed out, not monitored for.
+
+| Formula | Before | After |
+|---|---|---|
+| Flesch Reading Ease | 2.4 | **73.9** |
+| Flesch-Kincaid | 32.5 | 6.4 |
+| Gunning Fog | 35.1 | 7.8 |
+| Dale-Chall | 12.4 | 9.8 |
+| Band | college graduate | middle school |
+
+The argument survives intact, including the "not X but Y" structure that made the original worth writing. What changed is that each move in the argument now gets its own sentence.
+
+## 3. When Dale-Chall disagrees with everything else
+
+Short sentences, dense vocabulary:
+
+> The scheduler is preemptive. Tasks yield at quantum boundaries. Priority inversion is mitigated by inheritance. Starvation is bounded by aging. Throughput degrades gracefully under saturation. Latency percentiles remain stable. Backpressure propagates upstream. Idempotent retries preserve correctness. Observability instruments every transition.
+
+| Formula | Score | Band |
+|---|---|---|
+| Flesch-Kincaid | 14.8 | college |
+| Gunning Fog | 20.8 | college graduate |
+| Dale-Chall | **15.3** | college graduate |
+
+Nine sentences averaging four words each, and it still scores at the ceiling. **Splitting sentences cannot help — they are already as short as sentences get.** Every word is doing the damage: `preemptive`, `quantum`, `inversion`, `inheritance`, `starvation`, `saturation`, `percentiles`, `backpressure`, `idempotent`, `observability`.
+
+The remedies are to define terms on first use, add a worked example, or accept the score because the audience is systems engineers who know all ten words. **What does not work is shortening sentences**, which is the move the other formulas appear to be asking for.
+
+This is the whole reason the skill reports five formulas instead of one.
+
+## 4. When not to rewrite
+
+**Before** — 38 words, passes `technical`:
+
+> Under the standard the audit trail must be attributable, legible, contemporaneous, original, and accurate, which means every record needs an actor, a timestamp, and a reason captured at the moment of the change.
+
+**A "fix" that scores better and is professionally useless:**
+
+> Under the rules the log must be clear and correct, so each record needs a person, a time, and a why.
+
+The five adjectives are quoted from the standard being cited. Replacing them with plainer words does not simplify the sentence; it misquotes the source. **The original already passes its profile. Leave it alone.**
+
+The general rule: a score is a reason to look, never a reason to overwrite precise language with vague language.
+
+---
+
+## A note on this file
+
+Running the checker on this file reports a failure: two sentences over 40 words. That is correct, and it stays. The over-length sentences are the quoted "before" examples — they exist to be bad. Guardrail 6 in [SKILL.md](../../SKILL.md) covers this case: quoted material is not yours to edit.
+
+A failing score is a reason to look, not an instruction to rewrite.

--- a/skills/readability-check/resources/methodology.md
+++ b/skills/readability-check/resources/methodology.md
@@ -1,0 +1,89 @@
+# Readability methodology
+
+## Contents
+
+- [What each formula measures](#what-each-formula-measures)
+- [The shared grade bands](#the-shared-grade-bands)
+- [Why the thresholds sit where they do](#why-the-thresholds-sit-where-they-do)
+- [Dale-Chall banding, and the alternative](#dale-chall-banding-and-the-alternative)
+- [Known limits](#known-limits)
+
+## What each formula measures
+
+All five reduce to two inputs: how long the sentences are, and how hard the words are. They differ in how they define "hard."
+
+| Formula | Word difficulty defined as | Output | Direction |
+|---|---|---|---|
+| **Flesch Reading Ease** | syllables per word | 0–100 | higher = easier |
+| **Flesch-Kincaid Grade** | syllables per word | US grade | lower = easier |
+| **Gunning Fog** | words of 3+ syllables | US grade | lower = easier |
+| **SMOG** | count of polysyllabic words | US grade | lower = easier |
+| **Dale-Chall (v1)** | words absent from a ~3,000-word familiar list | raw score | lower = easier |
+
+Dale-Chall is the odd one out and the reason it earns its place: it uses a **word list** rather than syllable counting. A short but unfamiliar word — `SMOG`, `RAG`, `nexus` — is easy for the syllable-based formulas and hard for Dale-Chall. Running both catches prose that is simple to pronounce and still opaque.
+
+Because they disagree by construction, the script reports all five plus a consensus band. **Disagreement is information.** Low Flesch-Kincaid with high Dale-Chall means short sentences full of jargon. High Flesch-Kincaid with low Dale-Chall means long sentences of ordinary words.
+
+## The shared grade bands
+
+Five scales are hard to compare. Every score is therefore mapped to one band:
+
+| Band | Grade equivalent |
+|---|---|
+| elementary | below 6 |
+| middle school | 6–8 |
+| high school | 9–12 |
+| college | 13–15 |
+| college graduate | 16+ |
+
+Flesch Reading Ease is converted through Flesch's own interpretation table; Flesch-Kincaid, Fog, and SMOG already emit grades; Dale-Chall is converted through the table below. The consensus is the band most formulas agree on, and **ties resolve to the harder band** — understating difficulty is the more costly error for a reader.
+
+## Why the thresholds sit where they do
+
+| Profile | Reading Ease ≥ | FK ≤ | Fog ≤ | SMOG ≤ | Dale-Chall ≤ | Sentence ≤ |
+|---|---|---|---|---|---|---|
+| `technical` | 40 | 14 | 16 | 14 | 12.9 | 40 |
+| `general` | 50 | 12 | 14 | 12 | 8.9 | 35 |
+| `public` | 60 | 9 | 11 | 10 | 6.9 | 25 |
+
+- **`technical`** targets the top of the college band. Accurate engineering prose lands there once unavoidable terms are counted as complex, and pushing below it means deleting the terminology rather than clarifying the sentence.
+- **`general`** targets the top of high school — the widely used ceiling for professional communication.
+- **`public`** targets grade 9, the standard for material intended to be read by the general population without effort.
+
+**Sentence length is the lever that matters.** It appears in all five formulas, so it moves every score at once, and it is the property most responsible for prose that "makes no sense" on first read. When a document fails, fixing the longest sentences usually fixes the aggregate scores as a side effect.
+
+## Dale-Chall banding, and the alternative
+
+This skill maps Dale-Chall v1 as follows:
+
+| Raw score | Band |
+|---|---|
+| ≤ 4.9 | elementary |
+| 5.0–6.9 | middle school |
+| 7.0–8.9 | high school |
+| 9.0–12.9 | college |
+| ≥ 13.0 | college graduate |
+
+**This is wider than the published Chall & Dale (1995) table**, which places everything at 10.0+ in college-graduate. The reason is that v1 — the original 1948 formula, which is what `textstat.dale_chall_readability_score` implements — runs hotter on technical prose than the 1995 revision. Every term outside its familiar-word list counts as difficult, so ordinary professional writing saturates the 1995 top band and the scale stops discriminating between "dense" and "impenetrable."
+
+**To use the stricter published table instead**, edit `DALE_CHALL_TABLE` in `readability.py`:
+
+```python
+DALE_CHALL_TABLE = (
+    (4.9, 4.0), (5.9, 5.5), (6.9, 7.5),
+    (7.9, 9.5), (8.9, 11.5), (9.9, 14.0),
+    (float("inf"), 16.0),
+)
+```
+
+and lower `dale_chall_max` in each profile accordingly.
+
+## Known limits
+
+1. **Formulas measure structure, not sense.** Text can pass every threshold and still be wrong, circular, or empty. Passing is necessary, not sufficient.
+2. **They can be gamed.** Chopping every sentence at the comma improves the score and can destroy the argument. Optimize for the reader, then verify with the score.
+3. **Dale-Chall penalizes any specialist vocabulary**, including terms the audience knows perfectly well. On domain writing, expect it to read one band harder than the others; that is the formula working as designed, not a defect in the prose.
+4. **SMOG needs 30+ sentences.** The script omits it below that rather than reporting a meaningless number.
+5. **Under 40 words, nothing is scored.** Short outputs are exempt.
+6. **Sentence splitting is regex-based.** Abbreviations occasionally split early. That slightly affects the offender list and not the aggregate scores, which textstat computes independently.
+7. **These are English formulas.** The syllable and familiar-word models do not transfer to other languages.

--- a/skills/readability-check/resources/readability.py
+++ b/skills/readability-check/resources/readability.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""
+readability.py — score prose on five readability formulas and name the sentences to fix.
+
+Scores Flesch Reading Ease, Flesch-Kincaid Grade, SMOG, Gunning Fog, and Dale-Chall (v1),
+then reports the specific sentences dragging the score down. The per-sentence offender
+list is the actionable part; the aggregate scores only tell you whether to act.
+
+CONSISTENT GRADE BANDS
+  The five formulas use different scales, which makes them hard to read side by side.
+  Every score is therefore also reported on one shared band scale — elementary, middle
+  school, high school, college, college graduate — so a single glance shows whether the
+  formulas agree. Raw scores are always printed alongside the band.
+
+MARKDOWN-AWARE BY DEFAULT
+  Readability formulas are only valid on continuous prose. Markdown tables, code fences,
+  headings, and link URLs are not sentences, and scoring them produces noise. This script
+  strips them before scoring. Use --include-tables to score table cell text as well.
+
+GRACEFUL FALLBACK
+  If textstat is missing, prints the exact pip install line and exits 3. A missing
+  dependency is a normal branch, not a crash to debug.
+
+USAGE
+  python3 readability.py FILE [FILE ...]          # score files
+  python3 readability.py --stdin                  # score piped text (for draft output)
+  python3 readability.py FILE --profile public    # stricter target
+  python3 readability.py FILE --json              # machine-readable
+  python3 readability.py DIR --recursive          # all .md under DIR
+
+EXIT CODES
+  0  all inputs pass the profile
+  1  at least one input fails
+  3  textstat not installed
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+
+try:
+    import textstat
+except ImportError:
+    print(
+        "readability.py needs textstat.\n"
+        "Install it with:\n"
+        "    python3 -m pip install --user textstat",
+        file=sys.stderr,
+    )
+    sys.exit(3)
+
+
+# --- Thresholds -------------------------------------------------------------
+#
+# Each profile sets a floor on Flesch Reading Ease (higher = easier) and ceilings on the
+# three grade-level formulas (lower = easier). Values are anchored to what each formula
+# means, not picked for roundness.
+#
+#   technical  Dense engineering or scientific prose whose terminology is load-bearing.
+#              Grade ~14 is upper-undergraduate, which is where accurate technical writing
+#              lands once unavoidable terms are counted as complex. Below FRE 40 the prose
+#              is doing more work than the subject requires.
+#   general    Default for explanatory writing aimed at a competent non-specialist.
+#              Grade ~12 is the widely used ceiling for professional communication.
+#   public     Public-facing copy. Grade ~9 is the standard target for material intended
+#              to be read by the general population without effort.
+#
+# max_sentence_words is the single most actionable lever: sentence length dominates every
+# formula here, and over-long sentences are what make prose feel incoherent. The limits are
+# set where a reader must re-read to hold the clause structure.
+
+PROFILES = {
+    "technical": {
+        "flesch_reading_ease_min": 40.0,
+        "flesch_kincaid_grade_max": 14.0,
+        "gunning_fog_max": 16.0,
+        "smog_index_max": 14.0,
+        "dale_chall_max": 12.9,  # top of the college band; 13.0+ is college graduate
+        "max_sentence_words": 40,
+    },
+    "general": {
+        "flesch_reading_ease_min": 50.0,
+        "flesch_kincaid_grade_max": 12.0,
+        "gunning_fog_max": 14.0,
+        "smog_index_max": 12.0,
+        "dale_chall_max": 8.9,  # top of the high-school band
+        "max_sentence_words": 35,
+    },
+    "public": {
+        "flesch_reading_ease_min": 60.0,
+        "flesch_kincaid_grade_max": 9.0,
+        "gunning_fog_max": 11.0,
+        "smog_index_max": 10.0,
+        "dale_chall_max": 6.9,  # top of the middle-school band
+        "max_sentence_words": 25,
+    },
+}
+
+# --- Shared grade bands -----------------------------------------------------
+#
+# The five formulas are on incompatible scales: Flesch Reading Ease runs 0-100 and rises
+# as text gets easier, Flesch-Kincaid / SMOG / Gunning Fog emit US grade numbers directly,
+# and Dale-Chall emits a raw score read off a lookup table. Reporting all five on one band
+# scale makes disagreement between them visible at a glance.
+
+BANDS = (
+    (6.0, "elementary"),
+    (9.0, "middle school"),
+    (13.0, "high school"),
+    (16.0, "college"),
+    (float("inf"), "college graduate"),
+)
+
+# Dale-Chall (v1, the original 1948 formula) raw score -> representative US grade.
+#
+# Banding note: this maps 9.0-12.9 to college and reserves "college graduate" for 13.0+.
+# That is deliberately wider than the Chall & Dale 1995 table, which calls everything at
+# 10.0+ college-graduate. The v1 formula runs hotter than the 1995 revision on technical
+# prose, because every term outside its ~3,000-word familiar list counts as difficult, so
+# the 1995 cutoffs push ordinary professional writing into the top band and stop
+# discriminating. Widening the college band keeps the scale useful where real documents
+# actually land. methodology.md records the alternative for anyone who wants it.
+DALE_CHALL_TABLE = (
+    (4.9, 4.0),    # grade 4 and below
+    (6.9, 7.0),    # middle school
+    (8.9, 11.0),   # high school
+    (12.9, 14.0),  # college
+    (float("inf"), 16.0),  # college graduate
+)
+
+# Flesch Reading Ease -> representative US grade, per Flesch's own interpretation table.
+# Entries are (lower bound inclusive, representative grade), highest ease first.
+FLESCH_EASE_TABLE = (
+    (90.0, 5.0),
+    (80.0, 6.0),
+    (70.0, 7.0),
+    (60.0, 8.5),
+    (50.0, 11.0),
+    (30.0, 14.0),
+    (float("-inf"), 16.0),
+)
+
+
+def band_for_grade(grade: float) -> str:
+    for ceiling, label in BANDS:
+        if grade < ceiling:
+            return label
+    return BANDS[-1][1]
+
+
+def dale_chall_grade(raw: float) -> float:
+    for ceiling, grade in DALE_CHALL_TABLE:
+        if raw <= ceiling:
+            return grade
+    return DALE_CHALL_TABLE[-1][1]
+
+
+def flesch_ease_grade(raw: float) -> float:
+    for floor, grade in FLESCH_EASE_TABLE:
+        if raw >= floor:
+            return grade
+    return FLESCH_EASE_TABLE[-1][1]
+
+# SMOG is defined over a 30-sentence sample. Below that it is not meaningful and textstat
+# returns a value anyway, so we suppress it rather than report a number that means nothing.
+SMOG_MIN_SENTENCES = 30
+
+# Below this many words there is not enough text for any formula to be stable.
+MIN_WORDS_FOR_SCORING = 40
+
+
+# --- Markdown to prose ------------------------------------------------------
+
+FENCE = re.compile(r"^\s*(```|~~~)")
+HEADING = re.compile(r"^\s{0,3}#{1,6}\s")
+HR = re.compile(r"^\s{0,3}([-*_])\s*(\1\s*){2,}$")
+TABLE_ROW = re.compile(r"^\s*\|")
+LIST_MARKER = re.compile(r"^\s*([-*+]|\d+[.)])\s+")
+QUOTE_MARKER = re.compile(r"^\s*>+\s?")
+
+IMAGE = re.compile(r"!\[[^\]]*\]\([^)]*\)")
+LINK = re.compile(r"\[([^\]]+)\]\([^)]*\)")
+INLINE_CODE = re.compile(r"`[^`]*`")
+HTML_TAG = re.compile(r"<[^>]+>")
+BARE_URL = re.compile(r"https?://\S+")
+EMPHASIS = re.compile(r"(\*\*|\*|__|_|~~)")
+FOOTNOTE = re.compile(r"\[\^[^\]]+\]")
+
+
+def markdown_to_prose(text: str, include_tables: bool = False) -> str:
+    """Reduce markdown to the continuous prose a readability formula can validly score."""
+    lines = text.splitlines()
+    out: list[str] = []
+    in_fence = False
+    in_frontmatter = False
+
+    for i, raw in enumerate(lines):
+        if i == 0 and raw.strip() == "---":
+            in_frontmatter = True
+            continue
+        if in_frontmatter:
+            if raw.strip() == "---":
+                in_frontmatter = False
+            continue
+
+        if FENCE.match(raw):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+
+        if HEADING.match(raw) or HR.match(raw):
+            continue
+
+        if TABLE_ROW.match(raw):
+            if not include_tables:
+                continue
+            # Keep cell text only; the pipes and alignment row are not prose.
+            cells = [c.strip() for c in raw.strip().strip("|").split("|")]
+            if all(set(c) <= set("-: ") for c in cells):
+                continue
+            raw = ". ".join(c for c in cells if c)
+
+        line = QUOTE_MARKER.sub("", raw)
+        was_list_item = bool(LIST_MARKER.match(line))
+        line = LIST_MARKER.sub("", line)
+
+        # A bullet is a sentence even when it is not punctuated as one. Without a
+        # terminator, sentence splitting runs consecutive bullets together into one
+        # artificially long "sentence" and reports a false over-length failure.
+        if was_list_item:
+            stripped = line.rstrip()
+            if stripped and stripped[-1] not in ".!?:;":
+                line = stripped + "."
+            # Emit each bullet as its own paragraph. Sentence splitting keys on a capital
+            # letter after the terminator, and a bullet often starts lowercase (a filename,
+            # a code term), so punctuation alone would not separate consecutive bullets.
+            out.append(line)
+            out.append("")
+            continue
+
+        out.append(line)
+
+    prose = "\n".join(out)
+
+    prose = IMAGE.sub("", prose)
+    prose = LINK.sub(r"\1", prose)
+    prose = FOOTNOTE.sub("", prose)
+    prose = INLINE_CODE.sub("", prose)
+    prose = HTML_TAG.sub("", prose)
+    prose = BARE_URL.sub("", prose)
+    prose = EMPHASIS.sub("", prose)
+
+    # Collapse the blank lines left behind so sentence splitting stays clean.
+    prose = re.sub(r"[ \t]+", " ", prose)
+    prose = re.sub(r"\n{2,}", "\n\n", prose)
+    return prose.strip()
+
+
+# --- Sentence handling ------------------------------------------------------
+
+# Split on sentence-ending punctuation followed by whitespace and a capital or digit.
+# Abbreviations ("e.g.", "Dr.") will occasionally split early; that costs a little
+# precision in the offender list and does not affect the aggregate scores, which
+# textstat computes independently.
+SENTENCE_SPLIT = re.compile(r"(?<=[.!?])[\"')\]]*\s+(?=[A-Z0-9])")
+
+
+def split_sentences(prose: str) -> list[str]:
+    """Split on paragraph boundaries first, then on sentence punctuation within each.
+
+    Paragraphs are hard boundaries: a blank line always ends a sentence, whatever the
+    punctuation. Inside a paragraph, wrapped lines are joined before splitting, so a
+    hard-wrapped sentence is not cut at the line break.
+    """
+    sentences: list[str] = []
+    for para in re.split(r"\n\s*\n", prose):
+        flat = re.sub(r"\s*\n\s*", " ", para).strip()
+        if not flat:
+            continue
+        sentences.extend(s.strip() for s in SENTENCE_SPLIT.split(flat) if s.strip())
+    return sentences
+
+
+def word_count(s: str) -> int:
+    return len(re.findall(r"\b[\w'-]+\b", s))
+
+
+# --- Scoring ----------------------------------------------------------------
+
+
+@dataclass
+class Offender:
+    words: int
+    text: str
+
+
+@dataclass
+class Result:
+    source: str
+    words: int
+    sentences: int
+    flesch_reading_ease: float | None
+    flesch_kincaid_grade: float | None
+    smog_index: float | None
+    gunning_fog: float | None
+    dale_chall: float | None
+    bands: dict[str, str]
+    consensus_band: str | None
+    failures: list[str]
+    long_sentences: list[Offender]
+    scored: bool
+    note: str = ""
+
+    @property
+    def passed(self) -> bool:
+        return self.scored and not self.failures
+
+
+def score(prose: str, source: str, profile: str) -> Result:
+    limits = PROFILES[profile]
+    sentences = split_sentences(prose)
+    words = word_count(prose)
+
+    if words < MIN_WORDS_FOR_SCORING:
+        return Result(
+            source=source,
+            words=words,
+            sentences=len(sentences),
+            flesch_reading_ease=None,
+            flesch_kincaid_grade=None,
+            smog_index=None,
+            gunning_fog=None,
+            dale_chall=None,
+            bands={},
+            consensus_band=None,
+            failures=[],
+            long_sentences=[],
+            scored=False,
+            note=f"only {words} words of prose; too short to score reliably",
+        )
+
+    fre = round(textstat.flesch_reading_ease(prose), 1)
+    fkg = round(textstat.flesch_kincaid_grade(prose), 1)
+    fog = round(textstat.gunning_fog(prose), 1)
+    dc = round(textstat.dale_chall_readability_score(prose), 1)
+    smog = round(textstat.smog_index(prose), 1) if len(sentences) >= SMOG_MIN_SENTENCES else None
+
+    bands = {
+        "flesch_reading_ease": band_for_grade(flesch_ease_grade(fre)),
+        "flesch_kincaid_grade": band_for_grade(fkg),
+        "gunning_fog": band_for_grade(fog),
+        "dale_chall": band_for_grade(dale_chall_grade(dc)),
+    }
+    if smog is not None:
+        bands["smog_index"] = band_for_grade(smog)
+
+    # The consensus is the band the most formulas agree on. Ties resolve to the harder
+    # band, since under-stating difficulty is the more costly error for a reader.
+    order = [label for _, label in BANDS]
+    counts = {b: list(bands.values()).count(b) for b in set(bands.values())}
+    top = max(counts.values())
+    consensus_band = max((b for b, c in counts.items() if c == top), key=order.index)
+
+    failures = []
+    if fre < limits["flesch_reading_ease_min"]:
+        failures.append(f"Flesch Reading Ease {fre} < {limits['flesch_reading_ease_min']}")
+    if fkg > limits["flesch_kincaid_grade_max"]:
+        failures.append(f"Flesch-Kincaid Grade {fkg} > {limits['flesch_kincaid_grade_max']}")
+    if fog > limits["gunning_fog_max"]:
+        failures.append(f"Gunning Fog {fog} > {limits['gunning_fog_max']}")
+    if dc > limits["dale_chall_max"]:
+        failures.append(f"Dale-Chall {dc} > {limits['dale_chall_max']}")
+    if smog is not None and smog > limits["smog_index_max"]:
+        failures.append(f"SMOG {smog} > {limits['smog_index_max']}")
+
+    cap = limits["max_sentence_words"]
+    long_sentences = sorted(
+        (Offender(words=word_count(s), text=s) for s in sentences if word_count(s) > cap),
+        key=lambda o: o.words,
+        reverse=True,
+    )
+    if long_sentences:
+        failures.append(f"{len(long_sentences)} sentence(s) over {cap} words")
+
+    note = "" if smog is not None else f"SMOG omitted (needs {SMOG_MIN_SENTENCES}+ sentences)"
+
+    return Result(
+        source=source,
+        words=words,
+        sentences=len(sentences),
+        flesch_reading_ease=fre,
+        flesch_kincaid_grade=fkg,
+        smog_index=smog,
+        gunning_fog=fog,
+        dale_chall=dc,
+        bands=bands,
+        consensus_band=consensus_band,
+        failures=failures,
+        long_sentences=long_sentences,
+        scored=True,
+        note=note,
+    )
+
+
+# --- Reporting --------------------------------------------------------------
+
+
+def render(result: Result, offenders: int) -> str:
+    if not result.scored:
+        return f"— {result.source}: {result.note}"
+
+    mark = "PASS" if result.passed else "FAIL"
+    smog = f"{result.smog_index}" if result.smog_index is not None else "n/a"
+    lines = [
+        f"{mark}  {result.source}",
+        f"      {result.words} words / {result.sentences} sentences of prose"
+        f"   →  reads at: {result.consensus_band}",
+        f"      Flesch Reading Ease {result.flesch_reading_ease} ({result.bands['flesch_reading_ease']})",
+        f"      Flesch-Kincaid      {result.flesch_kincaid_grade} ({result.bands['flesch_kincaid_grade']})",
+        f"      Gunning Fog         {result.gunning_fog} ({result.bands['gunning_fog']})",
+        f"      Dale-Chall          {result.dale_chall} ({result.bands['dale_chall']})",
+        f"      SMOG                {smog}"
+        + (f" ({result.bands['smog_index']})" if result.smog_index is not None else ""),
+    ]
+    if result.note:
+        lines.append(f"      ({result.note})")
+    for f in result.failures:
+        lines.append(f"      ✗ {f}")
+    if result.long_sentences and offenders:
+        lines.append(f"      Longest sentences — rewrite these first:")
+        for o in result.long_sentences[:offenders]:
+            snippet = o.text if len(o.text) <= 220 else o.text[:217] + "..."
+            lines.append(f"        [{o.words}w] {snippet}")
+    return "\n".join(lines)
+
+
+def collect_paths(inputs: list[str], recursive: bool) -> list[Path]:
+    paths: list[Path] = []
+    for raw in inputs:
+        p = Path(raw)
+        if p.is_dir():
+            pattern = "**/*.md" if recursive else "*.md"
+            paths.extend(sorted(p.glob(pattern)))
+        elif p.exists():
+            paths.append(p)
+        else:
+            print(f"warning: {raw} not found, skipping", file=sys.stderr)
+    return paths
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Score prose readability and name the sentences to fix.",
+    )
+    ap.add_argument("inputs", nargs="*", help="files or directories")
+    ap.add_argument("--stdin", action="store_true", help="score text piped on stdin")
+    ap.add_argument("--profile", choices=sorted(PROFILES), default="general")
+    ap.add_argument("--recursive", action="store_true", help="recurse into directories")
+    ap.add_argument("--include-tables", action="store_true", help="also score table cell text")
+    ap.add_argument("--offenders", type=int, default=3, help="long sentences to show (0 to hide)")
+    ap.add_argument("--json", action="store_true", help="emit JSON")
+    args = ap.parse_args()
+
+    if not args.stdin and not args.inputs:
+        ap.error("give at least one file or directory, or use --stdin")
+
+    results: list[Result] = []
+
+    if args.stdin:
+        raw = sys.stdin.read()
+        prose = markdown_to_prose(raw, args.include_tables)
+        results.append(score(prose, "<stdin>", args.profile))
+
+    for path in collect_paths(args.inputs, args.recursive):
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as e:
+            print(f"warning: cannot read {path} ({e}), skipping", file=sys.stderr)
+            continue
+        prose = markdown_to_prose(raw, args.include_tables)
+        results.append(score(prose, str(path), args.profile))
+
+    if not results:
+        print("nothing to score", file=sys.stderr)
+        return 0
+
+    if args.json:
+        print(json.dumps(
+            {"profile": args.profile, "results": [asdict(r) for r in results]},
+            indent=2,
+        ))
+    else:
+        print(f"profile: {args.profile}\n")
+        for r in results:
+            print(render(r, args.offenders))
+            print()
+        scored = [r for r in results if r.scored]
+        failed = [r for r in scored if not r.passed]
+        print(f"{len(scored) - len(failed)}/{len(scored)} passed")
+        if failed:
+            print("failing: " + ", ".join(r.source for r in failed))
+
+    return 1 if any(r.scored and not r.passed for r in results) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/readability-check/resources/template.md
+++ b/skills/readability-check/resources/template.md
@@ -1,0 +1,55 @@
+# Readability report template
+
+Use when reporting a readability pass. Adapt sections to the situation; keep the scores table and the revisions.
+
+---
+
+## Readability: [document or draft name]
+
+**Profile:** `[technical | general | public]` — chosen because [audience].
+**Verdict:** [PASS | FAIL] — reads at **[consensus band]**.
+
+| Formula | Score | Band | Limit | |
+|---|---|---|---|---|
+| Flesch Reading Ease | | | ≥ | ✅/❌ |
+| Flesch-Kincaid Grade | | | ≤ | ✅/❌ |
+| Gunning Fog | | | ≤ | ✅/❌ |
+| SMOG | | | ≤ | ✅/❌ |
+| Dale-Chall (v1) | | | ≤ | ✅/❌ |
+| Sentences over [N] words | | — | 0 | ✅/❌ |
+
+### Revisions made
+
+| # | Before (words) | After (words) | Move applied |
+|---|---|---|---|
+| 1 | *"[first 12 words…]"* ([N]w) | *"[first 12 words…]"* ([N]w) | split at conjunction |
+
+### After revision
+
+| Formula | Before | After |
+|---|---|---|
+| Flesch Reading Ease | | |
+| Flesch-Kincaid Grade | | |
+| Gunning Fog | | |
+| SMOG | | |
+| Dale-Chall (v1) | | |
+
+**Result:** [passes the `[profile]` profile | still fails on [metric]].
+
+### Exceptions
+
+Only when something could not be fixed:
+
+- **[sentence or section]** — kept at [N] words because [reason: quoted material, load-bearing term, legal wording]. Trade-off: [what the reader loses].
+
+---
+
+## Short form
+
+For a quick inline check, one line is enough:
+
+> Readability (`general`): **PASS** — reads at high school. FRE 56.2, FK 9.8, Fog 12.1, SMOG 11.4, Dale-Chall 8.1. No sentence over 35 words.
+
+Report failures with the sentences attached:
+
+> Readability (`general`): **FAIL** — Dale-Chall 9.4 (limit 8.9) and 3 sentences over 35 words. Rewriting the three, then re-scoring.


### PR DESCRIPTION
## What this adds

A **`readability-check`** skill that scores prose on five readability formulas and names the specific sentences to rewrite, plus plugin-level hooks that can run it automatically.

## The skill

`skills/readability-check/`

- **Five formulas**: Flesch Reading Ease, Flesch-Kincaid Grade, SMOG, Gunning Fog, and **Dale-Chall (v1)**.
- **One shared grade-band scale** — elementary / middle school / high school / college / college graduate — so five incompatible scales can be read side by side, with a consensus band. Ties resolve to the harder band, since understating difficulty is the costlier error.
- **Markdown-aware**: strips tables, code fences, headings, and link URLs before scoring. Readability formulas are only valid on continuous prose.
- **The actionable output is the over-length sentence list.** Aggregate scores only say whether to act; the sentence list says where.
- **Three profiles** (`technical`, `general`, `public`) chosen by audience.
- **`--stdin` mode** so draft output can be checked before it is sent.

### Why Dale-Chall earns the extra formula

Four of the five define word difficulty by **syllable count**. Dale-Chall defines it by **absence from a ~3,000-word familiar list**. A short but unfamiliar word is easy for the syllable formulas and hard for Dale-Chall, so their disagreement is a diagnosis:

| Pattern | Means | Fix |
|---|---|---|
| High FK/Fog, low Dale-Chall | Long sentences, ordinary words | Split sentences |
| Low FK/Fog, high Dale-Chall | Short sentences, dense jargon | Define terms — **not** shorter sentences |

Banding maps Dale-Chall 9.0–12.9 to *college*, wider than the Chall & Dale (1995) table. The v1 formula runs hot on technical prose, so the 1995 cutoffs saturate and stop discriminating. `methodology.md` documents the alternative and how to switch.

### Examples are measured, not invented

Generated prose does not fail like textbook bad writing. It fails by **packing a list into one semicolon-joined sentence**, and by **stacking qualifications mid-sentence**. Both worked examples show real before/after scores from running the tool:

| Example | Before | After |
|---|---|---|
| 102-word semicolon chain → bulleted list | Reading Ease **−51.0**, Fog 48.3 | Reading Ease 43.7, Fog 11.9 |
| 79-word self-qualifying sentence → five sentences | Reading Ease 2.4, Fog 35.1 | Reading Ease **73.9**, Fog 7.8 |

A third example shows short sentences that still score at the ceiling, where shortening cannot help. A fourth shows when *not* to rewrite.

## Hooks — plugin-native

`hooks/hooks.json` at plugin root, using `"${CLAUDE_PLUGIN_ROOT}"` so paths survive plugin updates.

| Event | Checks |
|---|---|
| `Stop` | Claude's `last_assistant_message`, if ≥300 words |
| `PostToolUse` (`Write\|Edit`) | the document just written, if ≥300 words |

Safety properties, since this repo is public:

1. **Off until asked.** Registered on install, inert until `READABILITY_HOOK_ENABLED` is set. Installing a plugin should not silently change how someone's sessions behave.
2. **Fails open on every path** — missing `textstat`, unreadable file, malformed payload, unexpected exception all exit 0 silently.
3. **Advisory by default.** Blocking mode is opt-in and fires **at most once per turn**, because a Stop hook that blocks every failing draft loops when the rewrite also fails.
4. **Read-only**, no network, bounded output.

## Agent updates

Adds `slop-detector` + `readability-check` to the **34 agents that produce human-facing prose**, plus `strategist-voice` for analyst agents and `voice-check` for the writing pipeline.

Curated, not pattern-matched: `skills:` preloads *full* skill content, so four skills across all 68 agents would bloat every context, and `voice-check` validates against a specific writer's voice profile.

## README

Skill added to the index, `textstat` listed in optional dependencies, and component counts corrected to **248 skills / 68 agents** — the badge said 241/62 and the body said 247.

## Testing

- **Dogfooded**: running the skill on its own docs found a real bug — stripping list markers joined unpunctuated bullets into artificial mega-sentences, producing false over-length failures. Fixed by treating bullets as paragraph boundaries. 4/5 skill docs now pass `technical`; the fifth is `before-after.md`, which fails correctly because it quotes deliberately-bad examples.
- Hook tested on four paths: disabled (silent), enabled + long failing prose (advisory JSON), short text (silent), malformed payload (silent, exit 0).
- All 68 agent files validated for intact frontmatter and no duplicate `skills:` keys.
- `hooks/hooks.json` validated as JSON.
- Four evaluation scenarios and a six-criterion rubric in `resources/evaluators/`.

## Requires

```bash
python3 -m pip install --user textstat
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167jxKQAPhMak2tEso9P57u