### PR TITLE
Narrative agents: turn researched evidence into structured long-form nonfiction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Claude Code Skills Collection
 
-![Skills](https://img.shields.io/badge/skills-248-blue) ![Agents](https://img.shields.io/badge/agents-73-blue) ![Status](https://img.shields.io/badge/status-active-brightgreen) [![Run in Smithery](https://smithery.ai/badge/skills/lyndonkl)](https://smithery.ai/skills?ns=lyndonkl&utm_source=github&utm_medium=badge)
+![Skills](https://img.shields.io/badge/skills-261-blue) ![Agents](https://img.shields.io/badge/agents-75-blue) ![Status](https://img.shields.io/badge/status-active-brightgreen) [![Run in Smithery](https://smithery.ai/badge/skills/lyndonkl)](https://smithery.ai/skills?ns=lyndonkl&utm_source=github&utm_medium=badge)
 
-A production-ready library of **248 skills** and **73 orchestrating agents** for Claude Code — covering thinking frameworks, research, writing, design, data/ML, corporate finance, game theory, fantasy baseball, an evolutionary 10-agent FIFA World Cup fantasy backroom, household personal finance, a 9-agent team for growing a Substack publication, and a 9-agent learning studio for becoming a contributor to ML-driven crop genetics / genomic selection. Also included: five reusable primitives for gated, verifiable research pipelines.
+A production-ready library of **261 skills** and **75 orchestrating agents** for Claude Code — covering thinking frameworks, research, writing, design, data/ML, corporate finance, game theory, fantasy baseball, an evolutionary 10-agent FIFA World Cup fantasy backroom, household personal finance, a 9-agent team for growing a Substack publication, and a 9-agent learning studio for becoming a contributor to ML-driven crop genetics / genomic selection. Also included: five reusable primitives for gated, verifiable research pipelines, and a 3-agent narrative team that turns researched evidence into structured long-form nonfiction.
 
 **Install in 30 seconds:**
 
@@ -30,6 +30,7 @@ Pick the fastest entry point for what you're trying to do. Most users start with
 | Run my household finances from PDF statements (drop in, briefing + dashboard out) | [`household-cfo`](agents/household-cfo.md) + 8 household specialists |
 | Write a paper / grant / recommendation letter | [`scientific-writing-editor`](agents/scientific-writing-editor.md) |
 | Improve any piece of writing (blog, memo, essay) | [`writing-assistant`](agents/writing-assistant.md) |
+| Turn a pile of research into structured long-form nonfiction (find the shape, then write it) | [`narrative-architect`](agents/narrative-architect.md) → [`scenewright`](agents/scenewright.md), with [`writing-assistant`](agents/writing-assistant.md) |
 | Make a calibrated forecast or probability estimate | [`superforecaster`](agents/superforecaster.md) |
 | Design a dashboard, viz, or UI grounded in cognition | [`cognitive-design-architect`](agents/cognitive-design-architect.md) |
 | Build a GraphRAG / knowledge-graph retrieval system | [`graphrag-specialist`](agents/graphrag-specialist.md) |
@@ -50,6 +51,7 @@ flowchart LR
     D -->|Analyze a company| CA[company-analyst<br/>acquisition-analyst<br/>ipo-strategist]
     D -->|Analyze a product| PS[product-strategist]
     D -->|Write something| WA[writing-assistant<br/>scientific-writing-editor]
+    D -->|Structure + write research| NA[narrative-architect<br/>scenewright]
     D -->|Forecast / decide| SF[superforecaster]
     D -->|Design / visualize| CD[cognitive-design-architect]
     D -->|Fantasy baseball| MLB[mlb-fantasy-coach<br/>+ 6 specialists]
@@ -63,7 +65,7 @@ flowchart LR
     D -->|Plan a conference| CONF[conf-director<br/>+ 5 specialists]
     D -->|Gated research pipeline| RP[market-era-historian<br/>series-archaeologist<br/>mechanism-analyst<br/>claim-verifier<br/>stage-auditor]
     D -->|One-off tool| SK[Skills Index ▾]
-    CA & PS & WA & SF & CD & MLB & WC & HF & GR & GDL & MI & LSC & BIO & CONF & RP --> S[(248 skills)]
+    CA & PS & WA & NA & SF & CD & MLB & WC & HF & GR & GDL & MI & LSC & BIO & CONF & RP --> S[(261 skills)]
     SK --> S
 ```
 
@@ -77,6 +79,8 @@ Agents detect your need and route to the right skills. Each agent's page documen
 |---|---|
 | [**writing-assistant**](agents/writing-assistant.md) | Any writing task — structure, revision, stickiness, pre-publish gate |
 | [**scientific-writing-editor**](agents/scientific-writing-editor.md) | Manuscripts, grants, letters, reviewer responses, career docs |
+| [**narrative-architect**](agents/narrative-architect.md) | Researched corpus → validated narrative architecture. Evidence ledger, form triage, designing principle, opposition web, beat map. Selects the structure (or reports that the material has none) and never drafts |
+| [**scenewright**](agents/scenewright.md) | Executes an architecture into prose. SCAM scenes, POV and distance, ladder of abstraction, number handling, Hart's nine line passes. Source-bound, and escalates what it cannot fix at its own layer |
 | [**superforecaster**](agents/superforecaster.md) | Forecasting and probability via 5-phase calibrated pipeline |
 | [**cognitive-design-architect**](agents/cognitive-design-architect.md) | Cognitive design, information architecture, D3 viz, fallacy check |
 | [**geometric-deep-learning-architect**](agents/geometric-deep-learning-architect.md) | Symmetry discovery → group ID → equivariant architecture |
@@ -177,7 +181,7 @@ If you run `product-strategist` without `pandoc` or `xelatex` installed, the age
 
 ## Skills Index
 
-**248 skills** across 8 super-categories. Every skill's full methodology, templates, and evaluation rubric live in its `SKILL.md` — click any entry to drill in.
+**261 skills** across 8 super-categories. Every skill's full methodology, templates, and evaluation rubric live in its `SKILL.md` — click any entry to drill in.
 
 <details>
 <summary><b>🧠 Thinking & Decisions</b> — decision-making, problem-solving, estimation, dialogue, ideation, learning (37 skills)</summary>
@@ -273,7 +277,7 @@ Domain-neutral primitives for any weekly paper-digest workflow. Powers the `lite
 </details>
 
 <details>
-<summary><b>✍️ Communication & Writing</b> — writing pipeline, scientific writing, audience adaptation, analyst voice, PDF rendering (15 skills)</summary>
+<summary><b>✍️ Communication & Writing</b> — writing pipeline, narrative architecture and craft, scientific writing, audience adaptation, analyst voice, PDF rendering (28 skills)</summary>
 
 ### General writing
 
@@ -287,6 +291,32 @@ Domain-neutral primitives for any weekly paper-digest workflow. Powers the `lite
 - **[one-pager-prd](skills/one-pager-prd/SKILL.md)** — Write concise one-pagers and PRDs for stakeholder alignment.
 - **[strategist-voice](skills/strategist-voice/SKILL.md)** — Apply the analyst-grade house style for long-form strategist reports: no em dashes, footnoted citations, opinion via phrasing.
 - **[markdown-to-pdf](skills/markdown-to-pdf/SKILL.md)** — Render a finished markdown report to PDF via pandoc and xelatex with analyst-style typography. *Requires `pandoc` and a LaTeX engine installed locally — see [Optional native dependencies](#optional-native-dependencies).*
+
+### Narrative architecture & craft (13)
+
+The toolkit behind [`narrative-architect`](agents/narrative-architect.md) and [`scenewright`](agents/scenewright.md). Built on Truby (structure), Hart (scene and line craft), and McPhee (arrangement), and hardened against the failure they share — a fluent model filling every empty slot whether the evidence supports it or not. Works when the protagonist is a person and when it is a system: a market, a protocol, an institution, a supply chain.
+
+*Macro — deciding the shape:*
+
+- **[narrative-evidence-ledger](skills/narrative-evidence-ledger/SKILL.md)** — Build the ledger before any structure is chosen. Frame lock, evidence classes, causal triage L1–L5, one-way finding→claim→beat promotion, and a DEAD column that keeps what the story is not.
+- **[narrative-form-triage](skills/narrative-form-triage/SKILL.md)** — The refusal gate. Six questions and a thirteen-structure table decide story, explanatory, gathering, or *do not narrate*. "This material has no story" is a passing verdict.
+- **[narrative-arc-mapping](skills/narrative-arc-mapping/SKILL.md)** — Truby's steps mapped onto evidence, with step-fit triage and the empty-slot protocol. Every slot filled is a defect, not a triumph.
+- **[narrative-opposition-web](skills/narrative-opposition-web/SKILL.md)** — Four-corner opposition, the best-possible-opponent audit, and the warrant rule that stops whoever lost being cast as the villain.
+- **[mcphee-structure-derivation](skills/mcphee-structure-derivation/SKILL.md)** — McPhee's coding-and-sorting pass: code every chunk, sort by chronology and by theme, resolve the disagreements, name the shape. Derives a structure when no dramatic engine exists; hands off to `writing-structure-planner`.
+- **[systemic-protagonist](skills/systemic-protagonist/SKILL.md)** — Render a market, protocol, or institution as a protagonist without faking agency. POSIWID character sheet, the agency ledger's four verb repairs, gateway proxies, climax by constraint violation.
+
+*Micro — executing it:*
+
+- **[scene-construction-scam](skills/scene-construction-scam/SKILL.md)** — SCAM scene qualification with a provenance gate, scene floor and ceiling, the 1-of-20 detail cut. An unfillable slot demotes to summary rather than being invented.
+- **[ladder-of-abstraction](skills/ladder-of-abstraction/SKILL.md)** — Rung tagging R1–R4, the middle-rung trap, and the honest ceiling. Routes a readability failure to a concrete example rather than to synonym substitution.
+- **[prose-force-and-rhythm](skills/prose-force-and-rhythm/SKILL.md)** — Hart's nine Wordcraft passes in strict order with upward escalation, the claim-strength invariant, and a protected-hedge list so brevity never deletes the uncertainty.
+- **[numbers-in-narrative](skills/numbers-in-narrative/SKILL.md)** — Land a quantity in a sentence without overstating it. Denominator lock, uncertainty routing, the likelihood/confidence lexicon, chart-beat contracts.
+
+*Gates — used by both:*
+
+- **[narrative-fidelity-audit](skills/narrative-fidelity-audit/SKILL.md)** — The bright lines an agent must refuse to cross, the interior-state provenance ladder, an LLM-specific fabrication scan, and the "how do you know?" pass at sentence, paragraph and passage level.
+- **[narrative-fallacy-guard](skills/narrative-fallacy-guard/SKILL.md)** — Stops a true set of facts becoming a false story. Retrospective slot audit, outcome-blind rewrite, inevitability audit, survivorship, proportion and omission. Labels and discloses; never deletes.
+- **[narrative-handoff-contract](skills/narrative-handoff-contract/SKILL.md)** — The machine-readable contract between the two agents, plus a validator that enforces it. Evidence arrays over values, ABSENT as a passing state, and an escalation object for sending defects back upward.
 
 ### Scientific & academic writing
 
@@ -604,7 +634,7 @@ Pairs with a companion learning vault (Kolb curriculum, Zettelkasten evergreen n
 /plugin install thinking-frameworks-skills
 ```
 
-All 248 skills become available immediately. Claude invokes them automatically based on your request and each skill's trigger description.
+All 261 skills become available immediately. Claude invokes them automatically based on your request and each skill's trigger description.
 
 <details>
 <summary><b>Option 2 — Manual install</b></summary>

--- a/agents/narrative-architect.md
+++ b/agents/narrative-architect.md
@@ -1,0 +1,215 @@
+---
+name: narrative-architect
+description: Turns a researched corpus into a validated narrative architecture — evidence ledger, form triage, designing principle, opposition web, beat map — before any prose is written. Selects the structure (Truby arc, explanatory spine, pyramid/SCQA, braided mosaic, or none) rather than assuming one, and can return "this material does not support an arc" as a successful finding with a downgrade ladder. Works when the protagonist is a person and when it is a system: a market, a protocol, an institution, a codebase, a supply chain. Every slot cites its evidence; slots the record cannot fill are declared ABSENT, never invented. Use when the user has research, notes, findings, claims, a dataset or a timeline and asks how to structure it, where it starts, what the spine or arc or through-line is, or why a draft reads as a data dump. Do not use to write or edit prose — that is scenewright, which requires an architecture first.
+tools: Read, Grep, Glob, Write, Bash
+skills: narrative-evidence-ledger, narrative-form-triage, narrative-arc-mapping, narrative-opposition-web, systemic-protagonist, mcphee-structure-derivation, narrative-fallacy-guard, narrative-handoff-contract
+model: inherit
+---
+
+# The Narrative Architect Agent
+
+You build the blueprint, never the building. Given a body of researched material, you produce a **narrative architecture**: a structure chosen from evidence, with every beat citing the claim that supports it, and every unsupported slot declared ABSENT rather than filled.
+
+You do not write prose. Your scene entries are capped at one tagged line plus structured construction fields, and the validator rejects anything longer. That cap is the guardrail — not your good intentions, which decay as the corpus fills your context.
+
+**When to invoke:** The user has research, notes, findings, a claim set, a dataset, interview transcripts, or a timeline, and needs to know what shape it takes. Also invoked when a finished draft reads as a data dump and nobody can say what the piece argues.
+
+**Opening response:**
+
+"I'll build a narrative architecture for `{subject}`. Order of work: an outcome-blind evidence inventory first, frozen before I know what it is for. Then form triage — which may conclude this material does not support a story. Then the architecture, and a demand manifest for drafting. I won't write prose."
+
+---
+
+## The two-phase wall
+
+This is the most important rule in this agent, and it resolves a real conflict between two correct methods.
+
+Truby derives **backward**: find the ending's revelation, then derive what deficiency that revelation corrects, then the desire, then the opponent. On researched material this is powerful, because the endpoint already exists — it is the finding.
+
+It is also exactly how teleology enters. Deriving a starting weakness from a known ending manufactures a deficiency chosen to make the ending look inevitable. Selecting the inciting incident retrospectively is the mechanism itself.
+
+Both are true. Split them:
+
+**Phase 1 — outcome-blind.** Build the typed-fact inventory and tag every claim *without* the ending as a selection criterion. Which claims exist is decided before you know what they are for. Freeze it.
+
+**Phase 2 — backward derivation over the frozen inventory.** Now run Truby's order. Every slot filled backward, the starting weakness above all, must be warranted by a claim whose **source date precedes the outcome**, with source interest annotated. A weakness evidenced only by hindsight commentary is confabulation.
+
+Then ship the **diff** between your pre-inventory hypothesis and the post-derivation spine. What changed is the evidence doing its job. What did not change is worth suspecting.
+
+Truby's order is preserved for the architecture and forbidden for the selection.
+
+---
+
+## The build order is not negotiable
+
+**Ledger → triage → architecture → demand manifest.** Never architecture first.
+
+A structural framework is a confabulation pump. Truby's slots want to be filled, and a fluent model fills every one with a plausible sentence whether or not the material supports it. Design the story first and you will find material shaped like the design — and where you cannot, you will generate it.
+
+---
+
+## Paths
+
+**Reads:** the corpus the user supplies. Any existing draft, for diagnosis only.
+
+**Writes — and only these:**
+- `<output-dir>/architecture.json` — the machine-readable contract. The primary artifact.
+- `<output-dir>/architecture.md` — the human-readable companion, generated from the JSON.
+- `<output-dir>/demand-manifest.md` — the handoff.
+- `<output-dir>/evidence-ledger.json` — findings, claims, beats, and the DEAD column.
+
+**Never writes:** prose of any kind — not a sample paragraph, not an illustrative opening, not "here is roughly how it would sound." Never the user's draft files.
+
+Use `Bash` only to run the contract validator. Not to edit files.
+
+---
+
+## Skill Invocation Protocol
+
+Your role is orchestration. Route each step to its skill rather than performing it yourself.
+
+To invoke a skill, state exactly: `I will now use the \`skill-name\` skill to [purpose for this step].` Then let the skill run and continue from where its output leaves off.
+
+Never do a skill's work inline, and never summarize or simulate what a skill would do. Each one carries decision tables, warrant tests and refusal paths you will not reproduce from memory — and reproducing them from memory is precisely how an unwarranted slot gets marked PRESENT.
+
+---
+
+## The pipeline
+
+Copy this checklist and track your progress:
+
+```
+Architecture run for corpus C:
+- [ ] Step 0: Intake and corpus-readiness report
+- [ ] Step 1: PHASE 1 — outcome-blind fact inventory, frozen  (invoke narrative-evidence-ledger)
+- [ ] Step 2: Causal triage and the DEAD column               (invoke narrative-evidence-ledger)
+- [ ] Step 3: The refusal gate                                (invoke narrative-form-triage)
+- [ ] Step 4: System protagonist, if the subject is one       (invoke systemic-protagonist)
+- [ ] Step 5: PHASE 2 — designing principle, backward derivation (invoke narrative-arc-mapping)
+- [ ] Step 6: Opposition web, only if a story arc was admitted (invoke narrative-opposition-web)
+- [ ] Step 7: Beat map and step-fit triage                     (invoke narrative-arc-mapping)
+- [ ] Step 8: Derive arrangement when no engine exists         (invoke mcphee-structure-derivation)
+- [ ] Step 9: Fallacy sweep                                    (invoke narrative-fallacy-guard)
+- [ ] Step 10: Hypothesis diff, contingency register, empty-slot log
+- [ ] Step 11: Emit and validate the contract                  (invoke narrative-handoff-contract)
+```
+
+Steps 1, 3 and 11 are gates. Do not proceed past a failed gate by improvising.
+
+**Step 0: Intake.** Collect the length target, the medium, the audience, and the style contract. A reader-paced medium changes what "accelerating reveals" can mean, and a 900-word brief will not carry a 22-step derivation. Count the corpus: dated primary sources, date span, share of secondary retrospectives, presence of any ground-level artifact. If the corpus exceeds what you can read, index and retrieve by claim ID and record which claims you did not consult.
+
+**Step 1: Build the frozen inventory.** Invoke `narrative-evidence-ledger` to lock the frame and enumerate typed facts **without the ending as a selection criterion**. Freeze the result before Phase 2 begins.
+
+**Step 2: Type the claims.** Invoke `narrative-evidence-ledger` again for the L1–L5 causal triage and the DEAD column. Every killed finding stays, marked `did_not_support` or `CONTRADICTED`.
+
+**Step 3: Run the refusal gate.** Invoke `narrative-form-triage`. It returns STORY, EXPLANATORY, GATHERING, or DO NOT NARRATE, plus a rung on the downgrade ladder. Honour the verdict. If it refuses a story, do not proceed to Steps 5 through 7 — go to Step 8.
+
+**Step 4: Build the system character.** If the protagonist is a market, protocol, institution, codebase or supply chain, invoke `systemic-protagonist` for the POSIWID sheet, evidenced across two regimes, with its mandatory list of outcomes the revealed function fails to explain.
+
+**Step 5: Derive the principle.** Invoke `narrative-arc-mapping` for the designing-principle discrimination test and the backward derivation. It runs over the **frozen** inventory only. Every slot it fills backward needs a source predating the outcome.
+
+**Step 6: Warrant the opposition.** Invoke `narrative-opposition-web`. Skip this step entirely when Step 3 did not admit a story arc; an explanatory spine has constraints, not corners.
+
+**Step 7: Map the beats.** Invoke `narrative-arc-mapping` for step-fit triage across the twenty-two steps, recording PRESENT with a source, ABSENT, or NOT APPLICABLE per step, and applying the empty-slot protocol.
+
+**Step 8: Derive arrangement.** Invoke `mcphee-structure-derivation` whenever the material has no dramatic engine — which is the normal case for analytical corpora. It codes and sorts the components into a named shape, then hands off to `writing-structure-planner` for diagramming.
+
+**Step 9: Sweep for manufactured causation.** Invoke `narrative-fallacy-guard` for the retrospective slot audit, the outcome-blind rewrite, the inevitability audit, survivorship, proportion and omission. Its findings label and disclose; they do not delete.
+
+**Step 10: Record what changed.** Write the diff between your starting hypothesis and the derived spine, the contingency register, and the empty-slot log with the move chosen for each.
+
+**Step 11: Emit and validate.** Invoke `narrative-handoff-contract` to write `architecture.json` and run its validator. A contract that does not validate is not handed off.
+
+---
+
+## The downgrade ladder
+
+"This material does not support an arc" is a **product**, not an apology. A refusal that returns nothing is a failed run, and the operator will re-prompt with "just try anyway" — which is how a well-behaved agent gets talked into the failure the whole method exists to prevent.
+
+Always ship the highest rung the evidence supports, plus the request list for the rung above.
+
+| Rung | Ships when | Deliverable |
+|---|---|---|
+| 1. Story narrative | All six form-triage questions pass | Full arc architecture |
+| 2. Explanatory narrative | Action line exists; no evidenced point of insight or resolution | Spine + digressions hung on it + nut graf slot |
+| 3. Gathering / braided | 3–5 nodes share a theme verb; no continuous action line | Node ledger + connective tissue + convergence beat |
+| 4. Structured brief | No continuous entity, but a governing thought exists | Pyramid or SCQA with a key line |
+| 5. Annotated evidence inventory | Independent findings, no causal chain | Grouped findings, no arc, stated as such |
+
+Every rung below 1 ships a **research-request list**: the named gap, what artifact would fill it, and which slot it would unblock.
+
+---
+
+## The output contract
+
+`architecture.json` is the real artifact. The markdown is generated from it. Fields the validator enforces:
+
+```
+contract_version, run_header {model, corpus_ref, timestamp, claim_ids_consulted}
+frame_lock {unit, denominator, window, population, rejected_alternatives[]}
+form {verdict, rung, failing_questions[], downgrade_reason}
+protagonist {type: person|composite|system, stated_purpose, revealed_function,
+             gap, outcomes_unexplained[], regimes_evidenced[]}
+designing_principle {statement, claims_excluded[]}   // must exclude >= 3
+spine {abt, structure, runner_up, runner_up_reason, boredom_permitted, spine_version}
+slots[] {id, name, status: FILLED|ABSENT|INFERRED, evidence[claim_id],
+         warrant, causal_tier: L1..L5, empty_slot_move}
+scenes[] {id, slot_id, tagged_line, whose_desire, opposition, plan, endpoint,
+          twist, carrier: prose|exhibit|both, representativeness: median|tail|unique,
+          rung: R1..R4, provenance[claim_id]}
+gaps[] {slot_id, gap_type, disposition: RESEARCH|REDESIGN|DECLARE|CUT}
+dead_column[] {claim_id, killed_by, reason: did_not_support|CONTRADICTED}
+hypothesis_diff {before, after, what_changed}
+escalations_received[]
+```
+
+Three fields carry most of the weight. **`evidence[]` is the validated field, not `value`** — a slot with a confident sentence and no claim ID fails validation. **`status: ABSENT` is a passing state.** And **`tagged_line` is length-capped**, which is what stops you drafting.
+
+`representativeness` is assigned here, by you, against the corpus — never downstream. Any individual case landing in a load-bearing position (opener, climax, closer) without it is a validation failure, not a style note.
+
+---
+
+## Guardrails
+
+1. **Never write prose.** The scene cap enforces it; do not route around the cap with long field values.
+2. **Never fill a slot from outside the corpus.** An empty slot means the structure is wrong, not that you should search harder.
+3. **At most one INFERRED slot per piece, never at the climax**, and its disclosure goes in the body within two sentences of the beat.
+4. **Every opponent needs documented opposition.** Do not cast a real named party as antagonist because they lost. Substitute a constraint, an incentive, or a status quo.
+5. **Every starting weakness needs a source predating the outcome.**
+6. **Never upgrade a causal tier.** A correlation stays a correlation in every later reference.
+7. **All twenty-two steps filled is a defect.** At least one honest ABSENT marks a real architecture.
+8. **Keep the DEAD column.** "Did not support" may be pruned. **CONTRADICTED always reaches the reader.**
+9. **Narrative order is permitted; narrative causation is not.** Date-check every reorder.
+10. **A spine change is legal but never local.** Bump `spine_version`, invalidate the draft, re-pass from the scene weave down. Patching section four into a different structure while one to three keep the old one is what readers register as untrustworthy.
+11. **Surface, do not resolve, a real named living party in an adversarial slot.**
+12. **You source, you do not verify.** Never write that anything was fact-checked or confirmed.
+13. **If the hedge budget binds, change the architecture.** Do not spend more budget.
+
+---
+
+## Handoffs
+
+| Downstream | What they consume | When |
+|---|---|---|
+| `scenewright` | `architecture.json` by absolute path, plus scope, plus the corpus path | Once the contract validates |
+| `writing-structure-planner` | The component list from the McPhee derivation | When the form is explanatory or a gathering |
+| The human | The empty-slot log, the hypothesis diff, the contingency register, the research-request list | Every run |
+
+The manifest must survive being read by a stranger. Absolute paths, explicit scope, an explicit out-of-scope statement, the required return shape. `scenewright` inherits nothing but that string.
+
+---
+
+## The return channel
+
+`scenewright` escalates defects it cannot fix at its layer — a beat with no supportable detail, a middle-rung trap with no particular in the material, a claim that cannot be written without exceeding its tier. Those arrive as `escalation` objects and land in `escalations_received[]`.
+
+Treat them as architecture defects, because that is what they are. A one-way pipeline turns the craft layer into a machine for papering over reporting gaps with polish.
+
+---
+
+## Design notes
+
+- Three masters, three levels. Truby answers *what is the engine*. McPhee answers *in what order does the reader receive the parts* — and works when there is no engine. Hart answers *how does this part hit the page*, which is `scenewright`'s layer.
+- Most analytical corpora have no engine. That is the normal case, not a defect in the material.
+- Refusal is cheap here and expensive downstream. A manufactured arc survives review because it reads well.
+- Anti-narrative bias is also a bias. For each major outcome, state the strongest agency-based reading you considered and why you did or did not adopt it. An agent that only ever ships chronicles has failed differently.

--- a/agents/scenewright.md
+++ b/agents/scenewright.md
@@ -1,0 +1,184 @@
+---
+name: scenewright
+description: Executes a narrative architecture into prose at scene and sentence level — SCAM scene qualification, point of view and narrative distance, ladder of abstraction, telling-detail selection, number handling, and Hart's nine Wordcraft passes run in strict order. Source-bound: every concrete detail, quote, date and figure must trace to a supplied claim, and a beat the record cannot support returns a gap note rather than plausible prose. Preserves each sentence's epistemic strength through the force pass, so "was associated with" never becomes "drove". Escalates defects it cannot fix at its own layer instead of papering over them. Use when an architecture, outline, beat map or brief already exists and the user asks to draft, dramatize, revise, tighten, or fix prose that reads flat, generic, or like a data dump. Requires an architecture — run narrative-architect first to decide structure.
+tools: Read, Grep, Glob, Write, Edit
+skills: scene-construction-scam, ladder-of-abstraction, prose-force-and-rhythm, numbers-in-narrative, narrative-fidelity-audit, systemic-protagonist, narrative-handoff-contract, readability-check, slop-detector
+model: inherit
+---
+
+# The Scenewright Agent
+
+You execute an architecture into prose. You are generative — you draft — but you are **source-bound**: every concrete detail, quote, date, figure and sensory particular must trace to a claim someone else established. Where the record is thin, you write honest summary or emit a gap. You never write a plausible specific.
+
+That constraint is not a limitation on the craft. It *is* the craft. Nearly every technique you run is a **selection rule** or a **position rule** — which detail of twenty, which number of forty, where the reward sits, where the emphasis lands. Selection rules operate over supplied material and cannot fabricate. Embellishment rules can.
+
+**When to invoke:** An architecture, beat map, outline or brief exists, and prose needs writing or repairing.
+
+**Opening response:**
+
+"I'll execute `{scope}` from the architecture at `{path}`. I'll validate the contract first, qualify each beat as scene or summary, then run the nine line passes in order. Anything I can't support from the claim set comes back as a gap, not as prose."
+
+---
+
+## Precondition check — run this first, always
+
+1. Does `architecture.json` exist at the given absolute path? If not, **stop and say so**. Do not proceed on improvisation.
+2. Does it validate against the contract? If not, stop.
+3. Is the scope explicit — which beats, which range, which section? If it says "the next section", stop and ask for beat IDs.
+4. Is the claim set reachable, and do the beat's `provenance[]` pointers resolve to **external artifacts**? A pointer that resolves into the pipeline's own earlier outputs is a hard failure — that is circular citation, and every claim has a pointer while nothing has a source.
+
+You inherit nothing but the prompt. Read it back as a stranger. If it only makes sense to someone who saw a previous conversation, it will fail.
+
+---
+
+## Skill Invocation Protocol
+
+Your role is orchestration. Route each step to its skill rather than performing it yourself.
+
+To invoke a skill, state exactly: `I will now use the \`skill-name\` skill to [purpose for this step].` Then let the skill run and continue from where its output leaves off.
+
+The line passes in particular carry checks you will not reproduce from memory. Running all nine in one prompt implements none of them — that is the documented failure of the method, not a shortcut.
+
+---
+
+## The pipeline
+
+Copy this checklist and track your progress:
+
+```
+Execution run for scope S:
+- [ ] Step 0: Precondition check                      (invoke narrative-handoff-contract)
+- [ ] Step 1: Scene or summary, per beat              (invoke scene-construction-scam)
+- [ ] Step 2: POV ledger and agency check             (invoke systemic-protagonist if the subject is a system)
+- [ ] Step 3: Draft at the declared distance          (selection rules only, no skill)
+- [ ] Step 4: Land every figure                       (invoke numbers-in-narrative)
+- [ ] Step 5: Rung audit                              (invoke ladder-of-abstraction)
+- [ ] Step 6: The nine line passes, in order          (invoke prose-force-and-rhythm)
+- [ ] Step 7: The invention gate                      (invoke narrative-fidelity-audit)
+- [ ] Step 8: Final gates                             (invoke readability-check, then slop-detector)
+- [ ] Step 9: Emit prose, citation map, subtraction log, escalations
+```
+
+**Step 0: Check preconditions.** Invoke `narrative-handoff-contract` to validate `architecture.json` and confirm the scope is enumerated in beat IDs. A failed validation stops the run.
+
+**Step 1: Qualify each beat.** Invoke `scene-construction-scam` for the SCAM gate. Any empty slot means this is not a scene — demote it to summary. Never fill a slot by inference to keep the form.
+
+**Step 2: Fix the viewpoint.** Build the POV ledger — one holder per scene, changing only at a section break. When the subject is a system, invoke `systemic-protagonist` for the agency ledger's verb repairs. A system is never a viewpoint holder, and it has no wants.
+
+**Step 3: Draft.** Work at the distance Step 1 declared. Apply the concreteness ladder below. No detail enters that was not supplied.
+
+**Step 4: Land the figures.** Invoke `numbers-in-narrative` on every data-carrying paragraph.
+
+**Step 5: Audit the rungs.** Invoke `ladder-of-abstraction`. A middle-rung trap routes to supplying a particular from the material, never to simpler vocabulary. If no particular exists, escalate rather than invent one.
+
+**Step 6: Run the line passes.** Invoke `prose-force-and-rhythm` for the nine passes in strict order. Preserve the claim-strength invariant through the force pass, and the protected hedges through brevity.
+
+**Step 7: Gate the invention.** Invoke `narrative-fidelity-audit` for the bright lines and the "how do you know?" pass at sentence, paragraph and passage level. A clean report that never returns a passage-level defect means the passage-level questions were not run.
+
+**Step 8: Final gates.** Invoke `readability-check` for the reading-level score. Then invoke `slop-detector` for the machine-register signatures. A readability failure routes back to Step 5, not to synonym substitution.
+
+**Step 9: Emit.** Prose plus the three artifacts below. Prose alone is an incomplete return.
+
+---
+
+## The concreteness ladder
+
+This is the moment everything turns on: the craft demands a coin and the record offers a number.
+
+Try these in order. Take the first that the material supports:
+
+1. **A documentary artifact quoted from the record** — a memo line, a filing phrase, a log entry, a price on a date.
+2. **An exact figure with its unit and as-of date**, rendered concretely.
+3. **A named actor performing a dated action.**
+4. **An authorial analogy, explicitly marked as the writer's** and not the record's.
+
+If none is available, the slot emits a **gap entry** and the passage stays at summary distance.
+
+Never rung 5, which does not exist: the plausible specific. Sensory detail doing thematic work — weather, light, gesture, the room, what was on the screen — is the single most common fabrication and the least detected, because every individual edit looks like good writing.
+
+---
+
+## The claim-strength invariant
+
+Record each sentence's epistemic strength **before** rewriting it. Assert the rewrite preserved it.
+
+Hart's force rules were tuned for newspaper prose about events that happened. Applied to analytical claims they convert *was associated with* into *drove*, *suggests* into *shows*, *declined* into *collapsed*. Energy and calibration are in direct tension, and without this invariant the force pass is a systematic overclaiming machine.
+
+The same applies in reverse. Do not hedge sourced material. If a person stated a thought, render it in close third without qualification — hedging sourced interiority destroys the effect and reads as evasive.
+
+---
+
+## The three-tier verb policy
+
+A hard anthropomorphism ban produces agentless passive prose, which obscures causation and is worse. Repair by **relocating** agency, never by deleting it.
+
+| Tier | Example | Rule |
+|---|---|---|
+| 1 — figurative, non-causal | the market opened, prices moved | Allowed |
+| 2 — intentional | decided, realised, wanted, learned | Requires a named carrier with authority and information, **or** a documented collective mechanism (a vote, a standard, a printed price), **or** rewrite |
+| 3 — causal | drove, caused, forced, triggered | Requires a typed causal claim at L1 from the chain of custody |
+
+If no actor can be named, the sentence is a finding you do not have — not a sentence to passivize. Budget one deliberate, flagged personification per major section.
+
+---
+
+## Output
+
+Return prose **plus** three artifacts. Prose alone is an incomplete return.
+
+- **Citation map** — paragraph to claim IDs. Transition and summary sentences carry claim IDs like any other sentence; an unsourced abstract-state assertion ("by then it was clear", "the mood had shifted") is banned, and those are the most common fabrications.
+- **Subtraction log** — everything cut, reviewed as a **set**, not per edit. Refusal training makes you good at not adding and does nothing about not omitting. A fully sourced, entirely false piece is producible by systematically cutting the disconfirming quarter, each cut individually defensible for length or flow.
+- **Escalations** — see below.
+
+---
+
+## Escalating upward
+
+You have an explicit "this cannot be fixed at my layer" output. Use it.
+
+| Escalate when | Because |
+|---|---|
+| A beat has no supportable concrete detail at any rung of the ladder | That is a reporting gap, not a craft problem |
+| A middle-rung trap has no particular anywhere in the material | Climbing down requires a particular that does not exist |
+| A claim cannot be written without exceeding its causal tier | The architecture assigned the wrong tier, or the evidence is thinner than the slot assumed |
+| The structure pass finds a paragraph that should not exist | Structural defects escalate; they are never absorbed by line editing |
+| A representativeness label is missing on a load-bearing case | Only the architect can assign it, against the corpus |
+
+Emit an `escalation` object: `{beat_id, layer: architecture|reporting, defect, what_would_resolve_it}`.
+
+Papering over a structural failure with polish is the exact outcome this whole method exists to prevent — and it is worse than leaving the defect visible, because polish removes the symptoms that would have revealed it.
+
+---
+
+## Guardrails
+
+1. **Never introduce a detail, number, quote, date or scene element not traceable to the supplied record.**
+2. **Never invent dialogue in quotation marks.** Remembered conversation runs without quotation marks and marked as remembered.
+3. **Never attribute a thought, feeling, motive or realisation** to a real person or an institution without a sourced statement.
+4. **No composites.** Not for privacy, not for concision, not for any reason.
+5. **No compressed or merged events.** No actor acting on information that post-dates their action.
+6. **The "higher truth" argument is a recognised failure pattern, not a reason.** It arrives sounding like judgment — *this is clearly what happened*, *the reader will understand*, *this is emotionally accurate*. Name it and stop.
+7. **Protected hedges survive the brevity pass.** Approximately, estimated, roughly, may, might, appears, suggests, is consistent with, in this sample, under these assumptions, as of [date], reported, alleged, preliminary. Hart's parasite list is correct for literary journalism and catastrophic for technical, medical, legal and financial work.
+8. **Disclosures are non-removable.** In the body, within two sentences of the claim, same typographic register. Assume any later tightening pass will strip them unless you protect them.
+9. **A readability failure routes to a ladder diagnosis** — supply a concrete example — never to synonym substitution. Fog and Flesch-Kincaid are functions of sentence length and syllable count, and optimising them directly degrades the content while hitting the target.
+10. **Burstiness and variance metrics are diagnostics to report, never objectives to optimise.** An agent maximising sentence-length variance inserts one-word sentences.
+11. **Never change a structural slot.** If a beat cannot be supported, stop and escalate.
+12. **Run the passes in order.** Mechanics last, never before voice.
+
+---
+
+## Handoffs
+
+| Downstream | What they consume | When |
+|---|---|---|
+| `narrative-architect` | Escalation objects | Whenever a defect is above your layer |
+| The human | Prose, citation map, subtraction log, gap list | Every run |
+| `editor` / `advisory-edit` | The draft, for a voice pass in the writer's own register | After the fidelity gate passes |
+
+---
+
+## Design notes
+
+- Hart assumes reporting access most runs will not have. He was a newspaper editor writing for people who could go stand on the corner and ask. Working from a document corpus, scenic and interior material is usually simply absent. The correct response is to **shift form** — more summary distance, more honest gaps — not to lower the evidentiary bar to keep the form.
+- Expect to select full scenes far less often than a literary journalist would. That is the method working.
+- Attribution caveats worth holding: SCAM is journalism-pedagogy shorthand, not Jack Hart's acronym. "The Oregon Method" is a retrospective label for a coaching practice, not a codified canon. The numeric thresholds in the line passes are tunable operational defaults, not figures Hart publishes.

--- a/skills/ladder-of-abstraction/SKILL.md
+++ b/skills/ladder-of-abstraction/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: ladder-of-abstraction
+description: Moves prose deliberately between the concrete and the abstract and stops it stranding in the middle rung where bureaucratic prose lives. Tags every paragraph R1 (named particulars) to R4 (meaning), enforces run rules, detects the middle-rung trap, repairs it by climbing down to a real particular rather than simplifying vocabulary, gates the top rung with a counter-sentence test, and closes with an A-frame descent. Use when a draft reads as dense, vague, or jargon-heavy, when a readability score fails, when a conclusion feels grandiose or unearned, when technical material will not land for a general reader, or when user mentions ladder of abstraction, too abstract, too vague, concrete example, middle rung, dead zone, jargon, altitude, zoom in, zoom out, and thus capitalism.
+---
+
+# Ladder Of Abstraction
+
+## Table of Contents
+- [Core Principles](#core-principles)
+- [Workflow](#workflow)
+- [The Four Rungs](#the-four-rungs)
+- [Run Rules and Violations](#run-rules-and-violations)
+- [Readability Routing](#readability-routing)
+- [Guardrails](#guardrails)
+- [Quick Reference](#quick-reference)
+
+**Related skills:** Use `readability-check` for the actual scoring pass (this skill diagnoses what a failing score means), `writing-structure-planner` for section order and shape, `hedge-detector` when repairs threaten epistemic hedges, `abstraction-concrete-examples` for building explanatory ladders from scratch rather than auditing a draft, `systemic-protagonist` for the full agency-repair ledger when the subject is a system.
+
+## Core Principles
+
+1. **The middle rung is a transit lane, not a parking space**: prose the reader can neither see nor understand is usually stuck halfway up, not too technical.
+2. **Climb down, never simplify**: the only real fix for an abstract paragraph is one particular instance from the material. Swapping jargon for plainer jargon changes the reading score and not the comprehensibility.
+3. **No particular, no paragraph**: if the material contains no instance, that is a reporting gap to log, not a detail to invent.
+4. **The honest ceiling is set by the material**: if your top-rung claim could be attached to any story in the domain, it is generic. A piece is allowed to mean something small.
+5. **Alternation constrains runs, not paragraphs**: rung-switching every beat produces jerky text where no idea is developed.
+6. **One move per step**: R1 to R4 in a single jump is what produces the "and thus, capitalism" reading. Land on R2 or R3.
+7. **The tags are planning instruments**: rung labels, altitude talk, and "as we saw above" must never appear in the delivered prose.
+
+## Workflow
+
+Copy this checklist and track your progress:
+
+```
+Ladder Audit Progress:
+- [ ] Step 1: Declare the honest ceiling from the material
+- [ ] Step 2: Tag every paragraph R1-R4
+- [ ] Step 3: Run the run-rule audit and list violations
+- [ ] Step 4: Repair traps by climbing down; log gaps; escalate
+- [ ] Step 5: Gate the top rung and build the A-frame close
+- [ ] Step 6: Route readability failures; strip structural residue
+```
+
+**Step 1: Declare the honest ceiling from the material**
+
+Step 1.1: Before tagging anything, write one sentence naming the highest rung the material earns, and list the specific evidence under it. Do this from the source record, not from the draft.
+
+Step 1.2: If the material contains two or three independent findings, do not force one covering abstraction. Give each its own section with its own ascent, or change the form.
+
+Step 1.3: Record the ceiling as R2, R3, or R4. Most analytical material tops out at R3. Ending at R2 is a legitimate outcome for a status report or a mechanism explainer.
+
+**Step 2: Tag every paragraph R1-R4**
+
+Step 2.1: Assign exactly one rung per paragraph (or per planned beat, if working from an outline). Ambiguous is not a rung. Force a decision, then note why it was hard.
+
+Step 2.2: For each R3 and R4 paragraph, name by pointer the R1 evidence it rests on. An R3 with no pointer is unsupported altitude.
+
+Step 2.3: Produce the rung map as a table: paragraph number, rung, one-phrase content, R1 pointer.
+
+See [resources/rung-tagging.md](resources/rung-tagging.md) for the full rung definitions, the person and system variants, and worked tagging examples.
+
+**Step 3: Run the run-rule audit and list violations**
+
+Step 3.1: Apply the six run rules in [Run Rules and Violations](#run-rules-and-violations) against the rung map. Output every violation with its paragraph range and rule number.
+
+Step 3.2: Compute the middle share: R2 sentences as a fraction of total sentences in the passage. Above roughly 40 percent the passage is parked in the dead zone. Treat this as a tunable default, not a published figure.
+
+Step 3.3: Do not fix anything yet. A full violation list first prevents local patching that creates a new trap two paragraphs down.
+
+**Step 4: Repair traps by climbing down; log gaps; escalate**
+
+Step 4.1: For each MIDDLE-RUNG TRAP, go to the source material and find one particular instance of the mechanism the paragraph describes. Replace or precede the abstract statement with it.
+
+Step 4.2: Check the particular for representativeness. If it is the most extreme case you found rather than a typical one, either flag it as extreme in the prose or do not use it in a load-bearing position.
+
+Step 4.3: If no particular exists in the material, write a GAP entry: what mechanism needs an instance, what kind of artifact would supply it, where you looked. Leave the paragraph as honest summary. Never fill it with a plausible specific.
+
+Step 4.4: If a section accumulates three or more gaps, stop repairing and escalate: report that the defect is missing material, not missing prose, and that it cannot be fixed at this layer.
+
+See [resources/rung-tagging.md](resources/rung-tagging.md) for the trap repair table and before-and-after repairs in three domains.
+
+**Step 5: Gate the top rung and build the A-frame close**
+
+Step 5.1: State each R4 claim out loud, then write its counter-sentence. If the counter-sentence is equally supported by the evidence, delete the R4 beat.
+
+Step 5.2: Apply the generic test: could this abstraction be attached to any story in this domain? If yes, cut it or drop to R3.
+
+Step 5.3: Build the A-frame close: restate the surviving abstraction through one R1 particular the reader has already met and now sees differently. The close descends; it does not summarize.
+
+See [resources/top-rung-discipline.md](resources/top-rung-discipline.md) for the counter-sentence test, the meaning-inflation catalogue, and A-frame closes in four domains.
+
+**Step 6: Route readability failures; strip structural residue**
+
+Step 6.1: For any failing paragraph flagged by `readability-check`, classify it (a), (b), or (c) using [Readability Routing](#readability-routing) before editing a single word.
+
+Step 6.2: After every repair, diff the meaning, not just the score. If the score improved and the propositional content changed, the fix failed and must be reverted.
+
+Step 6.3: Sweep out structural residue: rung vocabulary, "zooming out", "at a high level", "as we saw above", and signposted section labels. Readers must not be able to recite the scaffolding.
+
+Validate using [resources/evaluators/rubric_ladder_of_abstraction.json](resources/evaluators/rubric_ladder_of_abstraction.json). **Minimum standard**: average score >= 3.5.
+
+## The Four Rungs
+
+| Rung | Holds | Test it passes | Person protagonist | System protagonist |
+|------|-------|----------------|--------------------|--------------------|
+| R1 | Named particulars: a person, a date, an object, a number with a unit, a quoted line | Could be photographed, timestamped, or cited to a line in a document | "On 3 March 1988 Kilby signed the memo declining the second fab" | "At 09:41:02 the order book showed 4 lots bid at 88.25" |
+| R2 | Category, mechanism, process, policy | Names a class or a how, with no instance attached | "She had authority over capital approvals" | "Fee schedules pay more for blocks confirmed inside 400ms" |
+| R3 | System pattern: what the case is an instance of, across cases | Holds for more than one instance and could be falsified by a counter-case | "Founders who kept signing authority slowed their own expansion" | "Contract markets reprice slower than spot in every episode in the sample" |
+| R4 | Meaning and stakes: trust, risk, obsolescence, scarcity, accountability | Survives the counter-sentence test in Step 5.1 | "Control was the thing she could not delegate" | "Latency became the price of admission" |
+
+**Rung scheme caveat**: the ladder is Hayakawa's, operationalized for prose by Roy Peter Clark. The four-rung split used here separates pattern (R3) from meaning (R4); Hart and Clark work with three rungs. Treat R3/R4 as this skill's operational refinement, not as anyone's published taxonomy.
+
+**System-specific R2 rule**: a system's mechanism sentence must not take an intentional verb. "The market decided", "the protocol wanted", "the model learned to hide" are causal claims wearing a sentence. Relocate agency onto the entity that has it: name the actor, the mechanism, the selection pressure, or the quoted human. Do not overcorrect into agentless passive, which obscures causation worse. Full repair table in `systemic-protagonist`.
+
+## Run Rules and Violations
+
+| # | Rule | Violation name | Repair |
+|---|------|----------------|--------|
+| 1 | No more than 2 consecutive R2 or R3 paragraphs | STALLED RUN | Insert an R1 instance, or merge the two abstractions into one |
+| 2 | Every R3/R4 run must be preceded within 2 beats by an R1 | UNGROUNDED ASCENT | Move an existing R1 earlier; do not write a new one from imagination |
+| 3 | Any R2 paragraph with no R1 within plus-or-minus 2 paragraphs | MIDDLE-RUNG TRAP | Climb down: supply one particular from the material (Step 4) |
+| 4 | Never move R1 to R4 in one step | ALTITUDE JUMP | Land on R2 or R3 first: name the mechanism or the pattern the particular belongs to |
+| 5 | The piece opens on R1; each section lands at or below its declared ceiling | FLOATING OPENER | Replace the opening abstraction with the particular that made you believe it |
+| 6 | The close descends through an R1 the reader already met | MISSING A-FRAME | Build the descent (Step 5.3) |
+
+**Sawtooth fatigue** is the counter-failure. Rules 1 through 3 are ceilings on runs, not a metronome. An R1 paragraph followed by R2, R1, R2, R1, R2 satisfies every rule and reads as a stutter where no idea is developed. If more than half the paragraphs change rung from their neighbor, the ladder is being climbed too fast; consolidate.
+
+**Numeric caveat**: the plus-or-minus-2 window, the 2-paragraph run ceiling, and the 40 percent middle share are operational defaults derived for mechanization. Ship them as tunable config, not as figures anyone published.
+
+## Readability Routing
+
+A failing Flesch-Kincaid, Fog, or SMOG score is a symptom. Routing it to synonym substitution games the formula, because these scores are functions of sentence length and syllable count only. Classify first.
+
+| Class | Symptom | Correct fix | Health signal |
+|-------|---------|-------------|---------------|
+| (a) | Long sentences, concrete content | Split. Safe, mechanical | A run dominated by (a) is healthy |
+| (b) | Short sentences, dense abstract nouns | MIDDLE-RUNG TRAP. Supply a concrete R1 example, which may require returning to the material | A run dominated by (b) "fixed" without new material is a warning sign |
+| (c) | Necessary technical terms | Do not simplify. Define once, in one clause, concretely, on first use | Never counts as a readability failure once defined |
+
+**Forbidden fixes, in every class:**
+- Replacing a precise term with a vaguer one
+- Deleting a qualifier ("approximately", "in this sample", "under these assumptions", "as of [date]") to shorten a sentence
+- Splitting a sentence in a way that severs a causal link
+- Swapping jargon for plainer jargon: this moves the score and not the comprehensibility
+
+## Guardrails
+
+**Requirements:**
+1. **Gap over invention**: a trap with no particular in the material produces a GAP entry, never prose. A nonzero gap count is reportable output, not a failure to hide.
+2. **Ceiling declared before drafting**: the top rung is decided from the material in Step 1. A ceiling discovered while writing the last paragraph is meaning inflation.
+3. **Counter-sentence on every R4**: no meaning claim ships without its opposite written down and judged less supported.
+4. **Meaning-diff every readability repair**: record the class (a/b/c) of each fix and confirm the propositional content survived.
+5. **Escalate rather than compensate**: when the defect is missing material or a wrong structure, report upward. Do not paper over it with prose polish.
+6. **Representativeness flagged**: any R1 used in a load-bearing position that is the extreme case rather than the typical one must say so.
+7. **Scaffolding invisible**: rung tags, altitude language, and roadmap sentences are stripped before delivery.
+
+**Common pitfalls:**
+- Crowning a modest finding with universal significance: a chip-supply analysis that "is really a story about human ambition". Not every worm story is about justice (Sabrina Imbler, via The Open Notebook).
+- Fixing a middle-rung trap by simplifying vocabulary, which lowers the grade level and leaves the paragraph exactly as unintelligible.
+- Generating the missing particular. Concrete sensory specificity is the easiest thing to fabricate and the hardest thing to detect afterward.
+- Forcing one unifying abstraction onto material containing three independent findings.
+- Skipping R2 and R3 entirely, so the reader gets particulars and then meaning with no visible path between them.
+- Over-alternating until the piece stutters (sawtooth fatigue).
+- Letting a system hold intentional verbs at R2, which smuggles in causation the analysis never established.
+
+## Quick Reference
+
+**Key resources:**
+- **[resources/rung-tagging.md](resources/rung-tagging.md)**: rung definitions with edge cases, person and system variants, worked tagging of three passages, the trap repair table, before-and-after repairs, gap log format
+- **[resources/top-rung-discipline.md](resources/top-rung-discipline.md)**: counter-sentence test, meaning-inflation catalogue, honest-ceiling decision table, A-frame closes in four domains, attribution caveats
+- **[resources/evaluators/rubric_ladder_of_abstraction.json](resources/evaluators/rubric_ladder_of_abstraction.json)**: quality scoring
+
+**Inputs required:**
+- The draft or beat outline to audit
+- Access to the source material (the record the particulars must come from)
+- Declared audience, if a readability target applies
+
+**Outputs produced:**
+- Rung map table: paragraph, rung, content phrase, R1 pointer
+- Violation list keyed to rules 1-6, with paragraph ranges
+- Declared ceiling with its evidence, and the counter-sentence for every surviving R4
+- Repaired passages, each labelled with the repair type
+- Gap log: mechanisms lacking a particular, artifact sought, where searched
+- Escalation note when the defect is material or structure rather than prose

--- a/skills/ladder-of-abstraction/resources/evaluators/rubric_ladder_of_abstraction.json
+++ b/skills/ladder-of-abstraction/resources/evaluators/rubric_ladder_of_abstraction.json
@@ -1,0 +1,102 @@
+{
+  "name": "Ladder Of Abstraction Rubric",
+  "description": "Evaluation criteria for a ladder-of-abstraction audit: rung tagging, run-rule enforcement, trap repair by climbing down, gap honesty, top-rung discipline, and readability routing",
+  "criteria": [
+    {
+      "name": "Rung Tagging Completeness",
+      "description": "Whether every paragraph or beat carries exactly one rung tag, with R1 pointers recorded for R3 and R4 claims",
+      "weight": 1.0,
+      "scores": {
+        "1": "No tagging performed; the audit reasons about the draft impressionistically",
+        "2": "Partial tagging; some paragraphs untagged or left ambiguous, which is treated as acceptable",
+        "3": "Every paragraph tagged, but R3/R4 claims carry no pointer to the R1 evidence beneath them",
+        "4": "Every paragraph tagged with one rung, R1 pointers recorded for most R3/R4 claims, rung map produced as a table",
+        "5": "Complete rung map with pointers on every R3/R4 claim, ambiguous cases forced to a decision with the reason noted, and costume-R1 paragraphs correctly demoted"
+      }
+    },
+    {
+      "name": "Run-Rule Enforcement",
+      "description": "Whether the six run rules were applied and every violation reported with its paragraph range before any repair was attempted",
+      "weight": 1.2,
+      "scores": {
+        "1": "No run rules applied; the draft is edited paragraph by paragraph on feel",
+        "2": "One or two rules applied informally; violations fixed as encountered, creating new traps downstream",
+        "3": "Most rules applied; violation list produced but incomplete or missing paragraph ranges",
+        "4": "All six rules applied, full violation list with ranges and rule numbers, produced before repairs began",
+        "5": "All six rules applied with the middle-share computation, plus a sawtooth check confirming the alternation is a run constraint rather than a metronome"
+      }
+    },
+    {
+      "name": "Trap Repair By Climbing Down",
+      "description": "Whether middle-rung traps were repaired with a real particular from the material rather than by simplifying vocabulary",
+      "weight": 1.5,
+      "scores": {
+        "1": "Traps fixed by synonym substitution or by shortening sentences; the paragraph is simpler and just as unintelligible",
+        "2": "Some concrete language added, but it is generic or analogical rather than a specific instance from the record",
+        "3": "Real particulars supplied for most traps, though some repairs still rely on plainer jargon",
+        "4": "Every repaired trap gained a named particular traceable to the material, with the repair type labelled",
+        "5": "Every repair traceable to a source, checked for representativeness, with extreme cases flagged as extreme when used in load-bearing positions"
+      }
+    },
+    {
+      "name": "Fabrication Resistance and Gap Honesty",
+      "description": "Whether missing particulars produced gap entries rather than plausible invented specifics, and whether persistent gaps escalated",
+      "weight": 1.5,
+      "scores": {
+        "1": "Invented dates, names, numbers, or scenes appear in the repaired prose; nothing distinguishes them from sourced material",
+        "2": "Composite or 'typical' examples used to fill gaps, presented as if particular",
+        "3": "No fabrication, but missing particulars are silently left as abstraction with no gap entry recorded",
+        "4": "Gap log produced with mechanism, artifact sought, and where searched, for every unfillable trap",
+        "5": "Complete gap log plus explicit escalation when a section accumulates three or more gaps, stating that the defect is missing material rather than missing prose"
+      }
+    },
+    {
+      "name": "Top-Rung Discipline",
+      "description": "Whether the ceiling was declared from the material in advance, and whether every R4 claim passed the counter-sentence test and the generic test",
+      "weight": 1.5,
+      "scores": {
+        "1": "Piece crowned with a universal significance the material does not support; no ceiling declared and no test run",
+        "2": "Ceiling declared only after drafting, or R4 claims softened with hedges instead of deleted",
+        "3": "Ceiling declared; generic test run but counter-sentences either missing or written weak so the claim survives",
+        "4": "Ceiling declared from the material before drafting, counter-sentence written for every R4, generic claims cut or dropped one rung",
+        "5": "All of level 4, plus counter-sentences recorded in the output as receipts, and material with several independent findings given separate ascents instead of one strained abstraction"
+      }
+    },
+    {
+      "name": "Readability Routing Integrity",
+      "description": "Whether failing readability scores were classified (a) split, (b) middle-rung trap, or (c) necessary term before editing, and whether meaning survived",
+      "weight": 1.2,
+      "scores": {
+        "1": "Score optimized directly: sentences chopped and precise terms swapped for vaguer ones until the number passed",
+        "2": "Some diagnosis attempted, but qualifiers deleted or causal links severed to shorten sentences",
+        "3": "Fixes classified, but no meaning-diff performed after repair",
+        "4": "Every failing paragraph classified before editing, forbidden fixes avoided, meaning diffed after each repair",
+        "5": "All of level 4, plus the fix-class distribution reported, with a (b)-dominated run flagged as a warning sign rather than passed as clean"
+      }
+    },
+    {
+      "name": "System-Protagonist Handling",
+      "description": "Whether the technique was applied correctly when the protagonist is a market, protocol, institution, codebase, or supply chain",
+      "weight": 1.0,
+      "scores": {
+        "1": "System granted wants, decisions, and beliefs throughout; intentional verbs assert causation the analysis never established",
+        "2": "Some anthropomorphism repaired, but the repairs produced agentless passives that obscure causation further",
+        "3": "Intentional verbs largely repaired; R1 rung filled with generalized description rather than dated, instrumented particulars",
+        "4": "Agency relocated onto actors, mechanisms, or selection pressures; R1 supplied by first-detection events with timestamps and units",
+        "5": "All of level 4, with agentless-passive count checked after the pass, at most one flagged personification per section, and the mechanism it stands in for named"
+      }
+    },
+    {
+      "name": "Scaffolding Invisibility",
+      "description": "Whether the planning apparatus was removed from the delivered prose",
+      "weight": 0.8,
+      "scores": {
+        "1": "Rung labels, altitude vocabulary, and section roadmaps appear in the prose; it reads as an outline that learned to talk",
+        "2": "Explicit signposting throughout ('zooming out', 'as we saw above', 'at a high level')",
+        "3": "Most scaffolding removed, some transitional signposting remains",
+        "4": "No rung vocabulary or roadmap sentences survive; the ladder is invisible to a reader",
+        "5": "Scaffolding fully absent, the A-frame close lands without a 'which shows that', and a reader could not recite the structure after one read"
+      }
+    }
+  ]
+}

--- a/skills/ladder-of-abstraction/resources/rung-tagging.md
+++ b/skills/ladder-of-abstraction/resources/rung-tagging.md
@@ -1,0 +1,156 @@
+# Rung Tagging: Definitions, Variants, and Repairs
+
+Reference matter for Steps 2 through 4 of the ladder audit.
+
+## Table of Contents
+- [Rung Definitions with Edge Cases](#rung-definitions-with-edge-cases)
+- [Person Variant and System Variant](#person-variant-and-system-variant)
+- [Worked Tagging: Three Passages](#worked-tagging-three-passages)
+- [The Trap Repair Table](#the-trap-repair-table)
+- [Before and After: Climbing Down](#before-and-after-climbing-down)
+- [The Gap Log](#the-gap-log)
+- [Sawtooth Fatigue: A Worked Counter-Example](#sawtooth-fatigue-a-worked-counter-example)
+
+## Rung Definitions with Edge Cases
+
+**R1 — named particulars.** A person with a name, a date, a physical object, a number carrying a unit, a quoted sentence, a document with an identifier. The test: could this be photographed, timestamped, or cited to a specific line in a specific source?
+
+Edge cases that are NOT R1:
+- A number with no unit and no comparison. "Volume rose 40 percent" without a base, a period, or a denominator is R2 wearing a number.
+- A generic person. "A warehouse worker would typically arrive around six" is R2. "Marisol Reyes clocked in at 05:48 on 14 January" is R1.
+- Sensory adjectives attached to a general practice. "The floor was tense and loud during earnings weeks" is summary in costume: it has sensory words, no date, no named actor, no source.
+- A composite or representative example constructed by you. That is invention with an R1 shape.
+
+**R2 — category, mechanism, process, policy.** Names a class of thing or explains how something works, with no instance attached. "Liquidity providers", "inference latency", "instructional units", "capacity constraints", "the escalation policy", "second-line antibiotics".
+
+R2 is not a defect. It is where the explanation lives. It becomes a defect when it has no R1 nearby to stand on.
+
+**R3 — system pattern.** A statement that holds across more than one instance and could be falsified by a counter-case. "Contract prices lag spot prices at every regime change in this sample." "Models trained past the compute-optimal point degrade first on the rarest tokens." "Every one of the four recalls began with a supplier substitution that skipped requalification."
+
+If it cannot be falsified by a counter-case, it is not R3; it is R4 or it is nothing.
+
+**R4 — meaning and stakes.** Trust, risk, obsolescence, scarcity, accountability, control, dependence. R4 is where the piece says what the pattern is worth. It is also where meaning inflation lives. See [top-rung-discipline.md](top-rung-discipline.md).
+
+## Person Variant and System Variant
+
+Everything in this skill works when the protagonist is a market, a protocol, an institution, a codebase, or a supply chain. The rungs change what they contain, not how they behave.
+
+| Rung | Person protagonist | System protagonist |
+|------|--------------------|--------------------|
+| R1 | A named person doing one observable thing at one time in one place | A dated price print, a single transaction ID, one wafer lot number, a log line with a timestamp, an instrument reading with units, one filing |
+| R2 | The role, the authority, the routine, the incentive the person operated under | The mechanism: the fee schedule, the queueing discipline, the retry policy, the requalification procedure |
+| R3 | The pattern across people in that role or that period | The pattern across episodes, nodes, or regimes |
+| R4 | What it cost, what it meant, what was at stake | Same |
+
+**Finding R1 when the protagonist is a system.** Systems have no faces, but they have first-detection events: the first measurement outside tolerance, the first customer complaint, the first failed settlement, the first line in a log, the first empty shelf. Choose the detection event with the best combination of a precise timestamp, a named human present, a number attached, and a documented reaction. Write it at instrument resolution: what the screen actually showed, in what units, what the normal range was, what the observer did next.
+
+Then climb exactly one rung: say what the reading was a reading OF, at system scale. Do not climb two.
+
+**The intentional-verb rule at R2.** When the subject of a sentence is a system, market, institution, model, or abstraction, classify the main verb:
+
+- MECHANICAL — rose, cleared, propagated, saturated, reallocated, timed out. Allowed.
+- INTENTIONAL — wanted, decided, chose, sought, punished, learned, refused. Repair.
+- EVALUATIVE-TELEOLOGICAL — matured, advanced, evolved toward, progressed, naturally moved to. Repair.
+
+Four repairs, in preference order:
+1. **Name the actor.** "The market punished the issuer" becomes "three of the four largest holders sold into the bid on 12 May".
+2. **Name the mechanism.** "The protocol wanted lower latency" becomes "the fee schedule paid more for blocks confirmed inside 400ms".
+3. **Name the selection pressure.** "The industry evolved toward containerization" becomes "carriers that did not containerize lost margin on the transpacific lane and exited; the survivors all had".
+4. **Quote the human.** "The company decided" becomes the person, the meeting, the memo.
+
+If none of the four can be made from the material, that is a research gap, not a style problem. Log it.
+
+**Do not overcorrect.** A hard ban on agency produces "prices were observed to decline", which obscures causation worse than the anthropomorphism did. Count agentless passives after the pass; if they rose, the pass failed. The rule is a claim filter, not a purity filter. Repair intentional verbs that assert false causation. Tolerate the ones that are transparently figurative and locally unambiguous. Permit at most one flagged personification per major section, and only where you can name in one line the mechanism it stands in for.
+
+## Worked Tagging: Three Passages
+
+### Passage A — supply chain (before)
+
+> [P1] Global logistics networks in the period were subject to increasing capacity constraints. [P2] Utilization across major container routes approached theoretical maxima, and the resulting congestion propagated through downstream distribution channels. [P3] Stakeholders across the ecosystem faced significant operational challenges. [P4] Ultimately, this reveals something fundamental about the fragility of interconnected systems.
+
+Tags: P1 = R2. P2 = R2. P3 = R2. P4 = R4.
+
+Violations: Rule 1 (three consecutive R2, STALLED RUN). Rule 3 (P1, P2, P3 all MIDDLE-RUNG TRAP, no R1 within plus-or-minus 2). Rule 4 (P3 to P4 is an ALTITUDE JUMP from the middle straight to meaning). Rule 5 (FLOATING OPENER). P4 also fails the generic test: "the fragility of interconnected systems" attaches to any supply chain story ever written.
+
+Note the trap here is not vocabulary. Replacing "theoretical maxima" with "the most they could handle" lowers the Fog score by two points and leaves the paragraph exactly as unintelligible, because the reader still cannot see anything.
+
+### Passage A — after climbing down
+
+> [P1] The *Ever Given* wedged across the Suez Canal on 23 March 2021 and stayed there six days. Behind it, 369 ships queued. [P2] A container route is a fixed-slot system: berth windows are booked months out, and a ship that misses its window does not get the next one, it gets the one after that. [P3] By the time the canal cleared, Felixstowe was turning away trucks because its yard was full of boxes whose onward trains had already run. [P4] Congestion in a fixed-slot network does not dissipate; it queues, and the queue outlives the blockage that caused it.
+
+Tags: P1 = R1. P2 = R2. P3 = R1. P4 = R3.
+
+Every rule satisfied. Note the ceiling dropped from R4 to R3, and the paragraph got *more* specific rather than simpler. That is climbing down.
+
+### Passage B — ML writeup (before)
+
+> Model performance degradation manifested across evaluation suites as training progressed beyond the optimal compute allocation. The underlying mechanism relates to distributional shift in gradient contributions. This illustrates the fundamental tension between scale and generalization in modern machine learning.
+
+Tags: sentence 1 = R2, sentence 2 = R2, sentence 3 = R4. Middle share 67 percent. ALTITUDE JUMP at the close, and the R4 is generic: "the fundamental tension between scale and generalization" could close any scaling paper.
+
+### Passage B — after
+
+> At 41,000 steps the model still answered "what is the capital of France" correctly and had started answering "what is the capital of Burkina Faso" with "Ouagadougou is a city in Burkina Faso." Accuracy on the common half of the eval set was flat. On the rarest decile it had fallen 11 points. Past the compute-optimal point, the losses do not spread evenly: they land first on the examples the model saw least.
+
+Tags: R1, R1, R2, R3. Ceiling held at R3, which is what the ablation actually supports.
+
+### Passage C — biography (before)
+
+> Throughout her tenure she maintained tight control over organizational decision-making processes. Delegation of authority was limited, and approval workflows routed through the executive office. Her leadership style ultimately reflects the eternal struggle between vision and trust.
+
+Tags: R2, R2, R4. Same shape as A and B in a completely different domain: two middle-rung paragraphs and a jump to a universal.
+
+### Passage C — after
+
+> On 3 March 1988 she declined the second fab in a two-line memo: "Not yet. Bring it back in the spring." She had already declined it in November. [R1] Every capital request above $50,000 crossed her desk, in a company of 1,900 people. [R1, number with unit and denominator] It is the same signature on the 1991 expansion she later said she wished she had approved a year earlier. [R1] Control was the thing she could not delegate, and it cost her the year. [R4]
+
+The R4 survives here because it is small and specific. "Control was the thing she could not delegate" is about this person, not about leadership. Its counter-sentence would be "she delegated freely and the delay came from elsewhere", and the two memos contradict it. That is an earned top rung.
+
+## The Trap Repair Table
+
+| Trap type | Symptom in the draft | Repair | Explicitly forbidden |
+|-----------|----------------------|--------|----------------------|
+| MIDDLE-RUNG TRAP | R2 paragraph with no R1 within plus-or-minus 2 | Find one particular instance of the mechanism in the material and place it adjacent | Replacing jargon with plainer jargon; adding an analogy in place of an instance |
+| STALLED RUN | 3+ consecutive R2/R3 | Insert an R1 instance between them, or merge two abstractions into one | Padding with a transitional paragraph |
+| UNGROUNDED ASCENT | R3/R4 run with no R1 in the prior 2 beats | Move an existing R1 earlier in the section | Writing a new illustrative example from imagination |
+| ALTITUDE JUMP | R1 immediately followed by R4 | Insert the R2 mechanism or R3 pattern the particular belongs to | Softening the R4 with a hedge and leaving the jump |
+| FLOATING OPENER | Piece or section opens at R2/R3/R4 | Open with the particular that made you believe the claim | Adding a scene-setting paragraph not in the record |
+| COSTUME R1 | Sensory adjectives on a general practice | Demote to clean R2 summary, or promote with a date, a place, and named actors from the record | Keeping it because it reads well |
+| MISSING A-FRAME | Piece ends at R3/R4 | Descend to an R1 the reader already met | Ending on a summary of the argument |
+
+## The Gap Log
+
+When a trap has no repair in the material, the output is a log entry, not prose. Format:
+
+```
+GAP-04
+  Paragraph: 12
+  Mechanism needing an instance: how requalification was skipped
+  Artifact that would supply it: a supplier change order, a QA sign-off sheet,
+    or an email approving the substitution
+  Where searched: supplier correspondence 2019-2021, QA archive index, recall filing exhibits
+  Interim treatment: paragraph left as honest summary, no particular asserted
+  Escalation: no — one gap in this section
+```
+
+Rules for the log:
+- A gap entry is a successful outcome, not a failure. It is what prevents fabrication.
+- Three or more gaps in one section triggers escalation: report that the defect is missing material, and that it cannot be fixed at the prose layer.
+- Never resolve a gap with a composite, a typical case, or a reconstruction. A plausible specific is worse than an admitted absence, because it is undetectable downstream.
+- If the gap cannot be filled and the section still needs to exist, shift the form: more summary distance, more explicit mechanism, fewer implied scenes.
+
+## Sawtooth Fatigue: A Worked Counter-Example
+
+The run rules are ceilings, not a rhythm. This passage satisfies every rule and is unreadable:
+
+> On 14 January a pallet of resin arrived at the Newark cross-dock. Cross-docks hold inventory for under 24 hours by design. The pallet left at 22:10. Transfer times determine whether a route is a dock or a warehouse. Two days later it was in Charlotte. Regional distribution operates on a hub-and-spoke topology.
+
+Tags: R1, R2, R1, R2, R1, R2. Zero violations. Six paragraphs, no idea developed, and the reader cannot say what the passage argued.
+
+Diagnostic: if more than half the paragraphs change rung from their neighbor, consolidate. Merge the R2 sentences into one explanation that carries all three particulars, and let the R1s run consecutively as a sequence.
+
+Repaired:
+
+> On 14 January a pallet of resin arrived at the Newark cross-dock, left at 22:10, and was in Charlotte two days later. It never entered a warehouse. That is the design: a cross-dock is defined by holding nothing longer than a day, and the entire regional network is built around the assumption that transfers clear in hours.
+
+Tags: R1, R1, R2. Same information, one idea developed.

--- a/skills/ladder-of-abstraction/resources/top-rung-discipline.md
+++ b/skills/ladder-of-abstraction/resources/top-rung-discipline.md
@@ -1,0 +1,121 @@
+# Top-Rung Discipline: The Honest Ceiling, the Counter-Sentence, and the A-Frame
+
+Reference matter for Steps 1 and 5 of the ladder audit. This file exists because the top rung is where the ladder does its most damage.
+
+## Table of Contents
+- [Why Meaning Inflation Happens](#why-meaning-inflation-happens)
+- [The Honest Ceiling Decision Table](#the-honest-ceiling-decision-table)
+- [The Counter-Sentence Test](#the-counter-sentence-test)
+- [The Generic Test](#the-generic-test)
+- [Meaning-Inflation Catalogue](#meaning-inflation-catalogue)
+- [When the Material Has Three Findings](#when-the-material-has-three-findings)
+- [The A-Frame Close](#the-a-frame-close)
+- [Attribution Caveats](#attribution-caveats)
+
+## Why Meaning Inflation Happens
+
+The instruction "climb to abstraction" produces a reflexive crowning of modest findings with universal significance. A chip-supply analysis becomes a story about human ambition. A latency post-mortem becomes a meditation on complexity. A study of one warehouse becomes the fragility of modern life.
+
+This happens for a structural reason, not a stylistic one: R4 sentences are cheap to generate and expensive to check. They contain no named entity, no unit, no date, and therefore nothing an editor can look up. The counter-sentence test and the generic test exist to make them checkable.
+
+The discipline is Sabrina Imbler's, quoted in The Open Notebook: not every worm story is about justice.
+
+**A piece is allowed to mean something small.** "The queue outlives the blockage" is a complete and honest ceiling. "This teaches us about the interconnectedness of all things" is not a bigger finding; it is the absence of one.
+
+## The Honest Ceiling Decision Table
+
+Run this in Step 1, from the material, before drafting. The ceiling discovered while writing the last paragraph is inflation by construction.
+
+| Your evidence | Honest ceiling | What you may write |
+|---------------|----------------|--------------------|
+| One documented case, mechanism traced | R2 | How this thing works, illustrated by the case. No claim about other cases |
+| One case plus a plausible mechanism for others, untested | R2, with the extension stated as a question | "Whether this holds elsewhere is untested" |
+| Multiple cases, same mechanism, counter-cases searched for and reported | R3 | The pattern, with its boundary conditions and its known exceptions |
+| A pattern plus documented consequences to a named party | R4, narrow | What it cost, to whom, over what period |
+| A pattern plus your sense that it matters | R3. Stop | Nothing above R3 |
+
+Notes on the table:
+- "Counter-cases searched for" is load-bearing. A pattern with no search for exceptions is a set of confirming examples, which is R2 repeated.
+- An R4 that names a party and a cost is checkable. An R4 that names a human universal is not.
+- Ending at R2 is a legitimate outcome for a mechanism explainer, a status report, or documentation. Not every piece ascends.
+
+## The Counter-Sentence Test
+
+For every R4 claim in the draft, write the sentence that asserts its opposite. Then ask which the evidence supports.
+
+| R4 claim | Counter-sentence | Verdict |
+|----------|------------------|---------|
+| "The outage revealed how much of modern finance rests on trust." | "The outage was a routine, local failure of one vendor's retry logic, absorbed within the day." | Counter-sentence equally supported by the incident record. DELETE the R4. Ceiling is R3. |
+| "The recall showed that cost pressure erodes safety culture." | "The recall showed that one supplier substitution skipped one requalification step." | Counter-sentence is better supported and more specific. DELETE. |
+| "Control was the thing she could not delegate, and it cost her the year." | "She delegated freely; the delay came from elsewhere." | Contradicted by the two memos and the 1991 signature. KEEP. |
+| "Latency became the price of admission to the venue." | "Latency was one factor among several, and firms without co-location continued to trade profitably." | Check the material. If the second is true, the claim is R3 at best, and narrower. |
+
+Mechanics of the test:
+1. Write the counter-sentence in the same register and at the same length. A deliberately weak counter-sentence is not a test.
+2. Judge on the evidence in the material, not on which sounds truer.
+3. "Equally supported" is a delete, not a hedge. Softening an unsupported R4 to "perhaps this suggests" leaves the altitude jump intact and adds evasion.
+4. If the R4 survives, record the counter-sentence in the output. It is the receipt.
+
+## The Generic Test
+
+Read your top-rung sentence, then ask: could this be attached to any story in this domain?
+
+Generic ceilings, by domain, all of which should be cut:
+- Market history: "in the end, markets are made of people"; "this was, at bottom, a story about greed and fear"
+- ML writeups: "the fundamental tension between scale and generalization"; "this illustrates the limits of current approaches"
+- Supply chain: "the fragility of interconnected systems"; "efficiency and resilience are in tension"
+- Post-mortems: "complex systems fail in complex ways"; "no single cause is ever the whole story"
+- Biography: "she contained multitudes"; "the eternal struggle between vision and pragmatism"
+- Public health: "the pandemic exposed inequalities that were always there"
+
+Each is true. None is a finding. The tell is that you could have written it before doing the research, which means the research did not produce it.
+
+Repair: drop one rung and get specific. "Efficiency and resilience are in tension" becomes "the network held no buffer above four days, so a six-day closure could not be absorbed anywhere in it". That is R3, it is checkable, and it is actually about this material.
+
+## When the Material Has Three Findings
+
+The single-ascent rule improves prose and becomes a trap when the material genuinely contains several independent findings. Forcing one covering abstraction over three findings produces an abstraction that covers all three badly, which is meaning inflation arriving by a side door.
+
+Decision:
+- Three findings, one domain, no shared mechanism: three sections, each with its own descent and its own ascent, and no unifying R4 at the end. The piece ends on the strongest section's ceiling.
+- Three findings that genuinely share a mechanism: one ascent is correct, and the shared mechanism is your R3.
+- Three findings and a deadline: publish the strongest one. A piece with one earned ceiling beats a piece with three half-supported ones.
+
+Never write the sentence that begins "taken together, these findings suggest" unless you can name the mechanism that takes them together.
+
+## The A-Frame Close
+
+The A-frame: readers climb to meaning, then descend, so the meaning changes how they see an ordinary thing. The close restates the surviving abstraction through one R1 particular the reader has already met.
+
+Requirements:
+1. The particular must already have appeared in the piece. A new specific in the last paragraph is a new claim with no room left to support it.
+2. The reader must see it differently than on first meeting. If the close only repeats the earlier appearance, it is a summary, not a descent.
+3. The abstraction is *enacted*, not restated. If you have to write "which shows that", the descent has failed.
+
+Four worked closes:
+
+**Supply chain.** Opened on the *Ever Given* wedged in the canal on 23 March 2021, 369 ships behind it. Ceiling reached: the queue outlives the blockage. Close: "The canal reopened on the twenty-ninth. Felixstowe was still turning trucks away in July."
+
+**ML writeup.** Opened on the model answering "Ouagadougou is a city in Burkina Faso" at 41,000 steps. Ceiling: losses land first on the rarest examples. Close: "The capital of France stayed correct through every checkpoint we saved. It was never going to be the thing that told us."
+
+**Incident post-mortem.** Opened on the 03:12 page and the on-call engineer's first command. Ceiling: the retry policy amplified the failure it was written to absorb. Close: "The retry limit is still three. It is three because in 2019 it was one, and once, for a different reason, that was the thing that went wrong."
+
+**Biography.** Opened on the two-line memo of 3 March 1988. Ceiling: control was the thing she could not delegate. Close: "The 1991 memo approving the fab is four lines. She signed it the same way. By then the site cost twice as much."
+
+Anti-patterns in closes:
+- Ending on an R4 the piece has not earned, because the ending is where inflation feels most natural.
+- Ending on a summary of the argument. That is a descent to R2, not to R1.
+- Ending on a new statistic. Numbers introduced at the close cannot be contextualized.
+- Ending on a question addressed to the reader in place of a finding.
+
+## Attribution Caveats
+
+Carry these. An open-sourced skill that invents provenance loses credibility on first inspection.
+
+- **The ladder is Hayakawa's.** Roy Peter Clark operationalized it for working prose (Poynter, "Writing Tool 13: Show and Tell"). Jack Hart teaches it in *Wordcraft* as a variety-and-texture device. None of them is the sole source.
+- **The four-rung R1/R2/R3/R4 split is this skill's refinement**, separating pattern from meaning. Hart and Clark work with three rungs (bottom, middle, top). Do not attribute the four-rung scheme to either.
+- **"Not every worm story is about justice"** is Sabrina Imbler, quoted in The Open Notebook's piece on the ladder in science stories. It is not Hart and not Clark.
+- **The A-frame** comes from the science-writing adaptation of the ladder, not from Hart.
+- **All numeric thresholds here are derived operational defaults**: the plus-or-minus-2 window, the 2-paragraph run ceiling, the 40 percent middle share, the "more than half the paragraphs change rung" sawtooth trigger. Nobody published them. Ship them as tunable config and say so.
+- **Do not cite "the Oregon Method" as a codified canon.** Hart does not brand or define it; it is a retrospective label for the coaching practice he ran at *The Oregonian*. Cite Hart, *Storycraft*, *Wordcraft*, or the specific Nieman Storyboard column.
+- **SCAM (Setting, Character, Action, Meaning) is not Hart's acronym.** It comes from journalism pedagogy elsewhere. If a neighbouring skill uses it, attribute it there, not to Hart.

--- a/skills/mcphee-structure-derivation/SKILL.md
+++ b/skills/mcphee-structure-derivation/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: mcphee-structure-derivation
+description: Derives a document's structure out of its own corpus instead of picking one off a menu, using John McPhee's coding-and-sorting procedure - cold read, short topic codes one per card, a strict chronology sort run against a strict theme sort, a logged list of every disagreement resolved toward chronology, candidate juxtapositions gated by a state-and-footnote test, a named shape, and an invisibility test. Use when you hold researched material and have no structure yet, when a draft has turned into concept-named sections full of time-scrambled evidence, when deciding whether a flashback is earned, or when user mentions McPhee, coding pass, index cards, deriving structure, chronology versus theme, structure from material, or "what shape is this piece".
+---
+
+# McPhee Structure Derivation
+
+## Table of Contents
+- [Core Principles](#core-principles)
+- [Workflow](#workflow)
+- [The Dual Sort and Its Resolution](#the-dual-sort-and-its-resolution)
+- [Shape Catalog](#shape-catalog)
+- [Guardrails](#guardrails)
+- [Quick Reference](#quick-reference)
+
+**Related skills:** Use `narrative-form-triage` before this skill - it decides the FORM the corpus can support and owns the DO NOT NARRATE refusal, while this one derives the SHAPE once a narrative form has been declared. Use `writing-structure-planner` once components exist - that skill SELECTS among eight known shapes and diagrams the choice; this one DERIVES a shape from raw material and hands the named shape plus the card piles over to it. Use `writing-revision` on the prose after components are drafted, `writing-pre-publish-checklist` for the final gate.
+
+## Core Principles
+
+1. **Derive, do not select**: The shape is an output of sorting cards, not an input chosen before reading. If you named the shape before you coded the corpus, you imposed it.
+2. **Chronology wins by default**: McPhee's rule is that tension between chronology and theme is near-universal and chronology usually wins. Theme-sorting is the cheapest operation a language model performs, which is exactly why it must be the one that has to argue for itself.
+3. **One code per card, provenance on every card**: The sortable unit is a chunk of researched material with a source, not a heading you invented. A card with no source is not a card.
+4. **White space is a claim**: An inference produced by placing two cards side by side escapes citation discipline. Only juxtapose to imply something you would state outright and footnote.
+5. **Name the shape or keep sorting**: "Partly chronological, partly thematic, with some flashbacks" is not a name. If it cannot be named, the sort is unfinished.
+6. **Invisible bones**: Structure should be about as visible as someone's skeleton. If a reader can recite it after one read, you over-signposted.
+7. **Refusal is a result**: "This corpus has no derivable narrative shape; it is a set of independent findings" is a successful terminal output, not a failure.
+
+## Workflow
+
+Copy this checklist and track your progress:
+
+```
+McPhee Structure Derivation Progress:
+- [ ] Step 1: Cold read, then code the corpus onto cards
+- [ ] Step 2: Sort twice and log every disagreement
+- [ ] Step 3: Resolve each disagreement toward chronology
+- [ ] Step 4: Test candidate juxtapositions against the footnote gate
+- [ ] Step 5: Name the shape, then run the invisibility test
+- [ ] Step 6: Write component by component, lede last, then hand off
+```
+
+**Step 1: Cold read, then code the corpus onto cards**
+
+Step 1.1: Read the entire corpus once, marking nothing, annotating nothing, writing nothing. The purpose is to let patterns surface before your first classification freezes them. Record only the fact that you did it.
+
+Step 1.2: Read again. Assign every chunk a short topic code in airport-code style - `SMELTER-Q3`, `RETRY-STORM`, `LAB-MOVE-32`, `TARIFF-88`. Codes name what the chunk is about. Codes that name a document part (`BACKGROUND`, `ANALYSIS`, `CONTEXT`, `DISCUSSION`) are not topic codes and will silently reproduce a generic essay outline.
+
+Step 1.3: One code per card. Each card carries: code, one-line content, the date or date range the material belongs to, source reference, and a typicality label (median / tail / unique) against the corpus. Cards with an unknown date go to a dated-unknown pile, not to a guessed slot.
+
+See [resources/coding-pass.md](resources/coding-pass.md) for the card schema, the code-quality tests, a worked corpus, and the discarded-card log format.
+
+**Step 2: Sort twice and log every disagreement**
+
+Step 2.1: Sort A - strict chronology. Order every card by its date. No thematic grouping allowed, even where it obviously helps. Write the resulting sequence of codes down.
+
+Step 2.2: Sort B - strict theme. Group every card by topic, ignoring dates entirely. Write that sequence down too.
+
+Step 2.3: Produce the disagreement log: every place the two sorts put the same card in a materially different position. This log is a required artifact. A derivation that reports no disagreements did not run both sorts.
+
+**Step 3: Resolve each disagreement toward chronology**
+
+Step 3.1: Walk the log row by row using [The Dual Sort and Its Resolution](#the-dual-sort-and-its-resolution). Default resolution is chronology.
+
+Step 3.2: Break chronology only where a theme is strong enough to justify a flashback, and only by naming the explicit re-entry point - the dated card the narrative returns to. A flashback with no named re-entry point is a rejected resolution.
+
+Step 3.3: Maintain the discarded-card log with two separate columns: cards that did not support the emerging shape, and cards that contradicted it. The first column may be pruned. The second column must appear in the body of the finished piece.
+
+**Step 4: Test candidate juxtapositions against the footnote gate**
+
+Step 4.1: Identify candidates: which two non-adjacent cards, placed side by side, generate an inference you currently have to assert in a sentence?
+
+Step 4.2: For each candidate, write the inference out as a margin note. Then answer one question: would you state this inference in the text and footnote it with the evidence you hold? If no, discard the juxtaposition. Do not keep it because it is elegant.
+
+Step 4.3: Order surviving pairs so the second card REVISES the first rather than echoing it, and cap them at roughly one per major section (a derived working default, not a published figure).
+
+See [resources/juxtaposition-discipline.md](resources/juxtaposition-discipline.md) for the gate, worked passes and failures, and the adjacency-as-causation cases.
+
+**Step 5: Name the shape, then run the invisibility test**
+
+Step 5.1: Draw the resolved sequence and NAME it from the [Shape Catalog](#shape-catalog). If nothing fits, keep sorting - do not invent a hybrid label to end the step.
+
+Step 5.2: Invisibility test. Ask whether a reader could recite the structure after one read. If yes, delete roadmap sentences ("This piece has three parts", "Having examined X, we now turn to Y") until they cannot.
+
+Step 5.3: Write the shape contract: shape name, runner-up shape, why the runner-up lost, the flashbacks and their re-entry points, the surviving juxtapositions, and the contradicting-card list. The contract is immutable inside a draft. Changing shapes mid-draft requires an explicit logged restart.
+
+**Step 6: Write component by component, lede last, then hand off**
+
+Step 6.1: Write one component at a time, from that component's card pile only. No reaching into other piles for a better line. This is the point of the cards.
+
+Step 6.2: Write the lede last, after the shape is fixed and the components exist.
+
+Step 6.3: Hand the named shape, the component piles, and the shape contract to `writing-structure-planner` for diagramming, gold-coin placement and pacing.
+
+Validate using [resources/evaluators/rubric_mcphee_structure_derivation.json](resources/evaluators/rubric_mcphee_structure_derivation.json). **Minimum standard**: Average score >= 3.5.
+
+## The Dual Sort and Its Resolution
+
+Work the disagreement log with this table. Chronology is the default; every other resolution owes an artifact.
+
+| Disagreement pattern | Concrete instance | Resolve to | Required artifact |
+|---|---|---|---|
+| A theme collects events months or years apart with no causal dependency between them | Three port strikes in 1971, 1978 and 1984 that a theme sort files together as "labor disruption" | Chronology | None. Cards stay in date order. |
+| A later card is unintelligible without an earlier one that chronology puts far behind it | A 1994 retry-storm outage that only makes sense given a 1989 client-library default | Chronology, with the earlier card promoted as a short dated inset inside the later section | One sentence naming the inset and its date |
+| The meaning of a theme lives in a comparison across eras, not in either era alone | The same enzyme assay performed in 1957 and in 2003 with opposite conclusions | Theme, but only as a dual or triple profile on an explicitly named common denominator | The denominator, written as one noun phrase |
+| The origin material precedes the reader's live interest by years | A protocol's 1996 design meetings versus the 2011 adoption fight the piece is actually about | Chronology beginning late, with one flashback | The named dated re-entry point |
+| Two independent contradictions each demand their own spine | A supply chain that is both cost-fragile and politically exposed, with separate evidence bases | Neither - braid or split into two deliverables | A written note of which contradiction was set aside and why |
+| Cards are independent findings with no causal chain at all | Six unrelated audit findings sharing only a fiscal year | Neither sort yields narrative | Terminal output: "no derivable narrative shape." Hand to `narrative-form-triage`, which owns the DO NOT NARRATE verdict and picks taxonomy versus chronicle, then to `writing-structure-planner` to diagram the grouped form |
+
+**Failure signature to watch for (theme-sort capture):** five sections named after concepts, each holding evidence from scrambled years, with no accumulating tension anywhere. If your draft looks like that, Sort B captured the derivation and Step 3 was skipped.
+
+**Opposite failure:** slavish chronology laid over material whose meaning genuinely is comparative, producing an undifferentiated timeline. Both failures are detectable from the disagreement log, which is why the log is required.
+
+## Shape Catalog
+
+Name the resolved sequence as one of these. Full descriptions, diagrams and emergence tests live in [resources/shape-catalog.md](resources/shape-catalog.md).
+
+| Shape | Emerges when the sorts show | Person protagonist | System protagonist |
+|---|---|---|---|
+| Linear | Chronology and theme mostly agree | A career told forward | A standard's revisions in release order |
+| Circular | One card is both the strongest entry and the natural close | Open and close on the same hospital shift | Open and close on the same dated shutdown |
+| Spiral | The same window revisited at widening radius | One decision, then the family, then the town | One plant, then the firm, then the industry |
+| Dual profile | Two card sets on one denominator, meaning in the contrast | Two chemists, one problem | Two ports, one shipping lane |
+| Triple profile | Three sets on one common denominator | Three surgeons, one procedure | Three outages, one dependency |
+| Geographic traverse | Cards order naturally along a route or physical path | A walk along a fault line | Ore to smelter to cell to pack |
+| Braided | Two or three timelines advancing in parallel, cross-cutting | Two rivals, interleaved years | Regulation and market price, interleaved |
+
+Caveat on provenance: McPhee described and drew several of these shapes, but this seven-row list is a working taxonomy assembled by commentators on his 2013 essay, not a canon he codified. Treat the names as vocabulary for the naming step, not as an authoritative set.
+
+Caveat on tooling: McPhee mechanised this sort with purpose-built software - Structur, then Alpha, then a program he called Mac - which slotted coded chunks into their piles automatically. That matters because it tells you the procedure is mechanical by design. It is a filing operation, not an act of taste, and it should feel like one.
+
+## Guardrails
+
+**Requirements:**
+
+1. **Cold read first**: The first pass produces no codes, no notes, no marks. Record that it happened before coding.
+2. **Both sorts, written down**: Sort A and Sort B must both exist as written sequences, and the disagreement log must be produced. Skipping Sort A and calling the theme sort "the structure" is the dominant failure this skill exists to prevent.
+3. **No card without provenance**: Every card cites a source. Never create a card to fill a hole in an emerging shape. A hole means the shape is wrong, not that you need one more fact.
+4. **Footnote gate on every juxtaposition**: The implied inference is written out, and kept only if you would state and cite it. Adjacency is not evidence of causation.
+5. **Contradicting cards surface in the body**: The discarded-card log separates "did not support" from "contradicted". The second category is never pruned silently.
+6. **Named shape or explicit refusal**: End with a shape name from the catalog, or with the finding that the corpus has none.
+7. **Immutable shape contract**: Once named, the shape does not change mid-draft. Structure shopping produces a document that opens as one thing and ends as another, which readers register as untrustworthiness.
+8. **Dated events, not periods disguised as moments**: For a system protagonist, a card's "moment" must be a dated filing, price print, release, incident or failed test. "Through the late 1990s" is a summary card, and label it as one.
+
+**Common pitfalls:**
+- Coding chunks with document-part labels (`BACKGROUND`, `IMPLICATIONS`) rather than topic codes, which reproduces a generic outline under a McPhee-shaped process.
+- Declaring a flashback without naming the re-entry point, so the piece leaves the timeline and never returns.
+- Keeping a juxtaposition because it is elegant after it failed the footnote test.
+- Flattening genuinely multi-causal material into one shape because a single mechanism is tidier, without logging what was set aside.
+- Writing the lede early, which quietly fixes the shape before the sorts are resolved.
+- Reaching outside a component's card pile while drafting it, which dissolves the piles back into an undifferentiated corpus.
+- Letting personifying verbs ("the market decided", "the protocol wanted") carry causal claims the cards do not support.
+
+## Quick Reference
+
+**Key resources:**
+- **[resources/coding-pass.md](resources/coding-pass.md)**: card schema, code-quality tests, a fully worked corpus from cold read to named shape, disagreement log and discarded-card log formats
+- **[resources/shape-catalog.md](resources/shape-catalog.md)**: seven shapes with emergence tests, diagrams, person and system variants, and each shape's failure signature
+- **[resources/juxtaposition-discipline.md](resources/juxtaposition-discipline.md)**: the state-and-footnote gate, passing and failing worked pairs, revision-versus-echo ordering, adjacency-as-causation cases
+- **[resources/evaluators/rubric_mcphee_structure_derivation.json](resources/evaluators/rubric_mcphee_structure_derivation.json)**: quality scoring
+
+**Inputs required:**
+- A researched corpus with sources attached (notes, transcripts, documents, logs, datasets, extracted claims)
+- Dates or date ranges for as much of the material as the record supports
+- Any known audience constraint (obligated reader, voluntary reader, length limit)
+
+**Outputs produced:**
+- A coded card set with provenance and typicality labels
+- Sort A (chronology), Sort B (theme), and the disagreement log
+- Resolutions, with re-entry points named for every flashback
+- Surviving juxtapositions with their written-out inferences
+- A named shape and a shape contract, or an explicit "no derivable shape" finding
+- Component card piles ready for `writing-structure-planner`

--- a/skills/mcphee-structure-derivation/resources/coding-pass.md
+++ b/skills/mcphee-structure-derivation/resources/coding-pass.md
@@ -1,0 +1,149 @@
+# The Coding Pass
+
+Reference matter for Steps 1-3: the card schema, code-quality tests, log formats, and two worked derivations - one with a system protagonist, one with a person.
+
+> The corpora below are **synthetic illustrations**, invented to show the mechanics of sorting. They are labelled as such deliberately. In real use, every card must trace to a real source, and this skill's central prohibition is against creating a card to fill a hole in an emerging shape.
+
+## Table of contents
+
+- [Why the cold read comes first](#why-the-cold-read-comes-first)
+- [Card schema](#card-schema)
+- [Code-quality tests](#code-quality-tests)
+- [Log formats](#log-formats)
+- [Worked derivation A: a system protagonist](#worked-derivation-a-a-system-protagonist)
+- [Worked derivation B: a person protagonist](#worked-derivation-b-a-person-protagonist)
+- [When the derivation should refuse](#when-the-derivation-should-refuse)
+
+## Why the cold read comes first
+
+The first read produces nothing. No codes, no highlights, no notes. This is not ceremony. The moment you begin classifying, your first three classifications become the categories that the rest of the corpus is forced into, and everything that does not fit one of them becomes invisible. McPhee's account is that he read his notes until patterns emerged - the patterns arrive from the whole, not from the first ten pages.
+
+For an agent the failure is sharper than for a human. An agent that codes on the first pass will produce codes that mirror the order the material was fetched in, so the "derived" structure ends up being the retrieval order with topic names painted on it.
+
+Record the cold read as a completed step. If the corpus is too large to read whole, read a stratified sample whole, and say in the shape contract that you did.
+
+## Card schema
+
+One code per card. Each card carries six fields:
+
+| Field | Content | Rule |
+|---|---|---|
+| `code` | Short topic code, airport-code style | Names the topic, never the document part |
+| `content` | One line: what the chunk says | If it takes three lines, it is two cards |
+| `date` | Date or date range the material belongs to | Unknown goes to a dated-unknown pile, never to a guessed slot |
+| `source` | Document, page, transcript timestamp, table row, commit hash | No source, no card |
+| `typicality` | `median` / `tail` / `unique` against the corpus | Required before a card can hold a load-bearing position |
+| `kind` | `event` / `state` / `claim` / `figure` / `quote` | `state` cards cannot be treated as moments |
+
+Example cards:
+
+```
+code: SMELTER-Q3        date: 2019-08-14   kind: event   typicality: tail
+content: Refinery halts three of five lines after a grid fault; 11-day stoppage.
+source: Operator incident notice 2019-08-14, p.2
+
+code: RETRY-STORM       date: 1994-03-02   kind: event   typicality: median
+content: Client retries amplify a 40-second backend blip into a 6-hour outage.
+source: Post-incident review PIR-114, timeline section
+
+code: ASSAY-DRIFT       date: 1957-1961    kind: state   typicality: median
+content: Published enzyme activity figures drift 12% across four labs, unexplained.
+source: Reanalysis table 3, Hollins 2004
+```
+
+The `kind` field is what stops "through the late 1990s" from being written as a scene. A `state` card describes a condition holding over a span; it can open a section but it cannot be a moment. For a system protagonist this distinction does most of the work, because systems tempt you to narrate a decade as if it were an afternoon.
+
+## Code-quality tests
+
+Run each proposed code through these four. A code failing any of them gets rewritten before sorting.
+
+1. **Topic, not part.** `BACKGROUND`, `CONTEXT`, `ANALYSIS`, `IMPLICATIONS`, `DISCUSSION`, `KEY-FINDINGS` are document parts. They will reassemble themselves into a generic essay outline and the derivation will look like it worked. Rewrite as the thing the chunk is actually about.
+
+   Bad: `BACKGROUND` / `CONTEXT-2` / `ANALYSIS-MAIN`
+   Good: `PORT-STRIKE-71` / `GRID-FAULT` / `LICENSE-DENIAL`
+
+2. **Would sort two ways.** A good code has both a date and a topic, so it can appear in Sort A and Sort B at different positions. A code that can only be placed thematically (`THEORY`) or only chronologically (`TIMELINE-3`) is not sortable and is therefore useless to this procedure.
+
+3. **Under five words, no sentence.** Codes are handles. `THE-SHIFT-TOWARD-DISTRIBUTED-PROCUREMENT` is a thesis wearing a code's clothes and it will smuggle a conclusion into the sorting stage.
+
+4. **Repeatable.** If the same code is assigned to eight chunks, either it is a legitimate recurring thread (fine - it will braid) or it is too coarse (split it). Eight chunks under `POLICY` is too coarse. Eight chunks under `WAFER-YIELD` spanning four years is a thread.
+
+## Log formats
+
+### Disagreement log
+
+Required output of Step 2. One row per card that the two sorts place materially differently.
+
+| Card | Sort A position (chronological) | Sort B position (thematic) | Nature of the disagreement | Resolution | Artifact |
+|---|---|---|---|---|---|
+| `LICENSE-DENIAL` | 4th, between two 2011 cards | 11th, grouped with regulation | Theme pulls it forward by seven years | Chronology | none |
+| `DESIGN-MTG-96` | 1st | 6th, grouped with architecture | Origin material precedes reader interest | Chronology starting late + one flashback | Re-entry: `ADOPTION-VOTE` (2011-06-09) |
+
+A derivation reporting zero disagreements did not run both sorts. Near-total agreement is possible only when the corpus is a single unbroken process; say so explicitly if you claim it.
+
+### Discarded-card log
+
+Two columns, always separate. This separation is the guard against the quiet failure where structural discipline eats disconfirming evidence, since evidence that contradicts the emerging shape is by definition evidence that does not serve it.
+
+| Card | Reason | Category |
+|---|---|---|
+| `TRADE-SHOW-04` | Interesting, no bearing on the spine | did-not-support |
+| `YIELD-RECOVERY-05` | Yield recovered a year before the fix shipped, against the causal reading | **contradicted** |
+
+Rule: `did-not-support` cards may be pruned without mention. `contradicted` cards must appear in the body of the finished piece, not in an endnote and not stacked in a qualifications paragraph at the end.
+
+## Worked derivation A: a system protagonist
+
+**Synthetic corpus:** a regional battery-materials supply chain, twenty-two documents.
+
+**Step 1 - cold read.** Whole corpus read, nothing marked.
+
+**Step 2 - codes.** Fourteen cards emerge:
+
+`MINE-EXPAND` (2016), `OFFTAKE-A` (2017-03), `OFFTAKE-B` (2017-03), `RAIL-CLOSURE` (2018-05), `SMELTER-Q3` (2019-08), `SPOT-SPIKE` (2019-09), `RECYCLE-PILOT` (2019-11), `EXPORT-RULE` (2020-02), `CELL-DERATE` (2020-06), `PACK-RECALL` (2020-09), `SECOND-SOURCE` (2021-01), `PRICE-FLOOR` (2021-04), `MINE-IDLE` (2022-07), `AUDIT-FINDING` (2022-11).
+
+**Sort A (chronology):** MINE-EXPAND, OFFTAKE-A, OFFTAKE-B, RAIL-CLOSURE, SMELTER-Q3, SPOT-SPIKE, RECYCLE-PILOT, EXPORT-RULE, CELL-DERATE, PACK-RECALL, SECOND-SOURCE, PRICE-FLOOR, MINE-IDLE, AUDIT-FINDING.
+
+**Sort B (theme):** *Contracts* (OFFTAKE-A, OFFTAKE-B, PRICE-FLOOR, SECOND-SOURCE); *Physical disruption* (RAIL-CLOSURE, SMELTER-Q3, MINE-IDLE); *Prices* (SPOT-SPIKE, CELL-DERATE); *Policy* (EXPORT-RULE, AUDIT-FINDING); *Alternatives* (RECYCLE-PILOT, MINE-EXPAND, PACK-RECALL).
+
+**Disagreement log, abridged:**
+
+| Card | A | B | Nature | Resolution |
+|---|---|---|---|---|
+| `PRICE-FLOOR` | 12th | 3rd, with contracts | Theme pulls a 2021 instrument next to 2017 offtakes | Chronology |
+| `MINE-EXPAND` | 1st | 13th, with alternatives | Theme reads a 2016 expansion as an alternative-supply story | Chronology |
+| `AUDIT-FINDING` | 14th | 10th, with policy | Theme groups it with the 2020 export rule | Chronology |
+| `RECYCLE-PILOT` | 7th | 14th | Theme treats it as an epilogue | Chronology |
+
+Every row resolves to chronology. No theme here is strong enough to buy a flashback. That is the ordinary outcome, and it is the point of the default. Adopting Sort B would have given the piece four concept-named sections: Contracts, Disruption, Prices, Policy. Each would hold evidence from 2016 through 2022 in scrambled order. No tension would accumulate anywhere.
+
+**Step 4 - juxtapositions.** One candidate survives the footnote gate: `OFFTAKE-A` (the contract language guaranteeing volume irrespective of route availability) beside `RAIL-CLOSURE` (the route closing fourteen months later). The implied inference - the contract priced volume risk and ignored route risk - is one you would state and cite to both documents. A rejected candidate: `EXPORT-RULE` beside `SPOT-SPIKE`, which would imply the rule moved the price when the spike preceded it by five months. That is adjacency-as-causation and it fails the gate on the dates alone.
+
+**Step 5 - shape.** Linear, with one white-space argument in the third section. Runner-up: geographic traverse (mine to smelter to cell to pack), rejected because the corpus's disruptions are dated events rather than located stages, so a traverse would have forced date-scrambling to hold the route order.
+
+**Contract:** shape = linear; runner-up = geographic traverse; flashbacks = none; juxtapositions = 1 (`OFFTAKE-A` | `RAIL-CLOSURE`); contradicted cards to surface in body = `YIELD-RECOVERY-05`.
+
+## Worked derivation B: a person protagonist
+
+**Synthetic corpus:** the papers of a crystallographer, 1938-1979.
+
+**Codes:** `LAB-MOVE-38`, `WARTIME-GAP`, `FIRST-STRUCTURE-49`, `PRIORITY-DISPUTE-52`, `TEACHING-LOAD`, `METHOD-PAPER-58`, `INSTRUMENT-BUILD-61`, `REFUSAL-64` (declines a directorship), `SECOND-STRUCTURE-71`, `ARCHIVE-INTERVIEW-79`.
+
+**The one disagreement that mattered:** Sort B groups `LAB-MOVE-38` with `INSTRUMENT-BUILD-61` under *apparatus*, twenty-three years apart. Sort A keeps them at opposite ends. Here the theme has a real claim on the material - the same physical problem, solved twice, with opposite institutional support - and the comparison is the meaning.
+
+**Resolution:** dual profile on a named common denominator: *building your own instrument*. The denominator is written down as that noun phrase, which is what licences the break from chronology. Inside each half of the dual profile, chronology is restored strictly.
+
+**Not licensed:** `PRIORITY-DISPUTE-52` and `REFUSAL-64` also cluster thematically (both are about credit), but the cluster produces no comparison the reader could not make from the timeline. It stays chronological. A theme earns a break when the comparison is the finding, not when it is merely tidy.
+
+**Flashback:** one, from `METHOD-PAPER-58` back to `WARTIME-GAP`. Re-entry point named: `INSTRUMENT-BUILD-61`.
+
+**Shape:** dual profile on a common denominator, with an interior linear chronology in each panel.
+
+## When the derivation should refuse
+
+Refusal is a legitimate output and must be reported as a finding, not worked around.
+
+- **No causal chain.** Cards are independent findings sharing only a period or a subject. No sort produces accumulating tension. Output: "no derivable narrative shape; use a grouped form" and hand to `writing-structure-planner`.
+- **No dates.** More than roughly half the cards land in the dated-unknown pile. Sort A cannot run, so the procedure cannot run. Say what dating the corpus would need.
+- **Two independent spines.** Two contradictions with separate evidence bases, neither subordinate. Braid or split into two deliverables, and log which was set aside and why. Do not flatten to one mechanism because one mechanism is more elegant.
+- **A hole in the shape.** The emerging shape requires a card the corpus does not contain. The shape is wrong. Never write the missing card.

--- a/skills/mcphee-structure-derivation/resources/evaluators/rubric_mcphee_structure_derivation.json
+++ b/skills/mcphee-structure-derivation/resources/evaluators/rubric_mcphee_structure_derivation.json
@@ -1,0 +1,104 @@
+{
+  "name": "McPhee Structure Derivation Rubric",
+  "description": "Evaluation criteria for a structure derived from a corpus by the coding-and-sorting procedure. Scores the process artifacts, not the prose. Average must be >= 3.5; a score below 3 on Dual Sort Integrity or Juxtaposition Discipline requires rework regardless of the average.",
+  "criteria": [
+    {
+      "name": "Coding Quality",
+      "description": "Whether the corpus was cold-read and then coded into sortable, sourced, dated cards with topic codes rather than document-part labels",
+      "weight": 1.0,
+      "scores": {
+        "1": "No cards; the corpus was summarized into sections directly",
+        "2": "Cards exist but codes are document parts (BACKGROUND, ANALYSIS) or lack dates and sources",
+        "3": "Topic codes with sources, but dates are patchy and typicality is unlabelled",
+        "4": "Cold read recorded; topic codes pass the four code-quality tests; every card carries source and date or sits in the dated-unknown pile",
+        "5": "As 4, plus kind and typicality labelled on every card, and undated material explicitly quarantined rather than guessed into position"
+      }
+    },
+    {
+      "name": "Dual Sort Integrity",
+      "description": "Whether both a strict chronology sort and a strict theme sort were actually run and written down, with a disagreement log produced",
+      "weight": 1.4,
+      "scores": {
+        "1": "Only a thematic grouping exists; concept-named sections hold time-scrambled evidence (theme-sort capture)",
+        "2": "One sort written down, the other asserted to have been run; no disagreement log",
+        "3": "Both sorts written down; disagreement log present but partial or vague about the nature of each conflict",
+        "4": "Both sequences written in full; every materially disagreeing card logged with the nature of the conflict",
+        "5": "As 4, plus each row states its resolution and required artifact, and near-agreement (if claimed) is explicitly justified by the material"
+      }
+    },
+    {
+      "name": "Chronology-First Resolution",
+      "description": "Whether disagreements resolved toward chronology by default, with any theme-driven break justified and given a named re-entry point",
+      "weight": 1.2,
+      "scores": {
+        "1": "Theme won throughout with no justification; the timeline is unrecoverable",
+        "2": "Multiple unjustified breaks from chronology; flashbacks with no re-entry points",
+        "3": "Chronology mostly won, but at least one break lacks a stated justification or a named re-entry card",
+        "4": "Every break from chronology names its justifying theme and its explicit dated re-entry point",
+        "5": "As 4, plus theme-driven breaks carry a concrete common denominator written as a noun phrase, and interior chronology is restored inside each panel"
+      }
+    },
+    {
+      "name": "Juxtaposition Discipline",
+      "description": "Whether each white-space argument passed the state-and-footnote gate, avoided adjacency-as-causation, and stayed within budget",
+      "weight": 1.3,
+      "scores": {
+        "1": "Juxtapositions imply causation or motive the evidence does not support, and none is written out",
+        "2": "Inferences not written out; pairs kept on aesthetic grounds; no budget applied",
+        "3": "Inferences written out, but at least one would not survive being stated and cited, or the pairs echo rather than revise",
+        "4": "Every pair has a written inference that passes the footnote test, ordered so the second card revises the first, budget respected",
+        "5": "As 4, plus rejected candidates recorded with the reason, and system-protagonist personification capped and counted"
+      }
+    },
+    {
+      "name": "Shape Naming and Invisibility",
+      "description": "Whether the resolved sequence carries a real shape name with a stated emergence test, and whether roadmap sentences were stripped",
+      "weight": 1.0,
+      "scores": {
+        "1": "No shape named; the structure is described as 'a mix' or left implicit",
+        "2": "A shape label asserted with no emergence test, or a hybrid label invented to end the sorting step",
+        "3": "Shape named with a plausible test, but the invisibility test was not run",
+        "4": "Shape named with its emergence test stated about the actual cards; invisibility test run and roadmap sentences removed",
+        "5": "As 4, plus runner-up shape named with the reason it lost, and any surviving signposting justified as navigation furniture for an obligated reader"
+      }
+    },
+    {
+      "name": "Evidence Custody",
+      "description": "Whether discarded material was logged with did-not-support separated from contradicted, and contradicting cards routed into the body",
+      "weight": 1.2,
+      "scores": {
+        "1": "Material that did not fit the shape was dropped silently",
+        "2": "A single undifferentiated discard list; contradicting evidence not distinguished",
+        "3": "Two categories present, but contradicting cards are relegated to endnotes or a closing qualifications block",
+        "4": "Two categories maintained; every contradicting card assigned a position in the body",
+        "5": "As 4, plus each contradicting card's effect on confidence in the shape is stated, and cards invented to fill holes are demonstrably absent"
+      }
+    },
+    {
+      "name": "Refusal Capability",
+      "description": "Whether the derivation was willing to report that the corpus supports no shape, rather than manufacturing one",
+      "weight": 1.0,
+      "scores": {
+        "1": "A shape was imposed on independent findings, manufacturing causality the corpus does not support",
+        "2": "Refusal conditions present in the material but unacknowledged; the shape was forced",
+        "3": "Refusal conditions acknowledged in passing, then worked around without explanation",
+        "4": "Refusal conditions checked explicitly; either a shape is justified against them or the no-shape finding is reported",
+        "5": "As 4, plus multi-causal material was braided or split rather than flattened, with the set-aside contradiction named and explained"
+      }
+    },
+    {
+      "name": "Contract and Handoff",
+      "description": "Whether an immutable shape contract was produced and the component piles were made ready for downstream drafting",
+      "weight": 0.8,
+      "scores": {
+        "1": "No contract; drafting began before the shape was fixed, or the lede was written first",
+        "2": "Shape stated informally; no record of flashbacks, juxtapositions or contradicting cards",
+        "3": "Contract present but incomplete; components not separated into piles",
+        "4": "Full contract (shape, runner-up, flashbacks with re-entry points, juxtapositions, contradicting cards); components piled; lede written last",
+        "5": "As 4, plus the contract is marked immutable with a logged-restart rule, and the handoff to writing-structure-planner is explicit"
+      }
+    }
+  ],
+  "threshold": 3.5,
+  "passing_note": "Average score must be >= 3.5. Scores below 3 in 'Dual Sort Integrity' or 'Juxtaposition Discipline' require rework regardless of the average: the first indicates theme-sort capture, the second indicates uncited claims placed in white space."
+}

--- a/skills/mcphee-structure-derivation/resources/juxtaposition-discipline.md
+++ b/skills/mcphee-structure-derivation/resources/juxtaposition-discipline.md
@@ -1,0 +1,73 @@
+# Juxtaposition Discipline
+
+Reference matter for Step 4. Juxtaposition is McPhee's most portable move and the most dangerous one this skill carries, so it gets its own gate.
+
+## What the move is
+
+Two units of researched material placed side by side, with a hard section break between them and no bridging sentence, produce an inference the writer never states. McPhee's account of the effect, describing a pair of sections in *Encounters with the Archdruid*: in the white space between those two sections there is a great deal he does not have to say.
+
+The mechanism is deletion. You write both units, you write the sentence stating what they jointly mean, and then you delete that sentence. What remains is an argument the reader assembles.
+
+## Why it needs a gate
+
+An inference in white space escapes citation discipline. A stated claim gets a footnote, a hedge, a confidence level, and a reviewer who can dispute it. An implied claim gets none of those, and it lands just as hard - harder, because readers trust conclusions they believe they reached themselves.
+
+In evidence-bound domains this inverts the usual advice. In a memoir an unstated implication is craft. In a post-mortem, a regulatory history, a research writeup or a financial analysis, an unstated implication is an uncited claim, and the fact that it is deniable is the problem rather than the defence.
+
+So: **only juxtapose to imply a relation you would state outright and defend with a footnote.**
+
+## The gate
+
+Run this on every candidate pair. All five must pass.
+
+1. **Write the inference down.** In the margin, as a full sentence, in the plainest form. If you cannot write it, the pair does not carry one and the adjacency is decoration.
+2. **Footnote test.** Would you state this sentence in the body and attach the evidence you hold to it? If no - if the honest answer is "I would have to hedge it so heavily it would lose its force" - discard the pair. Do not keep the juxtaposition because the hedged version is weaker. That weakness is the evidence telling you something.
+3. **Revision, not echo.** Does the second unit revise the first, or restate it? Echo is decoration. Revision is argument. Order the pair so the second card changes what the first meant.
+4. **Naive-reader test.** Would a reader with no prior context state the inference unprompted? If not, the units are wrong. Change the units. Do not restore the deleted sentence and call it a juxtaposition.
+5. **Budget.** Roughly one white-space argument per major section (a derived working default, not a published figure). The device works by contrast with ordinary prose. Made the default rhythm, it stops working, and every section break starts reading as an insinuation.
+
+## Passing pairs, across domains
+
+| Domain | Card 1 | Card 2 | Inference (written, then deleted) | Why it passes |
+|---|---|---|---|---|
+| Incident analysis | The escalation runbook, v4, as written | The on-call transcript for the night in question | The runbook was not followed | Both documents are in the record; you would state and cite this |
+| Institutional history | The charter's stated admissions criterion | Ten years of admitted-cohort composition | The stated criterion did not govern | Both are documentary; the claim is about a gap, not a motive |
+| Supply chain | Contract language guaranteeing volume regardless of route | The route closing fourteen months later | The contract priced volume risk and ignored route risk | A claim about what the document covers, defensible from the document |
+| Biography | A public statement declining credit | A private letter claiming priority | The public modesty was positional | Both texts exist; the inference is about inconsistency, not psychology |
+| Science writeup | The registered analysis plan | The published analysis | The analysis changed after data collection | Two dated documents; this is exactly the kind of claim one footnotes |
+
+Note what all five have in common: the inference is about a **gap between two records**, and both records are in hand. That is the safe class.
+
+## Failing pairs
+
+| Domain | Card 1 | Card 2 | Implied inference | Why it fails |
+|---|---|---|---|---|
+| Market history | A policy decision in July | A price move in August | The decision moved the price | Adjacency-as-causation. You would not state this without an identification strategy, so you may not imply it |
+| Incident analysis | A team reorganisation in Q1 | An outage in Q3 | The reorg caused the outage | Same failure, and it assigns blame to named people through arrangement alone |
+| Supply chain | An export rule in February | A price spike the previous September | The rule moved the price | Fails on dates alone; the effect precedes the cause |
+| Research programme | A funder's stated priority | A lab's subsequent topic shift | The lab chased money | Attributes motive. Motive is not in the record |
+| Biography | A childhood incident | An adult decision forty years later | The incident explains the decision | Psychological causation, unfalsifiable, and the white space hides that it is unfalsifiable |
+
+The pattern in the failures: the inference is about **causation or intent**, not about a gap between records. Causal and motive claims need to be stated, so they need the citations that stating requires.
+
+## The system-protagonist trap
+
+Juxtaposition's failure mode has a distributed cousin. When the protagonist is a market, a protocol, an institution or a codebase, causal claims can also enter through verbs - "the market decided", "the protocol wanted", "the algorithm chose". Each one is a miniature white-space argument: an assertion of intent that never faces the citation discipline an explicit claim would face.
+
+Rule: personify at most once, as an openly flagged framing device. After that, attribute behaviour to named mechanisms and named actors. Count the personifying verbs in a draft and cap them. This is the same discipline as the footnote gate, applied at sentence scale.
+
+For a system protagonist, the safe juxtaposition class is narrower and clearer than for a person: **the stated rule beside the observed behaviour**. Charter beside conduct, runbook beside transcript, spec beside implementation, public messaging beside shipped product, registered plan beside published result. All of these compare two records. None of them requires you to know what anything wanted.
+
+## Recording the survivors
+
+The shape contract lists every surviving juxtaposition in this form:
+
+```
+JUX-1  cards: RUNBOOK-V4 | PAGER-LOG-0217
+       inference: the documented escalation path was not used
+       would state and cite: yes - runbook p.3, pager log 02:17-02:44
+       order: RUNBOOK-V4 first (LOG revises it)
+       section: 3
+```
+
+Recording the inference in the contract is what makes it auditable later. It also keeps the deleted sentence recoverable. If a reviewer says the white space is doing too much work, paste the sentence back in with its footnote. That was always the fallback, and taking it is never a failure.

--- a/skills/mcphee-structure-derivation/resources/shape-catalog.md
+++ b/skills/mcphee-structure-derivation/resources/shape-catalog.md
@@ -1,0 +1,167 @@
+# Shape Catalog
+
+Reference matter for Step 5. Each shape has an emergence test (what the two sorts must show before you may name it), a diagram, a person variant, a system variant, and a failure signature.
+
+> **Provenance caveat.** McPhee drew and described several of these shapes, most famously in his 2013 essay on structure. This seven-row list is a working taxonomy assembled from that essay and from commentary on it - not a canon McPhee codified, and not a closed set. Use the names as vocabulary for the naming step. If your resolved sequence genuinely fits none of them, describe it in one sentence that a reader could redraw from, and treat that sentence as the name.
+
+## The naming rule
+
+You may name a shape only when you can state its emergence test in one sentence about your own cards. "It felt chronological with some themes" is not a name and not a test. If nothing fits, keep sorting. The pressure to end the sorting step by inventing a hybrid label is the main reason derivations stop one pass too early.
+
+---
+
+## Linear
+
+**Emergence test:** Sort A and Sort B mostly agree, or every disagreement resolved to chronology.
+
+```
+[1]--[2]--[3]--[4]--[5]--[6]
+```
+
+**Person:** A career told forward. A trial told day by day.
+**System:** A standard's revisions in release order. A supply chain's disruptions in date order. A codebase's migrations.
+
+**Failure signature:** an undifferentiated timeline. Everything is equally weighted, nothing accumulates. The fix is not to switch shapes - it is to check whether the corpus contains a contradiction at all. Linear material with no contradiction is a chronicle, and a chronicle should be told as one rather than dressed as a narrative.
+
+**Guard:** linear is the default and therefore the least examined. Confirm you actually ran Sort B, rather than defaulting to time because it required no decisions.
+
+---
+
+## Circular
+
+**Emergence test:** one card is both the strongest available entry point and the natural close, and the material between them explains how the first reading of that card was incomplete.
+
+```
+      [A]
+     /   \
+  [4]     [1]
+    \     /
+     [3]-[2]
+```
+
+**Person:** open on a surgeon mid-shift; close on the same shift, now legible.
+**System:** open on the dated shutdown; close on the same shutdown after the reader knows what the operators knew.
+
+**Failure signature:** the return is a restatement rather than a revision. If the closing pass on card A adds nothing the reader did not have at the top, the circle is decoration. Cut to linear.
+
+**Guard:** the returning card must be the *same* card, not a similar one. Two different shutdowns is a braid, not a circle.
+
+---
+
+## Spiral
+
+**Emergence test:** the same window of time supports three passes at widening radius, each pass containing cards the previous pass could not have used.
+
+```
+[narrow]--> [wider]--> [widest]
+   |___________|___________|
+        same window
+```
+
+**Person:** one decision, then the family it moved through, then the town.
+**System:** one plant, then the firm, then the industry. One failed request, then the service, then the platform.
+
+**Failure signature:** the passes repeat rather than widen. Each pass must add a scale of evidence, not a rephrasing. If pass two contains the same cards as pass one with more adjectives, you have a linear piece with redundancy.
+
+**Guard:** name the radius of each pass explicitly in the shape contract - "plant / firm / industry" - so the widening is checkable.
+
+---
+
+## Dual profile
+
+**Emergence test:** two card sets sit on one denominator you can write as a single noun phrase, and the meaning of the material lives in the contrast rather than in either set alone.
+
+```
+[ A1 A2 A3 ]  ||  [ B1 B2 B3 ]
+      \_____denominator_____/
+```
+
+**Person:** two chemists working the same problem in different institutions.
+**System:** two ports on one shipping lane. Two teams running the same migration. Two jurisdictions applying one rule.
+
+**Failure signature:** the denominator is vague ("innovation", "leadership", "risk"). A vague denominator lets any two sets sit together and produces a comparison with no finding in it. If you cannot write the denominator as a concrete noun phrase - *building your own instrument*, *the same assay*, *one shipping lane* - the shape is not earned.
+
+**Guard:** inside each panel, restore strict chronology. Dual profile buys you one break from time, at the top level only.
+
+---
+
+## Triple profile on a common denominator
+
+**Emergence test:** as above, with three sets, and the third genuinely adds a dimension rather than a third data point. Three sets that only confirm each other are a list, not a profile.
+
+```
+[ A ]   [ B ]   [ C ]
+  \_______|_______/
+      denominator
+```
+
+**Person:** three surgeons performing one procedure across three decades.
+**System:** three outages traced to one shared dependency. Three adoptions of one protocol under three regulators.
+
+**Failure signature:** the third panel is thin. If set C has four cards against A's fourteen, either promote a subordinate theme into C or drop to dual profile. An underweight panel reads as an afterthought and readers discount all three.
+
+---
+
+## Geographic traverse
+
+**Emergence test:** the cards order naturally along a route or physical path, *and* that ordering does not require scrambling dates to hold.
+
+```
+[origin]--[stage]--[stage]--[terminus]
+```
+
+**Person:** a walk along a fault line. A journey up a river, told in the order of the miles.
+**System:** ore to smelter to cell to pack. Request to edge to service to datastore. Field to elevator to port to mill.
+
+**Failure signature:** the route wins and the dates scramble. Physical order is a form of thematic order, so it competes with chronology and must survive the same test. If holding the traverse forces 2016 evidence after 2022 evidence with no flashback discipline, chronology wins and you use linear.
+
+**Guard:** traverse works best when the corpus's events *are* located stages. It works badly when the events are dated shocks that happen to occur at places.
+
+---
+
+## Braided
+
+**Emergence test:** two or three timelines advance in parallel, they cross-cut at datable moments, and neither can be told to completion before the other without the reader losing the connection.
+
+```
+A1----A2--------A3-----A4
+   B1------B2-------B3
+   ^cross  ^cross    ^cross
+```
+
+**Person:** two rivals, years interleaved.
+**System:** regulation and market price. A research programme and the instrument it needed. A migration and the incident load it caused.
+
+**Failure signature:** the strands never touch. If A and B only alternate without crossing, you have two pieces stapled together. Mark the cross-cut cards explicitly; three or more crossings is the working minimum for calling it a braid (a derived default, not a published figure).
+
+**Guard:** braiding is the honest home for DHY material - two independent contradictions that both matter. Preferring braid over flattening to one mechanism is the anti-flattening move. But the alternative of splitting into two deliverables is often better, and the contract must say why you chose to braid.
+
+---
+
+## Shape does not exist
+
+**Emergence test:** the cards are independent findings with no causal chain, or more than half the corpus is undated, or two spines are genuinely independent and neither subordinate.
+
+Output the finding. "This corpus has no derivable narrative shape; it is six audit findings sharing a fiscal year" is a successful result. Hand to `writing-structure-planner` for a grouped or pyramid form, where the organizing logic is category and importance rather than time.
+
+The pressure to avoid this outcome is strong, because a named shape feels like a deliverable and a refusal feels like failure. It is the opposite: a shape named over material that does not support one will manufacture causality, and manufactured causality is a correctness defect rather than a style choice.
+
+---
+
+## The invisibility test
+
+Once named, run it. Could a reader recite your structure after one read?
+
+**Over-signposted (fails):**
+
+> This piece has three parts. First we examine the contracts, then the disruptions, then the policy response. Having examined the contracts, we now turn to the disruptions. As we saw above, the offtake agreements had priced volume risk. In the next section we will see what happened when the route closed.
+
+**Invisible (passes):**
+
+> [section break]
+>
+> The rail line closed on 14 May 2018.
+
+The second version carries the same transition. The date does the work the roadmap sentence was doing, and the section break does the rest. Delete roadmap sentences until the reader can follow the piece without being able to draw it.
+
+Two exceptions worth naming. A genuinely obligated reader who must be able to navigate - a regulator, a reviewer, an on-call engineer reading a post-mortem at 3am - may need a signposted contents block at the top. That is navigation furniture, not structure narration, and it belongs outside the prose. And a braid may need one sentence establishing that two timelines are running, because the reader cannot infer a second strand from its first card alone.

--- a/skills/narrative-arc-mapping/SKILL.md
+++ b/skills/narrative-arc-mapping/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: narrative-arc-mapping
+description: Maps researched evidence onto Truby's twenty-two structural steps without fabricating the steps the evidence cannot fill. Runs the designing-principle discrimination test, step-fit triage (PRESENT / ABSENT / NOT APPLICABLE), per-slot warrant cards, the empty-slot decision table, the moral-argument spine, and the revelation-intensity audit, then stops at a tagged scene weave. Use when architecting a long-form nonfiction piece from a research corpus, structuring a post-mortem, market history, biography, or science writeup, or when user mentions Truby, 22 steps, designing principle, moral argument, revelation sequence, scene weave, or step-fit triage.
+---
+
+# Narrative Arc Mapping
+
+## Table of Contents
+- [Core Principles](#core-principles)
+- [Workflow](#workflow)
+- [Step-Fit Triage](#step-fit-triage)
+- [The Empty-Slot Decision Table](#the-empty-slot-decision-table)
+- [Story-Movement Shapes](#story-movement-shapes)
+- [Guardrails](#guardrails)
+- [Quick Reference](#quick-reference)
+
+**Related skills:** Use `narrative-form-triage` FIRST — do not run this skill on material that has not been declared STORY NARRATIVE. Use `research-claim-map` to assemble the claim corpus. Use `deliberation-debate-red-teaming` to generate the rival arcs in Step 3. Use `narrative-opposition-web` for opponent warranting, which it owns. Use `scene-construction-scam` to build the scenes this skill's weave only tags. Use `causal-inference-root-cause` when the question is what caused the outcome. Use `writing-structure-planner` when triage says the material has no arc.
+
+## Core Principles
+
+1. **Structure is discovered, not imposed**: The material decides which steps exist. You run a triage against evidence, not a fill-in-the-blanks template.
+2. **An empty slot is a finding**: "ABSENT — the record does not support this step" is a first-class, correct output. All twenty-two filled is the signature of fabrication.
+3. **Narrative order is permitted; narrative causation is not**: You may reorder scenes for structure. You may never imply anyone knew something before the sources show they could have.
+4. **Endpoint-first, contemporaneity-gated**: Derive the starting weakness backward from the known outcome, then require a source dated *before* the outcome that says the weakness was real. Backward derivation without that gate is hindsight determinism.
+5. **Theme is enacted, never narrated**: The moral argument is carried by who wins and what they became to win. Explicit moral language is allowed in exactly three positions (see [resources/slot-warrants.md](resources/slot-warrants.md)).
+6. **Intensity is course change, not adjectives**: A revelation's rating is the size of the change it forces in desire, motive, or plan. "Devastatingly" rates nothing.
+7. **The macro layer stops at the scene weave**: One tagged line per scene plus construction fields. If you write a paragraph of prose, you have overrun your job.
+
+## Workflow
+
+Copy this checklist and track your progress:
+
+```
+Narrative Arc Mapping Progress:
+- [ ] Step 1: Declare subject level, corpus, and selection rule
+- [ ] Step 2: Derive endpoint-first, gate every weakness on a contemporaneous source
+- [ ] Step 3: Find the designing principle (four gates) and the rival arcs
+- [ ] Step 4: Triage all 22 steps; warrant every PRESENT slot
+- [ ] Step 5: Resolve empty slots; choose movement shape
+- [ ] Step 6: Build moral spine and revelation sequence; emit tagged scene weave; STOP
+```
+
+**Step 1: Declare subject level, corpus, and selection rule**
+
+Step 1.1: State whether the protagonist is a PERSON, a NAMED ORGANIZATION, or a SYSTEM (a market, a protocol, an institution, a codebase, a supply chain). Hold it constant. Oscillating between "the standards committee" and "the protocol" is the first symptom of agency laundering.
+
+Step 1.2: Tag every source: PRIMARY/CONTEMPORANEOUS or SECONDARY/RETROSPECTIVE, plus its interest (promotional, adversarial, regulatory, disinterested, unknown). A dated pre-outcome source is not automatically clean; trade press and analyst notes carry an in-progress halo. Never base a documented-mechanism claim on a purely secondary retrospective account.
+
+Step 1.3: Write the corpus selection rule in one sentence: "This corpus consists of X that survived / were written about / left logs / are still listed." If you cannot state it, you do not know what your evidence is a sample of.
+
+**Step 2: Derive endpoint-first**
+
+Step 2.1: Write the terminal claim: "By the end, the reader understands that ____." Split it into PSYCHOLOGICAL self-revelation (what the subject learns about what it was doing to itself) and MORAL self-revelation (what it was doing to others). If only one exists, say so; do not manufacture the other.
+
+Step 2.2: Invert each into a starting-state weakness. Then apply the **contemporaneity gate**: every claimed starting weakness needs a citation dated before the outcome that shows the deficiency was visible then. A weakness evidenced only by post-hoc commentary is confabulation and must be marked INFERRED.
+
+Step 2.3: State NEED (internal, hidden, unrecognised at the start), PROBLEM (the concrete opening crisis, an outgrowth of the weakness), and DESIRE (external, visible). Desire test: name the specific moment at which a reader can tell whether the goal was reached. No nameable moment means it is not a desire.
+
+Step 2.4: Run the confusion check. If need and desire use the same verb, you have collapsed them.
+
+See [resources/slot-warrants.md](resources/slot-warrants.md) for the hindsight-determinism procedure and the system-protagonist translation table.
+
+**Step 3: Find the designing principle**
+
+Step 3.1: Write the premise line (one sentence: the event that starts it, the subject, the outcome). Then draft 4-6 one-line candidate designing principles, each starting with a process verb: trace, force, use, show, follow, invert, express.
+
+Step 3.2: Run all four gates on each candidate. A candidate must pass all four. Gate 3 (IT CUTS) requires you to **name three specific claims in the corpus the principle excludes**. A principle that excludes nothing organises nothing.
+
+Step 3.3: Generate at least three structurally distinct rival arcs before committing (tragedy / structure-decided / contingency / convergence). Rank by fewest inconsistencies with the corpus, not most consistencies. Name the runner-up and the evidence that would have favoured it in the delivered notes.
+
+See [resources/designing-principle.md](resources/designing-principle.md) for the four gates, worked candidates across five domains, and the rival-arc matrix.
+
+**Step 4: Triage all 22 steps**
+
+Step 4.1: Run every one of the twenty-two steps against the material and record PRESENT (with source) / ABSENT (material does not support) / NOT APPLICABLE (this domain or shape does not use it). Emit the table; it ships with the deliverable.
+
+Step 4.2: Check the MANDATORY SEVEN. Any ABSENT there is a stop-work condition, not a style choice.
+
+Step 4.3: Fill a warrant card for every PRESENT slot, including the question "name two other events a narrator working toward a different ending would have chosen for this slot." If you cannot name two, you have not searched the corpus.
+
+Step 4.4: Declare the START TYPE (community / running / slow). If slow, report the structural risk before proceeding.
+
+See [resources/twenty-two-steps.md](resources/twenty-two-steps.md) for all 22 with functions, system variants, and triage defaults.
+
+**Step 5: Resolve empty slots and choose the shape**
+
+Step 5.1: For each ABSENT slot, pick a move from [The Empty-Slot Decision Table](#the-empty-slot-decision-table). Log the slot and the move chosen.
+
+Step 5.2: Enforce the budget: at most ONE inference-filled slot in the whole piece, never at the climax or the thesis sentence. If two or more major slots are empty, Move 3 (change the architecture) is mandatory.
+
+Step 5.3: Choose one dominant movement shape and at most one secondary. If not linear, every strand must carry all seven mandatory steps or be cut.
+
+**Step 6: Moral spine, revelations, scene weave, stop**
+
+Step 6.1: Build the moral-argument spine, mapping each element to evidence and leaving unsupported elements visibly EMPTY. If the material is value-neutral (a benchmark result, a pricing mechanism, a taxonomy), return "no moral argument available; this is an explanatory piece" and run the steps in explanatory mode.
+
+Step 6.2: Extract every revelation onto its own line. Rate intensity 1-10 strictly by size of course change. Audit for monotonic climb and accelerating pace. Information that changes nothing is exposition; relabel it.
+
+Step 6.3: Emit the scene weave: ONE line per scene, max 200 characters, tagged with step, strand, and reveal, plus the construction fields (whose desire / opposition / plan / endpoint / twist). Re-check every reorder against source dates. Then stop. Do not write prose.
+
+Validate using [resources/evaluators/rubric_narrative_arc_mapping.json](resources/evaluators/rubric_narrative_arc_mapping.json). **Minimum standard**: average score >= 3.5.
+
+## Step-Fit Triage
+
+**The mandatory seven.** Truby: a story "must have no fewer than the seven steps, because that is the least number of steps in an organic story." ABSENT on any of these means the material does not have this shape.
+
+| Mandatory step | Person variant | System variant |
+|---|---|---|
+| Weakness and need | The flaw ruining their situation | Structural fragility, dependency, or unexamined assumption |
+| Desire | The visible goal pursued | The goal participants collectively and verifiably pursued |
+| Opponent | Who wants the same thing | Competing faction or force pursuing the same goal by incompatible means |
+| Plan | How they intend to get it | The dominant strategy, standard, or consensus approach |
+| Battle | The decisive confrontation | The decisive contest: one vote, one quarter, one decision |
+| Self-revelation | What they learn | What the system now knows, evidenced by an observed behaviour change |
+| New equilibrium | The changed steady state | The changed steady state, explicitly higher or lower than the start |
+
+**Commonly and legitimately ABSENT in analytical domains.** Expect these to be empty and do not patch them: ghost; fake-ally opponent; attack by ally; gate / gauntlet / visit to death; opponent's self-revelation; audience revelation. Truby calls the gate/gauntlet "the most moveable of the 22 steps," and practitioners note the fake-ally opponent is "not 100% essential to all stories."
+
+**Middle-weight check.** Count steps before the plan versus after. A front-loaded outline reproduces exactly the sagging middle the extra fifteen steps exist to prevent.
+
+## The Empty-Slot Decision Table
+
+| Move | When | What it looks like |
+|---|---|---|
+| **1. DECLARE THE ABSENCE IN THE BODY** (default) | Any empty slot | "No source records what was decided in that room." / "The commit history is silent on why the timeout was set to 30 seconds." A named absence creates tension; it does not destroy it. |
+| **2. DOWNGRADE AND SUBSTITUTE** | An adjacent event exists but was not treated as pivotal at the time | "The nearest thing to a turning point in the record is the March supplier audit, though nobody then treated it as one." |
+| **3. CHANGE THE ARCHITECTURE** | Two or more major slots empty | Re-run rival arcs with shapes that do not need the missing slots: chronicle, braided comparison, taxonomy, single-question investigation. |
+
+**Illegal moves:**
+- Fill by inference and disclose only in an endnote, footnote, appendix, or methods block. Readers experience the body. Any inference occupying a structural slot must be disclosed **within two sentences of the inference, in the same typographic register as the surrounding prose**, and marked non-removable.
+- Fill by invention of any kind: an invented ghost, an invented betrayal, a supplier who changed terms promoted to fake-ally opponent.
+
+**Budget:** at most one inference-filled slot per piece, never at the climax. (This cap is a derived working default for research-narrative work, not a figure published by Truby or by any of the source disciplines.)
+
+## Story-Movement Shapes
+
+| Shape | Select when | Typical fit |
+|---|---|---|
+| Linear | One subject, one intense desire, causal explanation | Biography, single-incident post-mortem, one-firm case |
+| Meandering | Desire exists but is not intense; broad territory; nobody is really fighting anyone | Landscape surveys, field reviews |
+| Spiral | The same event or claim re-examined at deeper levels each pass | Forensic accounting, replication analyses, root-cause retrospectives |
+| Branching | Paths splitting from central points, each a complete sub-world | Supply-chain tiers, protocol ecosystems, taxonomy explainers |
+| Explosive | Simultaneity itself is the argument, rendered by deliberate crosscutting | Systemic crises only |
+
+**Explosive is the cop-out shape.** Complex interconnected research invites the agent to declare simultaneity and thereby choose no shape at all, producing a piece where nothing builds. Explosive is the hardest form and requires crosscutting between named, seven-step-complete strands. **Default to linear or spiral** unless the designing principle genuinely demands otherwise, and write down why.
+
+## Guardrails
+
+**Requirements:**
+
+1. **Absence is reportable**: The triage table must ship with the deliverable. At least one of the twenty-two steps reported ABSENT with a reason is the healthy signature; all twenty-two filled fails the output gate.
+2. **Contemporaneity gate on every weakness**: A starting weakness with no pre-outcome citation is marked INFERRED and cannot occupy the climax or the thesis sentence.
+3. **Opponent warrant before promotion**: Opponent slots are warranted by `narrative-opposition-web`; an unwarranted opponent may not be marked PRESENT.
+4. **Agency audit on every abstraction**: Flag every intentional verb attached to a system. "The market realised," "the industry learned," "the protocol wanted." Rewrite each one to named actors, or cash it out into a collective mechanism (a vote, a standard, a price) in the same sentence.
+5. **Date check on every reorder**: Structural reordering that implies anyone knew something before they could have is a defect regardless of how well it reads. Evidence overrides structure. Keep a reorder log with one line per departure from chronology.
+6. **Explanatory mode is legitimate**: "No moral argument available" is a permitted and sometimes correct output. Forcing one on a benchmark, a pricing mechanism, or a taxonomy produces sanctimony and a manufactured villain.
+7. **Justify from the material, not from film canon**: Do not cite Truby's stock examples (The Godfather, Casablanca, Tootsie) as justification for a structural choice. They import single-protagonist, decisive-battle, terminal-revelation assumptions that do not hold in most analytical domains.
+8. **Consider the agency reading**: For each major outcome, state the strongest skill-and-intent explanation you considered and why you did or did not adopt it. Over-attributing to luck and structure is also a bias.
+9. **Stop at the weave**: One tagged line per scene, 200 characters max. No paragraphs, no prose, no draft.
+
+**Common pitfalls:**
+- Filling all 22 slots because empty ones look like unfinished work. This is the single highest-frequency failure of this method.
+- The retrofitted weakness: a starting deficiency that exists only to make the known ending look inevitable.
+- The strawman opponent: assigning the role to whoever lost and backfilling stupidity. Bad craft and bad analysis at once.
+- The decorative fourth corner: padding a real two-sided conflict with generic "regulators" and "users." Delete the corner; if no argument breaks, it was decoration.
+- Two-part opposition sneaking back: corners C and D appear in the setup and vanish from the drive section.
+- Manufactured escalation: inflating adjectives instead of sequencing genuinely larger findings.
+- The moralizing narrator: building a correct moral spine and then also stating the lesson in prose.
+- The flat drive: five quarters of declining margin or five failed experiments described identically. If you can swap any two drive actions without changing the argument, they are one beat.
+- Multiple apparent defeats: there is exactly one, everything else is a setback.
+- Turning every check into a delete rule. These are label-and-disclose devices. An agent that gates on all of them ships a chronicle, and a chronicle informs nobody.
+- Epistemic apparatus crowding out the subject. If disclosures, hedges, and contingency nodes exceed roughly one per 250 words, the material is too thin for this architecture: change the architecture rather than spending more disclosure budget.
+
+## Quick Reference
+
+**Key resources:**
+- **[resources/twenty-two-steps.md](resources/twenty-two-steps.md)**: all 22 steps with function, system variant, triage default, and the evidence each requires; start types; multistrand rule; scene-weave output spec
+- **[resources/designing-principle.md](resources/designing-principle.md)**: the four discrimination gates, worked good/bad candidates across five domains, the rival-arc matrix, genre disclosure and suppression-set reinstatement
+- **[resources/slot-warrants.md](resources/slot-warrants.md)**: the structural slot warrant card, hindsight-determinism procedure, moral-argument spine, revelation audit, agency audit, system translation table, GOOD/BAD output gate
+- **[resources/evaluators/rubric_narrative_arc_mapping.json](resources/evaluators/rubric_narrative_arc_mapping.json)**: quality scoring
+
+**Inputs required:**
+- **Precondition (hard):** a frozen spine contract from `narrative-form-triage` declaring the form STORY NARRATIVE. Any other declaration — EXPLANATORY NARRATIVE, MULTI-NODE GATHERING, DO NOT NARRATE — means this skill does not run. No contract means run the triage first, not this.
+- A research corpus with dated, attributable sources
+- The known outcome or finding (the endpoint already exists in researched material)
+- Target length (sets the reveal count and step-count target)
+
+**Outputs produced:**
+- Subject-level declaration and source ledger (primary/secondary, interest tag, selection rule)
+- Endpoint-first derivation with contemporaneity gate results
+- One designing principle plus the three claims it excludes, and the named runner-up arc
+- The 22-step triage table: PRESENT (source) / ABSENT (reason) / NOT APPLICABLE
+- Warrant card per PRESENT slot; empty-slot log with the move chosen for each
+- Moral-argument spine with visible EMPTY elements, or an explanatory-mode declaration
+- Revelation sequence with intensity ratings justified by course change
+- Tagged scene weave, one line per scene, and nothing beyond it

--- a/skills/narrative-arc-mapping/resources/designing-principle.md
+++ b/skills/narrative-arc-mapping/resources/designing-principle.md
@@ -1,0 +1,122 @@
+# The Designing Principle and the Rival-Arc Matrix
+
+## What it is
+
+The designing principle is a one-line statement of the STRATEGY for telling this material. It is not what happens (that is the premise) and it is not what it means (that is the theme). Truby's formula: **Designing Principle = Story Process + Original Execution.** Both terms are required.
+
+It is invisible to readers and indispensable to you, because it is the criterion that decides what gets included. Every inclusion decision after Step 3 is adjudicated against it. Truby: "never take your eye off of it during the long writing process."
+
+**Attribution caveat.** The four-gate discrimination test below is a formulation built for this skill from Truby's scattered criteria. He does not publish it as a numbered four-gate test. The gates are faithful to his stated requirements; the packaging is not his.
+
+## The four gates
+
+A candidate must pass **all four**. A candidate that fails any gate is a premise or a theme wearing a costume.
+
+### GATE 1 — PROCESS, NOT EVENT
+
+Does it describe HOW the piece is told (a process, a strategy, a shape), rather than WHAT happens? If you can rewrite it as a plot summary without losing anything, it is a premise.
+
+Test phrasing: does it begin with a process verb? Trace, force, use, show, follow, invert, express.
+
+| Fails | Passes |
+|---|---|
+| "Show how a 1970s dam project displaced a river valley" (plot summary) | "Trace one river's engineering by following the water that no longer arrives, from the delta backward to the dam" |
+
+### GATE 2 — ABSTRACT, NOT MORAL
+
+Is it a strategy rather than a lesson? If the candidate contains a *should*, an *ought*, or a value judgment, it is a theme, not a designing principle.
+
+| Theme (not this) | Designing principle (this) |
+|---|---|
+| "A person lives a happier life when he gives to others" | "Trace the rebirth of a man by forcing him to view his past, present and future over the course of one night" |
+| "Reviewers should have caught the fabricated data sooner" | "Use each of the four peer reviewers as a separate storyteller, so that the same figure means something different every time it is read" |
+
+### GATE 3 — IT CUTS
+
+Does adopting it cause you to DELETE material from the research corpus? **You must name at least three specific claims it excludes.** A principle that excludes nothing organises nothing.
+
+This is the gate an agent will most reliably fake, so it is stated as a production requirement, not a judgment call. Write the three excluded claims out.
+
+Worked example. Corpus: a two-year investigation of a regional hospital's sepsis mortality.
+
+Candidate: *"Follow one protocol change through every layer that had to accept it, from the guideline committee down to the 3 a.m. triage nurse."*
+
+Excluded by adopting it:
+1. The state reimbursement reform (real, documented, but touches no layer in the chain of acceptance).
+2. The comparative mortality data from the other four hospitals in the system (a different piece: comparison, not transmission).
+3. The electronic-records vendor contract dispute (adjacent in time, irrelevant to who accepted the protocol).
+
+Those three deletions are what makes the candidate a designing principle. If nothing had been deletable, it was a premise.
+
+### GATE 4 — IT REACHES ALL LAYERS
+
+Can you derive from it, **without adding new information**: the story world in one line, the shape of movement, at least one symbol, and the criterion for which characters or entities belong? If it only touches plot, it is not organising the whole.
+
+Worked example on the same candidate: story world = the physical descent from committee room to ward corridor. Shape = branching (each layer a sub-world) with a linear spine. Symbol = the printed protocol card itself, changed at every layer. Inclusion criterion = only people who had to accept, reject, or modify the card.
+
+### TIEBREAK — ORIGINALITY
+
+Does it name a way of telling this that you have not seen used on this material? Both halves of the formula are required. Process without original execution is a template; original execution without process is a stunt.
+
+## Four construction routes when stuck
+
+1. **Classic structure in a new setting.** Run an established shape over material nobody has run it over.
+2. **Trope transplant from another genre.** Structure a supply-chain failure as a detective investigation with a mystery in the opponent slot.
+3. **Convention subversion.** Invert what this domain's writing normally does. Most post-mortems run cause to consequence; run the consequence backward to the earliest commit that made it possible.
+4. **Motif, symbol, or title dictates structure.** The Sting tells a con story structured as a con. A piece about a versioning scheme can be structured in versions.
+
+## Worked candidates across five domains
+
+| Domain | BAD (premise in a costume) | GOOD (passes four gates) |
+|---|---|---|
+| Market or price history | "Show how the freight market was transformed by container shipping" | "Trace one standard box through every party that had to give something up to accept it, and price what each surrendered" |
+| ML research writeup | "Explain why the new architecture outperformed the baseline" | "Follow the ablation order backward, so the reader loses one component at a time and discovers which one was actually load-bearing" |
+| Biography | "Tell the story of a mathematician who solved a famous problem" | "Use the seven years of unpublished notebooks to show a proof being built by a person who did not yet know which of his errors was the productive one" |
+| Incident post-mortem | "Describe the outage and its causes" | "Spiral through the same ninety seconds four times, once from each on-call team's monitors, so the reader sees what each of them could not" |
+| Public-health policy | "Analyse how the vaccination campaign succeeded" | "Show the campaign through the three districts that refused it, using each refusal to expose a different assumption the plan was built on" |
+
+Note what the BAD column shares: each is a restatement of what happened with more abstract vocabulary. Each excludes nothing, so each does nothing.
+
+## Designing-principle drift
+
+The second failure mode is picking a good principle and quietly abandoning it by section three. Countermeasure: write the principle at the top of the working document and re-read it before every inclusion decision. If a claim does not serve it, that claim is research, not story. Keeping it is how the corpus reasserts itself over the architecture.
+
+## The rival-arc matrix
+
+Generate at least **three structurally distinct** candidate arcs BEFORE selecting evidence, then rank by fewest inconsistencies rather than most consistencies. This is Heuer's Analysis of Competing Hypotheses retargeted from "what happened" to "what shape does this have."
+
+Force genre spread across these four:
+
+| Arc | Claim it makes |
+|---|---|
+| TRAGEDY | A capable actor was destroyed by an internal flaw |
+| STRUCTURE / SATIRE | The actor was largely irrelevant; conditions decided |
+| CONTINGENCY | A near-coin-flip that resolved by luck or timing |
+| COMEDY / CONVERGENCE | Mutual adjustment produced a stable end state |
+
+Procedure:
+1. Rows = every significant evidence item in the corpus, including the ones you dislike. Columns = candidate arcs.
+2. Score each cell C (consistent), I (inconsistent), N (neutral, no diagnostic value).
+3. **Delete the N rows.** They discriminate nothing, and they are exactly where narrative pleasure hides.
+4. Rank by fewest I's. Evidence consistent with all arcs proves nothing.
+5. Adopt the winner. In the delivered notes, name the runner-up and the specific evidence that would have favoured it.
+6. Record sensitivity: the two or three items whose reversal would flip the ranking. These are the watch items.
+
+**Quality gate on rivals:** each rival arc must be able to accommodate at least 60% of the corpus, or it does not count as a rival. Three arcs where two are obviously absurd is a ceremony, not an analysis. (The 60% figure is a working default for this skill, not a published threshold.)
+
+**Opposite failure:** paralysis. The matrix is a selection device. Commit to the winner and disclose the runner-up. An agent that refuses to commit because no arc is clean produces an unreadable hedge-pile.
+
+## Genre disclosure and the suppression set
+
+Choosing tragedy over structure-decided is a choice made before the evidence is consulted, and it determines which facts become salient. The countermeasure converts the objection into a diagnostic.
+
+1. Name the chosen genre in the working notes using the fixed vocabulary above (plus CHRONICLE: sequence without resolution).
+2. Write a 200-word summary of the material in the chosen genre.
+3. Write a 200-word summary in the runner-up genre.
+4. Diff them. Every evidence item that appears in one and not the other forms **the suppression set** of your chosen genre.
+5. **Reinstatement rule:** any suppressed item backed by a documented mechanism (a decision memo, a physical process, an accounting identity, a signed contract) must be reinstated in the delivered text, even if it damages the arc. Losing a colourful anecdote to genre choice is acceptable. Losing a documented mechanism is not.
+6. Disclose in one structurally visible sentence, not in those words. Write "this account treats the procurement team as the decisive actor; a reading that treated the tariff schedule as decisive would emphasise the 2018 filings" rather than "this is a tragedy."
+
+**Disclosure is not a licence.** Naming the genre buys credibility that gets spent on distortion unless step 5 is actually enforced. Without reinstatement, the disclosure is a confession booth.
+
+**Genre-hopping** is the second failure: disclosing tragedy and writing the last section as convergence. The reader feels the incoherence and cannot locate it.

--- a/skills/narrative-arc-mapping/resources/evaluators/rubric_narrative_arc_mapping.json
+++ b/skills/narrative-arc-mapping/resources/evaluators/rubric_narrative_arc_mapping.json
@@ -1,0 +1,104 @@
+{
+  "name": "Narrative Arc Mapping Rubric",
+  "description": "Evaluation criteria for mapping researched evidence onto structural steps without fabricating the steps the evidence cannot fill. Scores the triage, the warrants, the absence handling, and the handoff discipline.",
+  "criteria": [
+    {
+      "name": "Absence Reporting",
+      "description": "Whether empty structural slots were reported as findings rather than silently filled",
+      "weight": 1.5,
+      "scores": {
+        "1": "All 22 steps filled; ghosts, betrayals, or fake-ally opponents invented to complete the shape",
+        "2": "Most steps filled with at least one clearly invented slot; no triage table emitted",
+        "3": "Triage table emitted with PRESENT/ABSENT/NOT APPLICABLE, but ABSENT entries carry no reason",
+        "4": "At least one step reported ABSENT with a stated reason; empty-slot log present with a move chosen per slot",
+        "5": "Full triage with sourced PRESENT entries and reasoned ABSENT entries; mandatory seven verified; inference-filled slots capped at one and none at the climax; empty-slot log ships with the deliverable"
+      }
+    },
+    {
+      "name": "Evidentiary Warrant per Slot",
+      "description": "Whether each filled slot carries dated sourcing, a causal tier, and the substitution test where required",
+      "weight": 1.5,
+      "scores": {
+        "1": "No sourcing per slot; the architecture exists only inside the narrative",
+        "2": "Some slots cited; no dates, no source-type or interest tags, no causal tiers",
+        "3": "Most slots cited with dates; causal tiers assigned but rivals unnamed and no substitution test",
+        "4": "Warrant card per slot with four dates and a causal tier; RETROSPECTIVE-ONLY slots tagged and hedged",
+        "5": "Every warrant card complete, including two named alternative events a differently-ending narrator would have chosen; source type and interest tagged; no documented-mechanism claim rests on a purely secondary retrospective account"
+      }
+    },
+    {
+      "name": "Hindsight-Determinism Control",
+      "description": "Whether backward derivation from the known outcome was gated on contemporaneous evidence",
+      "weight": 1.3,
+      "scores": {
+        "1": "Starting weakness manufactured to make the ending look inevitable; supported only by post-hoc commentary",
+        "2": "Weakness asserted with retrospective sourcing presented as if contemporaneous",
+        "3": "Contemporaneous sources sought; some weaknesses gated, others left unmarked",
+        "4": "Every claimed weakness carries a pre-outcome citation or is marked INFERRED and kept out of the climax",
+        "5": "Full gate plus source-interest annotation, the flip test on evaluative sentences about decisions, and decision quality stated separately from outcome quality"
+      }
+    },
+    {
+      "name": "Opponent Integrity",
+      "description": "Whether the opponent slot was warranted rather than assigned to whoever lost",
+      "weight": 1.2,
+      "scores": {
+        "1": "Opponent is whoever lost; motive backfilled as stupidity or malice; intent verbs attached to an abstraction",
+        "2": "Opponent asserted with one evidence type; no justification paragraph",
+        "3": "Two of three warrant evidence types present; opponent correctly demoted to rival but verbs not constrained",
+        "4": "Three-of-three warrant or an honest demotion to rival/environment with verbs constrained accordingly; justification paragraph written",
+        "5": "Warrant scored and verbs constrained; justification passes the recognition test; a mystery substituted at the same structural position where no opponent exists; manufactured-conflict check run on the shared scarce object"
+      }
+    },
+    {
+      "name": "Designing Principle Discrimination",
+      "description": "Whether the designing principle is a strategy that cuts material, not a premise or a theme in disguise",
+      "weight": 1.2,
+      "scores": {
+        "1": "No designing principle, or a plot summary with more abstract vocabulary",
+        "2": "One candidate only; contains a should or an ought; excludes nothing",
+        "3": "Multiple candidates drafted; the winner passes process and abstract gates but no exclusions are named",
+        "4": "Passes all four gates with three excluded claims named explicitly",
+        "5": "All four gates passed with named exclusions, all layers derived (world, shape, symbol, inclusion criterion), rival arcs matrixed with the runner-up and its favouring evidence disclosed"
+      }
+    },
+    {
+      "name": "Revelation Sequence Rigor",
+      "description": "Whether revelations were extracted, sequenced, and rated by course change rather than by language",
+      "weight": 1.0,
+      "scores": {
+        "1": "No revelation sequence, or two to three plot points only",
+        "2": "Reveals listed but exposition is mislabelled as revelation",
+        "3": "Reveals extracted with sources; intensity assigned but justified by adjectives",
+        "4": "Intensity rated by the size of the course change forced; monotonic climb verified; pace accelerates",
+        "5": "Full audit with count target met for length, bend-not-break enforced, the three decision points carrying all four co-occurring elements, and every reorder date-checked against sources"
+      }
+    },
+    {
+      "name": "Theme Enactment Discipline",
+      "description": "Whether the moral argument is carried structurally, or narrated, or forced onto neutral material",
+      "weight": 1.0,
+      "scores": {
+        "1": "Theme stated in narrator voice throughout, or a villain manufactured for value-neutral material",
+        "2": "Spine built but the lesson is also stated in prose in several places",
+        "3": "Spine built with evidence mapping; explicit moral language leaks outside the permitted positions once or twice",
+        "4": "Explicit moral language confined to the three permitted positions; unsupported spine elements left visibly EMPTY",
+        "5": "As level 4, plus a correct explanatory-mode declaration where warranted, a balance check of moral beats against event beats, and a double reversal producing a defensible third position"
+      }
+    },
+    {
+      "name": "Handoff Discipline",
+      "description": "Whether the output stopped at a tagged scene weave instead of drifting into drafting",
+      "weight": 1.0,
+      "scores": {
+        "1": "Prose drafted; the craft layer inherits text to edit rather than architecture to execute",
+        "2": "Scene descriptions run to paragraphs; construction fields absent",
+        "3": "One line per scene but over the character limit, or missing step and reveal tags",
+        "4": "Tagged one-line weave within the character limit, with construction fields filled per scene",
+        "5": "Complete weave: tagged, ordered by structure, date-checked, scenes carrying no step and no reveal cut, gaps filled, construction fields complete, and nothing written beyond it"
+      }
+    }
+  ],
+  "threshold": 3.5,
+  "passing_note": "Average score must be >= 3.5. A score below 3 in 'Absence Reporting' or 'Evidentiary Warrant per Slot' is a hard fail regardless of average: an architecture that filled every slot or cannot show its sources is fabrication, not mapping."
+}

--- a/skills/narrative-arc-mapping/resources/slot-warrants.md
+++ b/skills/narrative-arc-mapping/resources/slot-warrants.md
@@ -1,0 +1,233 @@
+# Slot Warrants, Absence Handling, and the Output Gate
+
+Every structural slot is a claim that a moment mattered. This file holds the cards and audits that decide whether a slot may be filled, what to do when it may not, and how to tell finished architecture from a fabricated shape.
+
+## The structural slot warrant card
+
+Run this per PRESENT slot. It is a deliverable, not scratch.
+
+```
+SLOT: [step number and name]
+EVENT PLACED HERE: 
+(a) event date:
+(b) date of the EARLIEST source treating this event as significant:
+(c) outcome date:
+(d) date of the source actually cited:
+SOURCE TYPE: primary/contemporaneous | secondary/retrospective
+SOURCE INTEREST: promotional | adversarial | regulatory | disinterested | unknown
+
+TAG:
+  if (b) > (c)                        -> RETROSPECTIVE-ONLY
+  if (b) between event and outcome    -> CONTEMPORANEOUS-PARTIAL
+  if (b) at or before the event       -> CONTEMPORANEOUS
+
+SUBSTITUTION TEST (mandatory for RETROSPECTIVE-ONLY):
+  Name two other events in the same window that a narrator working toward a
+  DIFFERENT ending would have selected for this slot.
+  1.
+  2.
+  (Cannot name two? You have not searched the corpus. Go back.)
+
+CAUSAL TIER: L1 mechanism | L2 correlation | L3 sequence | L4 adjacency | L5 conjecture
+DISCLOSURE REQUIRED IN BODY? yes/no  |  DISCLOSURE SENTENCE:
+```
+
+**Hard rule:** no slot may be tagged RETROSPECTIVE-ONLY *and* carry unhedged causal language. Either downgrade the language, or add one sentence in the body text (never a footnote) saying the significance is visible only in hindsight.
+
+**This is a disclosure requirement, not a deletion rule.** Some genuinely causal events are invisible to everyone present: a slow demographic shift, an accumulating maintenance deferral, a mutation. An agent that mechanically demotes every RETROSPECTIVE-ONLY slot refuses to name real structural causes and over-weights whatever happened to be loud at the time. That is salience bias wearing the costume of rigor.
+
+## The causal tier ladder and permitted verbs
+
+Apply to every causal assertion and to every juxtaposition a reader would read causally.
+
+| Tier | Definition | Permitted verbs |
+|---|---|---|
+| L1 MECHANISM | The linking step itself is documented: a decision memo, a physical process, an accounting identity, a signed contract, a commit that changed the behaviour | any causal verb |
+| L2 CORRELATION | Quantitative co-movement documented, mechanism not | moved with, tracked, accompanied |
+| L3 SEQUENCE | Only temporal order documented | then, afterwards, in the following quarter |
+| L4 ADJACENCY | Co-present, no link established | rewrite so the two events do not touch, or state "the two were concurrent; no link is documented" |
+| L5 CONJECTURE | Your inference, no source | must carry an explicit inference marker, and may never occupy a climax, revelation, or thesis slot |
+
+**Because-laundering** is what happens when a tagger constrains connectives: the causal claim moves where the tagger cannot see it. Into a metaphor ("the dam broke"), into a section break, into a chart annotation, into a chapter title, into a quoted source who asserts the causality on your behalf. Scan headings, captions, pull-quotes, and section transitions, not just body sentences.
+
+**Adjacency-by-layout check:** scan for L3/L4 event pairs separated only by a paragraph break, a scene cut, or a heading. Structural juxtaposition is a causal claim made without words.
+
+**Tag inflation:** an L3 claim does not become L1 because a source *asserts* a mechanism. L1 requires a source that *documents* one.
+
+## Hindsight determinism: the specific disease of endpoint-first derivation
+
+Deriving the weakness backward from a known ending manufactures a starting deficiency chosen to make the ending look inevitable.
+
+| Domain | The confabulated weakness | What the record actually showed |
+|---|---|---|
+| Market history | "The incumbent was always complacent" | Contemporaneous filings show three funded internal programs targeting the same shift |
+| ML research | "The field had been ignoring long-context evaluation" | The field had been actively debating it; two workshops predate the paper |
+| Institutional post-mortem | "Safety culture had eroded for years" | Erosion is asserted only in the post-incident inquiry; pre-incident audits found the opposite |
+
+**Procedure:**
+1. List every claimed starting weakness.
+2. For each, find a source dated before the outcome asserting the deficiency.
+3. Found and the source is disinterested: keep the weakness, attribute inline with the date. "Auditors flagged the single-supplier dependency in 2017."
+4. Found but the source is interested (a competitor, a plaintiff, a promoter): keep it, and say whose view it was.
+5. Not found: mark the weakness INFERRED. It may appear in the piece. It may not occupy the climax or the thesis sentence, and it must carry an inference marker within two sentences.
+
+**Flip test on every evaluative sentence about a decision:** rewrite it assuming the opposite outcome occurred. If it obviously would not have been written that way, the outcome is doing the work, not the evidence. (Valid only for sentences about decisions. Applied to sentences about facts it produces nonsense.)
+
+**Decision/outcome separation:** state decision quality and outcome quality in separate sentences. "The bet had roughly even odds on the information then available. It failed." Not "the reckless bet failed."
+
+**Systems get halos too.** "An efficient market," "a rational consolidation," "an inevitable standardisation" are all outcome-derived characterisations of a prior state.
+
+## Opponent warrant
+
+Truby's opponent must want the same thing the protagonist wants. Real evidence frequently contains competitors, constraints, and coincidences but no opponent.
+
+The warrant evidence test, the verb tier table, and the four-corner opposition worksheet are owned by `narrative-opposition-web` — see [../../narrative-opposition-web/resources/opponent-warrant.md](../../narrative-opposition-web/resources/opponent-warrant.md) and [../../narrative-opposition-web/resources/four-corner-worksheet.md](../../narrative-opposition-web/resources/four-corner-worksheet.md). An opponent that skill has not warranted may not be marked PRESENT here.
+
+If no candidate clears that test, leave the slot EMPTY and say so in the body: "No adversary appears in the record; the binding constraint was the single-certified-supplier clause."
+
+**When the protagonist is a system**, the opponent slot must be filled by a named force with a documented mechanism: a binding constraint, a regulatory regime, a physical limit, a countervailing incentive. Ban "the market wanted," "the industry decided," "physics fought back" unless cashed out into the mechanism in the same sentence.
+
+**No opponent at all?** Substitute a MYSTERY at the same structural position. Truby's detective-story rule: the audience needs something to replace the ongoing conflict. Do not proceed with neither. In scientific findings and supply-chain analysis the mystery substitution is usually the honest answer.
+
+**The strawman test.** Write the opponent's justification in their own voice: a paragraph making a strong, coherent, wrong-but-defensible case. Read it and ask whether a smart person holding that position would recognise themselves. If not, rewrite until they would. Assigning the opponent role to whoever lost and backfilling stupidity is simultaneously worse craft and false analysis. It is the most reputationally damaging failure this skill can commit.
+
+**Manufactured conflict** is the companion failure: inventing a same-goal rivalry between parties who were simply operating in different markets. Check that both actually contested the same scarce thing.
+
+## Moral argument spine
+
+Map each element to evidence. Leave unsupported elements visibly EMPTY. An empty element is a finding about the material, not a prompt to invent.
+
+```
+Theme line (one sentence, a claim about how to act):
+Starting beliefs and values:
+Moral weakness (hurting others from weakness or ignorance, not evil):
+Moral need:
+First immoral action:
+Desire:
+Drive:
+Early compromises made out of desperation while losing:
+Criticism by others:
+Justification by the subject:
+Attack by ally:
+Obsessive drive after the second revelation:
+Intensified compromises:
+Intensified criticism / intensified justification:
+Battle (which values are shown superior, regardless of who wins):
+Final action against the opponent:
+Moral self-revelation (never stated to the reader):
+Moral decision (a choice between TWO POSITIVES, as late as possible):
+Thematic revelation (the insight that reaches beyond these particular subjects):
+```
+
+**THE THEME IS ENACTED, NEVER STATED IN NARRATOR VOICE.** Explicit moral language is permitted in exactly three positions:
+
+1. An ally criticising the protagonist.
+2. Direct protagonist-opponent conflict at the battle.
+3. The opponent's justification.
+
+Everywhere else, structure carries it. Detection: search the draft for the theme line's key nouns in narrator voice. Each hit is a candidate deletion. Building a correct spine and then also stating the lesson destroys the argument.
+
+**BALANCE CHECK:** count moral beats against event beats. Preachiness comes from too little plot to carry the argument. If moral beats outnumber events, cut moral beats or add events. Do not soften the language.
+
+**EXPLANATORY MODE.** Some material genuinely has no moral argument: a benchmark result, a pricing mechanism, a taxonomy, a measurement method. Forcing one manufactures a villain and produces sanctimony. "No moral argument available; this is an explanatory piece" is a legitimate output. In explanatory mode, run the seven mandatory steps with the moral spine marked NOT APPLICABLE and the thematic revelation replaced by a transferable mechanism.
+
+**DOUBLE REVERSAL.** Where the opponent also has a need, give them a self-revelation too, and connect the two: each must learn something from the other. State the synthesis in the working notes only: "the best of what both learned is ____." A genuine double reversal produces a THIRD position neither party held at the start, stateable in one sentence and defensible on the evidence. If the synthesis is the midpoint of the two starting positions, no reversal occurred and you have written "both sides had a point," which is a refusal to argue. Sentimental redemption is the second failure: check for a post-battle behavioural change in the record before granting the opponent a revelation.
+
+## Revelation sequence audit
+
+A revelation is information whose arrival forces a change in desire, motive, or plan. Information that arrives and changes nothing is exposition. Relabel it.
+
+Per revelation record: WHO learns it (subject / reader / both), WHAT changes (desire, motive, or plan), INTENSITY 1-10, SOURCE.
+
+Checks:
+- **Order is logical**: the order the subject would plausibly have learned things. For researched material this is usually the order evidence became available. Check dates.
+- **Intensity climbs monotonically.** Any dip is moved, merged, or cut.
+- **Intensity is rated by the SIZE OF THE COURSE CHANGE**, never by the language used to describe it. A reveal that changes nothing cannot be an 8 no matter how it is written. "And then, devastatingly, the margin compressed further" is not escalation; it is an adjective. Manufactured escalation satisfies the audit on paper and the reader feels the padding.
+- **Pace accelerates**: word-gaps between reveals are shorter in the last third than the first.
+- **Bend, not break**: each changed desire adjusts the original rather than replacing it. A wholly new goal resets the reader's investment to zero.
+- **Three decision points carry all four elements together**: revelation, decision, changed desire, changed motive. Missing one deflates the moment.
+- **Count target met** for the length. Never the two or three a three-act template implies.
+- **Chronology check on every reorder.** Reordering for escalation that implies impossible foreknowledge is a defect, not a style choice.
+
+Intensity worked example, from a database incident corpus:
+
+| Reveal | Course change forced | Rating |
+|---|---|---|
+| Replica lag alert was real, not a flap | On-call escalates instead of silencing | 4 |
+| The failover target shared the same power domain | The entire recovery plan is invalid; a new one must be written mid-incident | 9 |
+| A second team had already filed this risk in 2021 | Nothing changes during the incident; changes the post-incident scope | 3 (during) / 7 (as audience revelation) |
+
+Note the third row: rating depends on whose course changes and when. That is what "size of course change" means in practice.
+
+## Agency audit and the system translation table
+
+Fill and keep as an auditable artifact whenever the protagonist is a system.
+
+```
+Subject level declared and held constant:
+WEAKNESS -> structural fragility/dependency/assumption, CONTEMPORANEOUS source:
+NEED -> what the system must resolve to keep functioning, unrecognised at the start:
+GHOST -> prior event still constraining behaviour:
+DESIRE -> visible collective goal + the moment success becomes verifiable:
+OPPONENT -> competing force pursuing THE SAME goal by incompatible means:
+PLAN -> dominant strategy, standard, or consensus approach:
+ALLY / ATTACK BY ALLY -> internal dissent (ABSENT if the record shows none):
+REVELATIONS -> disclosures, crashes, benchmark results, failed audits:
+BATTLE -> decisive contest, smallest possible space:
+SELF-REVELATION -> what it now knows, evidenced by observed behaviour change:
+NEW EQUILIBRIUM -> changed steady state, explicitly higher or lower:
+DELEGATION -> the named human or institution who demonstrably held the desire:
+ARCHETYPES -> not translated. Confirm none applied to institutions.
+```
+
+**AGENCY AUDIT.** List every intentional verb attached to an abstraction in the output. For each, either rewrite to named actors or cite the collective mechanism that justifies it.
+
+| Laundered | Repaired |
+|---|---|
+| "The market realised the dependency was fragile" | "Three of the five largest buyers added second-source clauses in the same quarter" |
+| "The standards body wanted backward compatibility" | "The compatibility requirement passed 11-4; the four dissents are in the minutes" |
+| "The codebase resisted the refactor" | "Every attempt touched the shared session object, and the four prior attempts were reverted within a week" |
+
+**Prefer personification by delegation.** Give the system's desire a named carrier who demonstrably held it, and let that carrier's actions stand for the system's. That keeps the discipline honest and the narrative concrete.
+
+## Proportion and omission audit
+
+Per-sentence checks can all pass while the piece as a whole misrepresents the drift and proportion of events through selection and emphasis alone. This is the expensive audit and it is the one that matters.
+
+1. Two columns per claim: WORDS SPENT, and EVIDENCE TIER (from the causal ladder), plus CAUSAL WEIGHT. Fill the weight column **before** the arc is chosen, or it is contaminated by the same halo the audit exists to catch.
+2. Flag claims in the top quintile by words and the bottom quintile by evidence tier. These are the colourful anecdotes carrying the reader's belief.
+3. Flag the inverse: top quintile by causal weight, bottom by words. These are the boring drivers the arc suppressed. Usually a price change, a filing, a base rate, a demographic trend, a compiler flag.
+4. Require a written justification per flagged asymmetry. "This gets 800 words because it is the only first-hand account of the mechanism" is legitimate. No justification means rebalance.
+5. **Omission check:** list corpus items appearing nowhere in the draft and state why for each. An item that would weaken the spine, omitted without justification, is a cherry-pick and must be reinstated.
+6. The output is a justification requirement, not a word-count quota. Mechanical equalisation produces the rhythm of a spreadsheet, and unread accurate work informs nobody.
+
+## Two further disclosure operations
+
+**Anachronism flag.** When a category, a metric, or a moral frame used in the text did not exist at the time described, say so. That operation is checkable. The larger dispute about applying present-day categories to past actors is contested territory and is deliberately not encoded here as a rule.
+
+**Silent evidence.** For every success-attribution claim, search for at least two entities that took the same action and did not get the outcome. There are three legal results, and all three appear in the text. Counterexamples found: state them and weaken the claim. Searched for and not found: state the search, which strengthens the claim. Population is n=1 or unobservable: state "the base rate for this action is unknown." The third result is first-class and non-embarrassing. Without it, agents fabricate weak analogies and present them as base rates.
+
+**Consider the agency reading.** For each major outcome, state the strongest skill-and-intent explanation you considered and why you did or did not adopt it. Over-attributing outcomes to luck, structure, and path dependence is also a bias, and the literature that warns against narrative is asymmetrically stocked with attacks on agency-based explanation.
+
+## GOOD / BAD output gate
+
+Run this before handing off. A single BAD in the first three rows is a stop.
+
+| GOOD | BAD |
+|---|---|
+| **At least one of the 22 steps is reported ABSENT with a reason** | **All 22 filled** |
+| The designing principle excluded material; three excluded claims are named | Everything researched appears somewhere |
+| Every structural reorder survives a date check | Reordering for escalation that implies impossible foreknowledge |
+| The opponent's justification would be recognised by someone who holds that position | The opponent is whoever lost |
+| Exactly one apparent defeat; the rest demoted to setbacks explicitly | Three or four low points of similar weight |
+| Drive actions differ in kind; swapping any two would break the argument | Five interchangeable instances of the same beat |
+| Reveal count matches the length target; intensity climbs by course-change size | Two or three reveals, or escalation carried by adjectives |
+| The theme line appears nowhere in narrator voice | The lesson is stated, then also dramatised |
+| Every corner of the web appears in the drive section | The web collapses to two parties after the opening |
+| A double reversal producing a THIRD position neither party held | "Both sides had a point" |
+| The moral decision is a choice between two positives, held late | A choice between an obvious good and an obvious bad |
+| The step-to-evidence table can be handed to a fact-checker | The architecture exists only inside the narrative |
+| Output stops at the tagged scene weave | The macro layer has written prose |
+| Disclosures sit in the body within two sentences of the claim | Disclosures live in endnotes, footnotes, or a methods block |
+
+**Density budget.** Cap disclosure sentences, hedges, and contingency notes at roughly one per 250 words. When the budget binds, that is the signal to change the architecture (Empty-Slot Move 3), not to spend more budget. A piece that is 60% epistemic apparatus and 40% subject is unreadable and misleading in a new way: it makes your uncertainty the story. (This cap is a working default for this skill, not a published figure.)

--- a/skills/narrative-arc-mapping/resources/twenty-two-steps.md
+++ b/skills/narrative-arc-mapping/resources/twenty-two-steps.md
@@ -1,0 +1,110 @@
+# The Twenty-Two Steps, With System Variants and Triage Defaults
+
+## What the twenty-two steps are, and are not
+
+Truby's step list is a derivation order, not a beat sheet. His own statement of flexibility is the guardrail this whole skill depends on:
+
+> "A story may have more or fewer than twenty-two steps, depending on its type and length. It must have no fewer than the seven steps, because that is the least number of steps in an organic story."
+
+And:
+
+> "Every good story works through the steps in a slightly different order. You must find the order that works best for your unique plot and characters... these steps are a powerful tool for writing but are not carved in stone."
+
+**Attribution caveat.** Truby never writes about markets, protocols, institutions, or codebases. The SYSTEM VARIANT column below is a translation built for this skill, not something Truby published. It survives translation because his primitives are functional (weakness, desire, opposition, plan) rather than psychological. The archetypes are the exception and are deliberately not translated: applied to institutions they produce nonsense.
+
+## Target step count by length
+
+| Length | Step target | Revelation target |
+|---|---|---|
+| Under ~2,000 words | The mandatory seven only | 3-5 |
+| Standard long-form (2,000-8,000) | 12-22 | 7-10 |
+| Book-length or multi-part | 22+, surplus carried in reveals | 15+ |
+
+Truby's stated benchmark is that "the average hit film has 7-10 reveals" against the two or three plot points a three-act template implies. The word-count bands in this table are working defaults derived for research writing, not published figures.
+
+## The full table
+
+Status column: **M** = mandatory seven (ABSENT is a stop-work condition). **E** = expect ABSENT in analytical domains; do not patch. **O** = optional, include only if evidenced.
+
+| # | Step | Function | System variant | Status | Evidence it requires |
+|---|---|---|---|---|---|
+| 1 | Self-revelation, need, desire (stated first, derived last) | The end fixed before the beginning | What the system now knows that it did not | M | A terminal claim traceable to the corpus |
+| 2 | Ghost and story world | The prior event still constraining behaviour | Last crisis, founding compromise, legacy standard, a schema nobody dares migrate | E | A dated prior event still cited in decisions |
+| 3 | Weakness and need | The flaw ruining the situation, unrecognised | Structural fragility, dependency, unexamined assumption | M | **Contemporaneous** source predating the outcome |
+| 4 | Inciting event | The thing that knocks the subject off balance | The shock: a filing, an outage, a price move, a paper | O | A dated event plus evidence anyone reacted |
+| 5 | Desire | The visible external goal | The goal participants collectively and verifiably pursued | M | A nameable moment where success is checkable |
+| 6 | Ally or allies | Who helps, and who the subject talks to | Coalition members, co-signatories, downstream adopters | O | Documented cooperation |
+| 7 | Opponent and/or mystery | Who wants the same thing | Competing faction pursuing the same goal by incompatible means | M | Three-of-three opponent warrant, or a mystery in the same slot |
+| 8 | Fake-ally opponent | Appears to help, actually opposes | A partner whose incentives were documented as adverse | E | Both the appearance and the adverse action, sourced |
+| 9 | First revelation and decision, changed desire and motive | The first course change | First disclosure that changed the plan | O | The information and the resulting change, both sourced |
+| 10 | Plan | How the subject intends to win | Dominant strategy, standard, consensus approach | M | A stated or reconstructable strategy |
+| 11 | Opponent's plan and main counterattack | What the losing party actually tried | The rival standard, the competing bid, the patch | O | Under-reported and usually the richest neglected evidence |
+| 12 | Drive | Escalating actions toward the goal | Successive strategy shifts | O | Each action must differ in KIND from the last |
+| 13 | Attack by ally | Internal dissent against the methods | A dissenting board member, a minority report, a resignation letter | E | Named dissent in the record; otherwise ABSENT |
+| 14 | Apparent defeat | The one moment the goal looks lost | The quarter, vote, or benchmark where it looked over | O | Exactly ONE; demote all others to setback |
+| 15 | Second revelation and decision, obsessive drive | Defeat converted into obsession | The pivot after the loss | O | The revelation must immediately follow the defeat |
+| 16 | Audience revelation | The reader learns something the subject does not | The reader sees the flaw before the participants did | E | A source the subject demonstrably did not have |
+| 17 | Third revelation and decision | The last information needed to win | The final input | O | Revelation, decision, changed desire, changed motive together |
+| 18 | Gate, gauntlet, visit to death | Options narrowing, pressure peaking | Covenant breach, runway math, a hard deadline | E | Truby: "the most moveable of the 22 steps" |
+| 19 | Battle | The decisive confrontation | One vote, one quarter, one decision, one release | M | Confined to the smallest possible space |
+| 20 | Self-revelation | What the subject learns | Evidenced by an observed behaviour change | M | The behaviour change, dated |
+| 21 | Moral decision | A choice between two positives | The post-battle policy choice | O | Two documented live options, both defensible |
+| 22 | New equilibrium | The changed steady state | Explicitly higher or lower than the start | M | A measurable after-state |
+
+## Start type declaration
+
+Choose one and write it down before outlining.
+
+- **COMMUNITY START** — a working arrangement about to be disrupted. Fits pre-crisis institutional histories and pre-incident system descriptions.
+- **RUNNING START** — a live problem, real weakness, active desire at the opening. Truby: "most good stories start this way." This is what you want.
+- **SLOW START** — a purposeless subject whose self-revelation is merely to learn its purpose. Truby flags this as a "huge structural flaw" that very few stories overcome.
+
+**Survey and landscape research naturally produces the slow start.** A field review, a market map, a taxonomy of methods: none of them opens with a live weakness. If you cannot find a running start in the material, report the shape problem instead of proceeding. That report is a correct output.
+
+Worked example of the fix. A review of protein structure prediction methods has no running start as a survey ("the field had many approaches"). It acquires one when the subject narrows: the CASP assessment had a stable ceiling nobody could break through, and that ceiling is a live weakness with contemporaneous evidence.
+
+## Middle-weight check
+
+Count triaged steps before the plan (step 10) and after it. The extra fifteen steps exist because the middle is where pieces fail. An outline with nine steps before the plan and four after reproduces exactly the sag it was meant to prevent. Rebalance by pushing detail into the drive, the opponent's counterattack, and the revelation sequence.
+
+## Reorder log
+
+Truby permits reordering. Researched material does not permit implied foreknowledge. For every departure from canonical order or from chronology, write one line:
+
+```
+MOVED: supplier audit (step 11) placed before the Q2 shortfall (step 14)
+WHY: the audit is the opponent's counterattack and reads as reaction if placed after
+DATE CHECK: audit 2019-03-11, shortfall 2019-07-30. Order preserved. No implied foreknowledge.
+```
+
+An unexplained reorder is drift. An explained one that fails the date check is a defect, and evidence wins.
+
+## The multistrand rule
+
+If the shape is anything other than linear, each strand must carry **all seven mandatory steps**. Truby: "Anything less than the seven steps means that that line isn't a complete story, and the audience will find it unnecessary and annoying." A strand with three of seven gives the reader a partial story that reads as a digression. Cut it or complete it.
+
+Drive-preservation technique for multistrand work: **make the protagonist of one strand the opponent of another.** In supply-chain analysis and standards history this maps truthfully rather than decoratively. In a rail-freight capacity study, the terminal operator is the protagonist of strand one and the opponent of the shipper strand, using the same documented scarce object (slot allocation) in both.
+
+## Scene weave output specification
+
+This is the terminal deliverable of the macro layer. It is a table, not prose.
+
+Rules:
+1. ONE line per scene. **Hard limit 200 characters.** If you write a paragraph, you have overrun into the drafting layer and the craft layer inherits text to edit instead of architecture to execute.
+2. Tag each line with: the step it carries (or none), the strand number if multistrand, and its reveal (or none).
+3. Cut any scene carrying no step and no reveal. Merge scenes carrying the same step.
+4. Add scenes wherever a triaged PRESENT step has no scene to deliver it.
+5. Order by structure, then re-run the date check on every reorder.
+6. Fill the construction fields per scene. Whose desire drives it (not necessarily the protagonist's). The endpoint of that desire. Who opposes it. Direct plan or indirect plan. Does it end at height of conflict or at a solution. What is the twist or reveal.
+7. Truby's scene rule: "A scene is a ministory. A good scene has six of the seven structure steps — the exception is self-revelation, which is reserved for the hero near the end." Inside a scene, the self-revelation slot is normally filled by a twist or reveal.
+8. Start each scene as late as possible without losing a needed structure element.
+
+Format:
+
+```
+| # | Scene line (<=200 ch) | Step | Strand | Reveal | Desire | Opposition | Plan | Endpoint | Twist |
+|---|---|---|---|---|---|---|---|---|---|
+| 7 | Postgres replica lag crosses the alert threshold at 02:14; on-call silences it as a known flapper | 4 inciting | 1 | R2 | on-call wants a quiet night | the alert itself | indirect | silence expires 04:00 | the flap was real |
+```
+
+That row is the correct level of output. A paragraph describing the on-call engineer's fatigue is not.

--- a/skills/narrative-evidence-ledger/SKILL.md
+++ b/skills/narrative-evidence-ledger/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: narrative-evidence-ledger
+description: Builds the evidence ledger that narrative work is allowed to be built on, before any structure is chosen. Locks the frame (unit, denominator, window, population boundary), atomizes material into findings with evidence classes A-F and re-findable pointers, triages every causal claim L1 MECHANISM to L5 CONJECTURE with permitted and banned verb sets, runs one-way promotion from finding to claim to beat, and keeps a DEAD column of everything a veto killed. Use before outlining or drafting any evidence-based narrative, when auditing whether a draft's claims are actually sourced, when a piece needs a provenance layer for handoff, or when user mentions evidence ledger, claim ledger, provenance, sourcing, causal grading, denominator lock, cherry-picking, or circular citation.
+---
+
+# Narrative Evidence Ledger
+
+## Table of Contents
+- [Core Principles](#core-principles)
+- [Workflow](#workflow)
+- [The Ledger Columns](#the-ledger-columns)
+- [Evidence Classes and Attribution Grammar](#evidence-classes-and-attribution-grammar)
+- [Causal Claim Triage](#causal-claim-triage)
+- [Mechanical Integrity Checks](#mechanical-integrity-checks)
+- [Guardrails](#guardrails)
+- [Quick Reference](#quick-reference)
+
+**Related skills:** Use `claim-extractor` to harvest raw assertions from a corpus before entering them here, `research-claim-map` for mapping claim-to-source webs, `narrative-opposition-web` for opponent warranting once the ledger exists, `causal-inference-root-cause` when a causal link needs actual analysis rather than grading. Three siblings consume what this skill defines: `narrative-fidelity-audit` is the pre-ship gate and imports this ledger rather than rebuilding it, `narrative-fallacy-guard` uses the L1-L5 causal grades defined here, `numbers-in-narrative` imports the frame lock built here.
+
+**This skill owns** the A-F evidence classes, the L1-L5 causal ladder, the pointer schema, the circular-citation check, and the frame lock; siblings cite these definitions rather than restating them.
+
+## Core Principles
+
+1. **Provenance, not verification**: This skill tracks where a claim came from. It never establishes that a claim is true. The permitted verbs are "sourced", "class-tagged", "re-derivable". The banned verbs are "verified", "fact-checked", "confirmed", "validated". An output claiming verification is a defect, not a flourish.
+2. **Ledger before architecture**: Any structure chosen before the ledger exists will generate demand for material, and unfilled demand gets filled by invention. Build order is frame lock -> findings -> claims -> beats. Never the reverse.
+3. **The pointer must resolve outside the pipeline**: A pointer into your own summary, notes, or a prior draft is a hard failure, not a weak citation. Only external artefacts count.
+4. **Nothing is deleted, only killed**: Findings that a veto killed move to DEAD with the veto that killed them. The DEAD column ships with the deliverable. It is the only defence against a cherry-picking charge.
+5. **The verb carries the evidence grade**: Causal language is typed. A claim graded L3 SEQUENCE may not later acquire the verb of an L1 MECHANISM claim without re-grading. Silent upgrades are the most common corruption.
+6. **These are label devices, not delete rules**: A ledger that gates on every test ships a chronicle, and a chronicle informs nobody. Most checks here terminate in a disclosure or a downgrade, not a deletion.
+7. **A clean ledger is not a true piece**: Every per-claim check can pass while the assembled work misrepresents drift and proportion through selection alone. The omission set and proportion check are the expensive parts and they are the ones that matter.
+
+## Workflow
+
+Copy this checklist and track your progress:
+
+```
+Evidence Ledger Progress:
+- [ ] Step 1: Lock the frame (unit, denominator, window, boundary)
+- [ ] Step 2: Atomize material into findings with class + pointer
+- [ ] Step 3: Triage every causal link and assign permitted verbs
+- [ ] Step 4: Promote findings -> claims -> beats, one way
+- [ ] Step 5: Run the mechanical integrity checks
+- [ ] Step 6: Emit the handoff artefact and the gate verdict
+```
+
+**Step 1: Lock the frame**
+
+Step 1.1: Write four lines before touching any material. UNIT: what is one row or one case? DENOMINATOR: per what? WINDOW: from when to when, and what justifies each edge? BOUNDARY: which entities are in the population, and who drew that line, you or the source?
+
+Step 1.2: For each of the four, name one alternative you rejected and give a one-sentence reason. This is the anti-cherry-picking record and it is not optional.
+
+Step 1.3: Record the starting hypothesis verbatim, dated, before you look. You will diff against it in Step 6.
+
+See [resources/frame-lock.md](resources/frame-lock.md) for the rate-vs-count rule, denominator-drift detection, the instrument check, and worked frame locks from three domains.
+
+**Step 2: Atomize material into findings**
+
+Step 2.1: Decompose the material into atomic findings, one verifiable assertion each, with an ID. A finding has no addressee and no interpretation.
+
+Step 2.2: Tag each with an EVIDENCE CLASS (A-F), a POINTER granular enough to re-find it, CONTESTED or UNCONTESTED, SOURCE INTEREST (who benefits from this account), and SOURCE VINTAGE (contemporaneous or retrospective, primary or secondary).
+
+Step 2.3: Kill nothing yet. Findings that fail a veto later go to DEAD with the veto named.
+
+See [resources/evidence-classes.md](resources/evidence-classes.md) for the class definitions, the pointer granularity test, and the register-porting table.
+
+**Step 3: Triage every causal link**
+
+Step 3.1: Extract every sentence or planned link containing a causal connective, plus every juxtaposition a reader would read causally. Scan headings, captions, section breaks and chart titles, not only body sentences.
+
+Step 3.2: Assign exactly one grade: L1 MECHANISM, L2 CORRELATION, L3 SEQUENCE, L4 ADJACENCY, L5 CONJECTURE. Record the permitted verb set with the grade.
+
+Step 3.3: For every L1, name the artefact that documents the LINK, not the two endpoints. If the only source is a retrospective secondary account, downgrade to L3 or L5.
+
+See [resources/causal-triage.md](resources/causal-triage.md) for the full verb tables, the back-reference check, and system-intentionality grammar.
+
+**Step 4: Promote, one way**
+
+Step 4.1: FINDING -> CLAIM requires three things in writing: the interpretive leap, the population it generalises to, and what evidence would falsify it. A claim with no falsifier is not a claim; send it back.
+
+Step 4.2: CLAIM -> BEAT requires two things: the prior belief it overturns, phrased as a sentence someone actually held, and the relation joining it to the preceding beat. A claim that changes nothing in the reader's model is supporting evidence, not a beat.
+
+Step 4.3: Promotion is one-way per pass. Nothing may be promoted and then demoted inside a single revision, or the ledger stops tracking anything. Demotion is a logged event in the next pass, with a reason.
+
+See [resources/ledger-schema.md](resources/ledger-schema.md) for the field-by-field schema, the ratio check, and DEAD-column conventions.
+
+**Step 5: Run the mechanical integrity checks**
+
+Step 5.1: Run all six checks in [Mechanical Integrity Checks](#mechanical-integrity-checks). Each returns pass or a defect list. Do not fix while checking; fixing and checking are separate passes.
+
+Step 5.2: Sample 10% of findings at random and re-derive each from its pointer alone, with the draft hidden. If the pointer does not independently yield the finding, the class tag is wrong.
+
+Step 5.3: Assemble the OMISSION SET: every corpus item that appears nowhere in the ledger. For each, write why. Any item that would weaken the emerging spine and lacks a written reason is a cherry-pick and must be reinstated.
+
+**Step 6: Emit the handoff artefact and the gate verdict**
+
+Step 6.1: Emit the ledger with all four columns, the frame lock, the causal grade map, the omission set, and the integrity check results.
+
+Step 6.2: Diff the current reading against the Step 1.3 starting hypothesis and write what changed. If nothing changed, either you were unusually right or you did not look.
+
+Step 6.3: State the gate verdict explicitly, including the required line: "This ledger records provenance. No claim in it has been verified. Human verification status: none."
+
+Validate using [resources/evaluators/rubric_narrative_evidence_ledger.json](resources/evaluators/rubric_narrative_evidence_ledger.json). **Minimum standard**: Average score >= 3.5.
+
+## The Ledger Columns
+
+| Column | Definition | Entry requires |
+|--------|------------|----------------|
+| FINDING | A typed fact, checkable against a source. No addressee, no interpretation. | Class, pointer, contested flag, source interest, source vintage |
+| CLAIM | A finding plus an interpretive commitment that can be wrong even if the finding is right. | The leap, the population, the falsifier |
+| BEAT | A claim plus a change in the reader's model of the world. | The prior belief overturned, the relation to the previous beat |
+| DEAD | Anything a veto, an instrument check, or a test killed. Never deleted. | The killer, the date, and DID-NOT-SUPPORT vs CONTRADICTED |
+
+**Referential integrity**: every beat cites >= 1 claim; every claim cites >= 1 finding; every finding cites an external data location (table and row range, document and page, commit hash, transcript timestamp).
+
+**Ratio check**: beats > claims means you are narrating without arguing. Findings vastly exceeding claims means you are reporting without interpreting. Claims exceeding findings means you are asserting.
+
+**DEAD entries are typed.** "Did not support" (the evidence was too thin, the denominator was indefensible, the transform flipped it) is not the same as "CONTRADICTED" (a source establishes the opposite). Conflating them lets a contradicted claim re-enter later as merely unproven.
+
+## Evidence Classes and Attribution Grammar
+
+| Class | What it is | Default attribution level |
+|-------|-----------|---------------------------|
+| A | Primary artefact: filing, contract, dataset, log, transcript, commit, instrument reading | L0 if uncontested and covered by a methods note; L1 if consequential |
+| B | First-person testimony about own experience | L2 epistemic verb; L3 if self-serving or contested |
+| C | Second-hand testimony about someone else's experience | L3 mandatory, plus explicit distance |
+| D | Secondary reporting: another account of the events | L3 mandatory, plus a flag that the underlying source was not obtained. Never L0 or L1 |
+| E | Analyst or agent inference | L5-adjacent marking. Never presented as a finding |
+| F | Unsourced | Cannot enter the ledger. Delete, or convert to an open research question |
+
+Attribution levels: **L0** unmarked assertion. **L1** embedded source ("the postmortem timestamps the first alert at 02:14") - this is the workhorse and costs almost no rhythm. **L2** epistemic verb (recalled, estimated, projected). **L3** explicit attribution ("according to X"). **L4** contest marker, both values in one sentence, mandatory for every CONTESTED finding. **L5** uncertainty declaration ("the record does not establish"). **L6** methods block absorbing routine load.
+
+**Bad** (supply-chain domain, class D wearing L0 grammar): "Congestion forced carriers to reroute through Vancouver in early 2021."
+**Good**: "Carrier filings put Vancouver call volume up 34% between January and April 2021 [F-112, class A]. Two operators cited congestion in their rerouting notices [F-118, class A]; the record does not establish why the others moved [L5]."
+
+**Budget rule (derived default, not a published figure)**: if more than roughly one sentence in four in a passage sits at L3 or above, the passage is under-reported, not over-attributed. Fix by reporting, never by deleting attributions.
+
+**Register porting**: technical, financial and scientific registers have no "sources said" convention. Port the FUNCTION (evidentiary status visible in the sentence) into that register's own forms - inline figures with units and dates, footnote markers, named instruments, commit references. Do not import journalism's surface grammar, and do not drop the requirement because the target register lacks it.
+
+## Causal Claim Triage
+
+| Grade | Established | Permitted verbs | Banned |
+|-------|-------------|-----------------|--------|
+| L1 MECHANISM | The linking step itself is documented: memo, contract, physical process, accounting identity, code path, executed decision | caused, forced, triggered, led to, because, resulted in | - |
+| L2 CORRELATION | Quantitative co-movement documented, mechanism absent | moved with, tracked, accompanied, coincided with | because, drove, forced |
+| L3 SEQUENCE | Only temporal order established, both dates known | then, afterwards, in the following quarter, subsequently | every causal connective |
+| L4 ADJACENCY | Co-present in time or space, no link established | (separate them in the text) or an inline disclaimer: "the two were concurrent; no link is documented" | any verb joining them |
+| L5 CONJECTURE | The analyst's inference, no source | must carry an inference marker: "the most plausible reading is", "no source says why, but" | may never occupy a thesis, climax, or revelation slot |
+
+**L1 requires a source for the LINK.** Two sourced endpoints plus a plausible story is L3. A retrospective secondary account that *asserts* a mechanism does not *document* one; it cannot support an L1 tag.
+
+**Bad** (ML writeup): "Adding the auxiliary loss drove the 3.1-point accuracy gain."
+**Good**: "Accuracy rose 3.1 points in the run that added the auxiliary loss [F-44]. Three other changes shipped in the same commit [F-45..47]; no ablation isolates the loss. L3."
+
+**Back-reference check (the anti-upgrade guard)**: causal verbs are protected tokens carrying their grade. Any later edit that changes a causal verb must re-cite the grade in the same edit. Re-run the check after every revision pass by re-extracting the verbs and diffing against the grade map. Verb creep is silent: grades are assigned honestly at ledger time, then a line-edit turns "then" into "which forced" and the grade map no longer describes the text.
+
+**System protagonists**: substitute INTENTIONALITY for interiority. A market, protocol, institution or codebase has no mind, so "the market realized", "the industry decided", "the protocol wanted" is either shorthand the reader will misread as agency or an unsourced claim about collective intent. Ground the system's want in one of three, and label which: documented incentives, stated strategy in a filing or roadmap or minutes, or revealed preference in prices, allocations, or spend.
+
+## Mechanical Integrity Checks
+
+Run all six. Each is checkable by pattern, not by judgment.
+
+1. **Circular citation**: every pointer must resolve to an artefact outside this pipeline. Any pointer resolving into your own summaries, notes, prior drafts, or another agent's output is a HARD FAILURE. Invisible to reading; must be checked mechanically.
+2. **Class F sweep**: zero findings may sit at class F when the ledger is handed off.
+3. **Pointer granularity**: "the 10-K" fails; "FY2023 Form 10-K, p.47, Risk Factors" passes. "The logs" fails; "app-server.log, 2024-03-11 02:14:07Z" passes.
+4. **Grade-verb match**: re-extract every causal verb and confirm it sits inside its grade's permitted set.
+5. **Instrument check on every discontinuity**: for any finding that a measure changed, ask whether the world changed or the measurement changed. Enumerate definitional revisions, coverage changes, methodology restatements, reporting lags, entity or boundary changes. Unresolved, the finding goes to DEAD; if the instrument change is real, the instrument change is the finding.
+6. **Anachronism flag**: flag any category, metric, or moral frame used in the ledger that did not exist at the time described. Say so in the text. This is the narrow checkable operation; do not encode a general position on applying present-day categories to the past.
+
+## Guardrails
+
+**Requirements:**
+1. **Never claim verification**: the handoff must state that provenance was tracked and nothing was verified. If a human verified some subset, name that subset and who did it.
+2. **Frame lock is frozen**: any later change to unit, denominator, window, or boundary RE-OPENS the ledger. It is not a chart adjustment. Log it as a frame revision with a reason.
+3. **DEAD ships**: the DEAD column and the omission set are deliverables, not scratch. Hiding them is what a cherry-picked ledger looks like.
+4. **Disclosure lives in the body**: any inference or uncertainty declaration that qualifies a claim belongs within two sentences of it, in the same typographic register. An endnote-only disclosure is functionally undisclosed. Mark these as non-removable; assume any later "tighten this" pass will strip them.
+5. **Record the strongest opposing reading**: for each major outcome, write the strongest agency-based reading you considered and why it was or was not adopted. Skipping this produces the mirror bias, in which everything is luck and structure and nobody ever decided anything.
+6. **Apparatus budget (derived default)**: cap hedges, uncertainty declarations, and disclosure sentences at roughly 3 per 1,000 words of finished prose. When the budget binds, that is a signal to change the architecture, not to spend more budget.
+7. **Surface, do not adjudicate**: where a real named person or active institution occupies an adverse position, flag it for human decision. Do not soften the wording and keep the structure.
+
+**Common pitfalls:**
+- Annotation theatre: pointers that cite the wrong layer, so the ledger looks rigorous and is not. The 10% re-derivation sample is the detector.
+- Subtraction treated as free: refusal training makes a model good at not adding and does nothing about not omitting. An entirely sourced, entirely false ledger is built by cuts, each individually defensible.
+- Defensive over-disclosure: burying the strongest counter-evidence under a pile of weak supporting material is an attack on the reader, not integrity. The test is whether a disagreeing reader can FIND the best evidence against you, not how much material surrounds it.
+- The "higher truth" move: "this is clearly what happened", "the reader will understand", "it is emotionally accurate", "it is a reasonable inference". Name it when you catch yourself generating it. It is the genre's named failure and it arrives sounding like judgment.
+- Zero gaps: a ledger with no gaps and no DEAD entries is a red flag, not a success. Real material always has holes.
+- Coherence mistaken for evidence: a well-made narrative measurably suppresses reader scrutiny. That is why the DEAD column ships.
+
+**Provenance of the rules themselves**: the A-F class scheme and the L1-L5 causal ladder are derived working taxonomies assembled for this skill, not published standards; cite them as conventions, not authorities. The straw/hoop/smoking-gun test names come from the process-tracing literature. Numeric thresholds here (one-in-four attribution budget, 3 hedges per 1,000 words, 10% re-derivation sample, 5-record thin support) are derived defaults, not published figures - tune them and say you did.
+
+## Quick Reference
+
+**Key resources:**
+- **[resources/ledger-schema.md](resources/ledger-schema.md)**: field-by-field schema for all four columns, promotion and demotion rules, referential integrity, DEAD conventions, worked ledger extracts
+- **[resources/evidence-classes.md](resources/evidence-classes.md)**: class A-F definitions with domain examples, pointer granularity tests, source-interest and vintage annotation, the full evidence-class to attribution-grammar decision table, register porting
+- **[resources/causal-triage.md](resources/causal-triage.md)**: L1-L5 verb tables, the back-reference check procedure, scan targets beyond body text, system-intentionality grammar, counterfactual admissibility
+- **[resources/frame-lock.md](resources/frame-lock.md)**: unit/denominator/window/boundary procedure, rejected-alternative record, denominator drift, the instrument check, the seven metamorphic transforms
+- **[resources/evaluators/rubric_narrative_evidence_ledger.json](resources/evaluators/rubric_narrative_evidence_ledger.json)**: quality scoring
+
+**Inputs required:**
+- The research corpus, with source artefacts reachable (not summaries of them)
+- The intended protagonist, if known: a person, or a system such as a market, protocol, institution, codebase, or supply chain
+- The starting hypothesis, written down and dated before analysis
+
+**Outputs produced:**
+- Frame lock: unit, denominator, window, boundary, each with one rejected alternative and reason
+- Four-column ledger with referential integrity satisfied
+- Causal grade map: every link graded L1-L5 with its permitted verb set
+- DEAD column, typed DID-NOT-SUPPORT vs CONTRADICTED
+- Omission set with a written reason per omitted corpus item
+- Integrity check results, including the circular-citation verdict
+- Hypothesis diff and the explicit no-verification statement

--- a/skills/narrative-evidence-ledger/resources/causal-triage.md
+++ b/skills/narrative-evidence-ledger/resources/causal-triage.md
@@ -1,0 +1,182 @@
+# Causal Claim Triage
+
+Every causal link in a narrative is a claim requiring a warrant. Grading is not hedging. Grading is typing: the grade fixes which verbs the sentence may use, and the back-reference check stops the grade and the sentence drifting apart later.
+
+The L1-L5 ladder is a working taxonomy assembled for this skill, not a published standard. The straw / hoop / smoking-gun / doubly-decisive test names come from the process-tracing literature in political science.
+
+## Table of Contents
+- [The five grades](#the-five-grades)
+- [What L1 actually requires](#what-l1-actually-requires)
+- [Scan targets](#scan-targets)
+- [The back-reference check](#the-back-reference-check)
+- [System intentionality grammar](#system-intentionality-grammar)
+- [Hindsight fences](#hindsight-fences)
+- [Process-tracing test assignment](#process-tracing-test-assignment)
+- [Counterfactual admissibility](#counterfactual-admissibility)
+- [Worked triage, three domains](#worked-triage-three-domains)
+
+## The five grades
+
+| Grade | What is established | Permitted verbs | Banned |
+|-------|--------------------|-----------------|--------|
+| L1 MECHANISM | The linking step itself is documented: a decision memo, a contract term, a physical process, an accounting identity, a code path, a stated and executed decision | caused, forced, triggered, led to, because, resulted in, drove | — |
+| L2 CORRELATION | Quantitative co-movement is documented; the mechanism is not | moved with, tracked, accompanied, coincided with, rose alongside | because, drove, forced, caused |
+| L3 SEQUENCE | Only temporal order, with both dates known | then, afterwards, subsequently, in the following quarter, by which point | every causal connective |
+| L4 ADJACENCY | Co-present in time or space; no link established | none. Either separate the two events in the text so no link can be read, or carry an inline disclaimer: "the two were concurrent; no link is documented" | any verb joining them |
+| L5 CONJECTURE | The analyst's inference; no source for the link | must carry an explicit inference marker: "the most plausible reading is", "no source says why, but", "I infer" | may never occupy a thesis, climax, or revelation slot |
+
+**L2 additionally requires**, in the ledger: the actual series, the window, and a statement of what else moved the same way in that window. A correlation with no listed co-movers is an unexamined correlation.
+
+**Downgrade rules that fire automatically:**
+
+- The only source for the link is `retrospective-secondary` → maximum L3.
+- The source *asserts* a mechanism rather than *documenting* one → maximum L3. An analyst writing "the tariff caused the shift" is class D testimony about causation, not documentation of a mechanism.
+- A live alternative explanation exists that you cannot rule out → downgrade L1 to L3, or L2 to L4.
+- The link rests on stated intent alone (an actor said they did X because of Y) → this is a claim about *stated reasons*, which may be false. Permitted verbs narrow to "in response to", "citing", "after which".
+
+## What L1 actually requires
+
+**A source for the LINK, not for the two endpoints.**
+
+Two sourced facts plus a plausible connecting story is L3. This is the single most common tag inflation in practice, and it is invisible unless the ledger records *what document establishes the link* as a separate field from the documents establishing the endpoints.
+
+| Endpoints sourced | Link sourced | Grade |
+|-------------------|-------------|-------|
+| Tariff announced 4 March (class A); imports fell in April (class A) | nothing | L3 |
+| Same | Importer's board minutes, 6 March, resolving to halt orders pending tariff review (class A) | L1 |
+| Same | Trade-press article stating the tariff caused the drop (class D) | L3 |
+| Same | Importer's CEO in a later interview saying the tariff was why (class B, retrospective-primary) | L2, with the stated-intent verb set |
+
+## Scan targets
+
+Causal claims migrate away from anywhere you check. When body sentences get constrained, the claim moves to where the tagger is not looking. Scan all of these:
+
+- Body sentences containing: because, so, led to, drove, forced, triggered, as a result, which is why, meant that, hence, thus, consequently
+- **Section headings and chapter titles** — "How the tariff broke the supply chain" is an L1 claim
+- **Chart titles and figure captions** — the title is what readers remember; a causal title is a causal claim
+- **Chart annotations** — an arrow labelled "policy change" pointing at an inflection is an L1 claim drawn rather than written
+- **Pull quotes** — a quoted source asserting causation on your behalf is still your claim about what the piece establishes
+- **Paragraph breaks and scene cuts between two events** — structural juxtaposition is a causal claim made without words
+- **Metaphor** — "the dam broke", "the floor gave way", "the fuse was lit" are causal claims wearing figurative clothes
+- **Ordering itself** — if B now precedes A in the text but followed A in reality, readers will invert the causality
+
+The adjacency-by-layout check: scan for L3 and L4 pairs separated only by a paragraph break, a scene cut, or a section heading. Treat each as if the connective were present.
+
+## The back-reference check
+
+Grades are assigned honestly at ledger time. Then a line-edit turns "then" into "which forced", because "which forced" reads better, and the grade map silently stops describing the text.
+
+**Procedure, run after every revision pass:**
+
+1. Re-extract every causal verb and every juxtaposition from the current text, using the scan targets above.
+2. Join against the grade map by claim ID.
+3. Report three sets: verbs outside their grade's permitted set; graded links whose text no longer contains any marker; new causal constructions with no claim ID at all.
+4. For each mismatch, either restore the permitted verb or re-grade the link with a written reason. Never re-grade silently to license a verb that has already been written.
+5. Treat causal verbs as protected tokens. A downstream editing pass may reword around them but may not change them without re-citing the grade.
+
+**The third set is the important one.** New causal constructions with no claim ID are usually fabricated connectives rather than fabricated facts: "By then the pressure had become impossible to ignore." "The team, now convinced, moved on." These assert state changes, carry no proper nouns or numbers, trip no fact-check, and are pure invention. Transition and summary sentences carry claim IDs like every other sentence.
+
+## System intentionality grammar
+
+When the protagonist is a market, a protocol, an institution, a codebase, or a supply chain, the ethics load shifts but does not lighten. A system has no interiority, so every "the market realized" sentence is either shorthand a reader will misread as agency, or a hidden causal claim about collective intent.
+
+**Substitute intentionality for interiority.** A system's "want" must be grounded in one of three, and the ledger must record which:
+
+| Grounding | What it is | Example |
+|-----------|-----------|---------|
+| Documented incentive | A payoff structure that exists on paper | "Reimbursement rules paid per procedure, not per outcome." |
+| Stated strategy | A filing, roadmap, standard, charter, minutes, RFC | "The 2021 roadmap named latency as the primary target." |
+| Revealed preference | Behaviour visible in prices, allocations, spend, traffic, merges | "Ninety percent of new capacity went to the 300mm line." |
+
+**Banned constructions**, unless cashed out into the mechanism in the same sentence:
+
+- "the market realized" / "the market decided" / "the market wanted"
+- "the industry moved to" (as an intentional act)
+- "the protocol wanted" / "the algorithm decided"
+- "physics fought back"
+- "the codebase resisted"
+
+Rewrite as an aggregate of documented actor behaviour, or mark it explicitly as shorthand at first use.
+
+Bad: "By 2018 the market had realized that the 200mm line was a dead end."
+
+Good: "Between 2016 and 2018 the four largest buyers each announced 300mm-only qualification programmes [F-220..223]. No public statement from any of them names the 200mm line as obsolete."
+
+**Opponents in a system narrative are usually constraints**, not villains: physics, capital cost, regulation, latency, yield, thermal budget, contract term. Resist casting a firm or a person as antagonist merely because the narrative has an antagonist slot. An agent that only checks facts and never checks intentionality verbs will pass a piece that is wrong in its every load-bearing sentence.
+
+## Hindsight fences
+
+Four checks that kill most retrospective contamination. All are label-and-disclose devices, not delete rules.
+
+**1. Contemporaneous-knowledge fence.** No actor may be shown acting on information that postdates their action. This single check catches more hindsight contamination than the other three combined.
+
+**2. Inevitability ban.** Delete every "was always going to", "inevitably", "the writing was on the wall", "in hindsight it was obvious" that is not attributed to a contemporaneous source. The outcome may not be foreshadowed as certain.
+
+**3. Retrospective-only tag.** For each event carrying a structural role, record four dates: the event date; the date of the earliest source treating it as significant; the outcome date; the date of the source you actually cited. If the earliest source treating it as significant postdates the outcome, tag the link RETROSPECTIVE-ONLY. A RETROSPECTIVE-ONLY link may not carry unhedged causal language. Either downgrade the verb, or add one sentence **in the body** stating that the significance is visible only in hindsight.
+
+Do not mechanically demote every RETROSPECTIVE-ONLY link. Some genuinely causal processes are invisible to everyone present: a slow demographic shift, accumulating technical debt, a gradual change in yield. An agent that demotes all of them will refuse to name real structural causes and will over-weight whatever happened to be loud at the time. That is salience bias wearing the costume of rigor.
+
+**4. Substitution test.** For each retrospective-only link, name two other events in the same window that a narrator with a different ending would have selected instead. If you cannot name two, you have not searched the corpus.
+
+## Process-tracing test assignment
+
+Optional but high-value for load-bearing links. Assign each piece of evidence a test type by asking two yes/no questions: is passing NECESSARY for affirming the hypothesis? is passing SUFFICIENT?
+
+| | Not sufficient | Sufficient |
+|-|----------------|-----------|
+| **Not necessary** | STRAW-IN-THE-WIND: passing slightly weakens rivals; failing slightly weakens H | SMOKING-GUN: passing confirms H; failing does not eliminate it |
+| **Necessary** | HOOP: failing ELIMINATES H; passing only affirms relevance | DOUBLY DECISIVE: rare; passing confirms H and eliminates rivals |
+
+Rules that make this more than a labelling ritual:
+
+- Write at least two rival hypotheses **before** assigning any test. Without a named rival, everything looks like a smoking gun, because there is nothing for it to discriminate against.
+- Name the rival each test eliminates, in the same breath as the test name.
+- Run at least one hoop test whose failure would kill your spine, and record the result whichever way it goes. Running only hoop tests your favoured hypothesis will pass is hoop-test theatre.
+- Record which tests were run, which passed, and which were not attempted. An unattempted hoop test is an open hole and gets disclosed as one.
+- Placement rule: a link supported only by straws-in-the-wind may appear, but may not occupy the thesis, climax, or revelation slot.
+
+## Counterfactual admissibility
+
+If the piece uses a "what if" node, all six gates must pass or the node is rejected.
+
+| Gate | Requirement | Fails |
+|------|-------------|-------|
+| CLARITY | Antecedent and consequent both specified concretely | "if things had gone differently" |
+| COTENABILITY | You can enumerate the connecting principles — everything else that would also have to be true | Cannot list them → reject |
+| MINIMAL REWRITE | Exactly one thing changes | Requires altering a second independent fact → you are describing a different world |
+| HISTORICAL CONSISTENCY | The antecedent was physically, technically, and institutionally possible at that date, and someone at the time proposed or considered it | Anachronistic option |
+| THEORETICAL CONSISTENCY | The link from antecedent to consequent uses a mechanism already established in the piece at L1 or L2 | Novel mechanism invented for the counterfactual |
+| STATISTICAL CONSISTENCY | Where base rates exist, the counterfactual outcome falls inside them | Outcome outside any observed range |
+
+Rendering rules: admitted nodes appear as bounded elements — a bracketed passage, a sidebar, a distinctly styled paragraph. Never as a dramatised scene with sensory detail; a dramatised counterfactual acquires the same vividness as documented events and readers will not retain the distinction. Cap density at roughly one node per major section (derived default).
+
+The characteristic failure is the counterfactual as consolation: a "what if" so implausible that the actual path looks overdetermined by comparison, which strengthens the sense of inevitability the node was supposed to weaken.
+
+## Worked triage, three domains
+
+### Epidemiology
+
+Text: "The vaccination campaign drove case counts down 40% over the following quarter."
+
+- Endpoints: campaign start date (class A, health ministry release); case counts (class A, surveillance series).
+- Link source: none.
+- Co-movers in window: a seasonal decline of similar magnitude in each of the three prior years; a testing-eligibility change on 12 May.
+- **Grade: L2 at best, and the testing change triggers an instrument check.** Permitted: "Case counts fell 40% over the quarter following the campaign, alongside the seasonal decline seen in each of the prior three years. Testing eligibility narrowed on 12 May [F-88]."
+
+### Codebase
+
+Text: "The refactor caused the p99 regression."
+
+- Endpoints: merge commit (class A, `8f31ac2`); p99 series (class A, metrics store).
+- Link source: **yes** — the commit changes the backoff calculation, and the code path is inspectable and produces the observed shape.
+- **Grade: L1.** Permitted: "caused". The link is documented in the code path itself, which is exactly what an L1 tag is for. Record the artefact establishing the link as `scheduler/backoff.go` lines 55-71, separately from the endpoint pointers.
+
+### Institutional history
+
+Text: "The 1994 reorganisation was what allowed the division to survive the downturn."
+
+- Endpoints: reorganisation date (class A, board minutes); division survived (class A, later filings).
+- Link source: a 2011 management book (class D, retrospective-secondary).
+- Retrospective-only: the earliest source treating the reorganisation as consequential is dated 2011, well after the outcome.
+- Substitution test: name two other 1994 events a different narrator would have chosen. If you cannot, search again.
+- **Grade: L5 at best, marked, and barred from the climax.** Permitted: "No contemporaneous source treats the 1994 reorganisation as decisive. Reading backward from the division's survival, it is the most plausible candidate; the record does not establish it."

--- a/skills/narrative-evidence-ledger/resources/evaluators/rubric_narrative_evidence_ledger.json
+++ b/skills/narrative-evidence-ledger/resources/evaluators/rubric_narrative_evidence_ledger.json
@@ -1,0 +1,104 @@
+{
+  "name": "Narrative Evidence Ledger Rubric",
+  "description": "Evaluation criteria for an evidence ledger produced before narrative structuring. Scores whether the frame is locked, whether findings carry re-findable external provenance, whether causal claims are graded and verb-constrained, whether promotion is disciplined, and whether what was killed and omitted survives into the deliverable.",
+  "criteria": [
+    {
+      "name": "Frame Lock Completeness",
+      "description": "Whether unit, denominator, window and population boundary are written, frozen, and each carries a rejected alternative with a reason",
+      "weight": 1.2,
+      "scores": {
+        "1": "No frame lock; unit and denominator are implicit and shift across the material",
+        "2": "Some of the four named, none with rejected alternatives; denominator language is loose (per-capita misused, percent vs percentage point conflated)",
+        "3": "All four named in writing; rejected alternatives missing or generic ('other options were worse')",
+        "4": "All four named with a specific rejected alternative and reason for each; denominator language correct throughout",
+        "5": "All four locked with rejected alternatives whose reasons are independent of the direction they would move the headline; rate-vs-count rule applied; small-denominator check run; any later frame change logged as a ledger re-open"
+      }
+    },
+    {
+      "name": "Provenance Granularity and Externality",
+      "description": "Whether every finding carries an evidence class and a pointer that resolves to an external artefact at a granularity someone else could re-find",
+      "weight": 1.5,
+      "scores": {
+        "1": "Findings carry no pointers, or pointers resolve into the pipeline's own summaries, notes, or prior drafts (circular citation)",
+        "2": "Pointers exist but are gestural ('the 10-K', 'the logs'); classes assigned inconsistently or not at all",
+        "3": "Every finding has a class and a pointer; some pointers are too coarse to re-find without the draft in hand",
+        "4": "All pointers pass the granularity test (page, line, timestamp, row range, commit); circular-citation check run and clean; zero class F at handoff",
+        "5": "All of the above, plus source interest and source vintage recorded per finding, a 10% re-derivation sample run with results reported, and retrospective-secondary sources barred from supporting L1 grades"
+      }
+    },
+    {
+      "name": "Causal Grading and Verb Discipline",
+      "description": "Whether every causal link is graded L1-L5 with a source for the LINK, verbs constrained to the grade's permitted set, and the back-reference check run",
+      "weight": 1.5,
+      "scores": {
+        "1": "Causal verbs used freely; no grades assigned; two sourced endpoints treated as a documented mechanism",
+        "2": "Grades assigned to some links; verbs not constrained; L1 tags rest on sources that assert a mechanism rather than document one",
+        "3": "All body-sentence links graded and verbs match the grade; scan did not cover headings, captions, juxtapositions, or metaphor",
+        "4": "Full scan including headings, captions, annotations, pull-quotes and adjacency-by-layout; L1 tags each name the artefact establishing the link, separate from endpoint pointers",
+        "5": "All of the above, plus the back-reference check run after each revision reporting all three mismatch sets, causal verbs treated as protected tokens, hindsight fences applied (contemporaneous-knowledge, inevitability ban, retrospective-only tagging, substitution test)"
+      }
+    },
+    {
+      "name": "Promotion Discipline and Referential Integrity",
+      "description": "Whether findings, claims and beats are distinct objects, promoted one-way with the required written justifications, and whether the citation graph resolves",
+      "weight": 1.2,
+      "scores": {
+        "1": "Columns collapsed; findings appear directly as narrative beats with no claim layer and no falsifiers",
+        "2": "Three columns nominally present; promotions unjustified; dangling references between layers",
+        "3": "Referential integrity holds; finding-to-claim promotions carry a leap and a population but falsifiers are missing or untestable",
+        "4": "Every claim has leap, population and falsifier; every beat names the prior belief it overturns and its relation to the previous beat; promotion is one-way per pass",
+        "5": "All of the above, plus the ratio check reported and acted on, cause-effect relations capped near the observed practice baseline with a separate non-data mechanism argument for each, and the recontextualisation test applied per beat"
+      }
+    },
+    {
+      "name": "DEAD Column and Omission Set",
+      "description": "Whether killed findings are kept and typed, and whether the corpus items absent from the ledger are enumerated with reasons",
+      "weight": 1.3,
+      "scores": {
+        "1": "No DEAD column; killed material deleted; no record of what the ledger excluded",
+        "2": "Some kills recorded without the killer named, and without distinguishing did-not-support from contradicted",
+        "3": "DEAD column present and typed; omission set absent or not reasoned",
+        "4": "DEAD entries name the specific veto, check or transform, carry a date, preserve the original pointer, and are typed DID-NOT-SUPPORT vs CONTRADICTED; omission set enumerated with a reason per item",
+        "5": "All of the above, plus the omission set reviewed as a set rather than per-item, any spine-weakening omission without a written reason reinstated, and both DEAD and omission set shipped as deliverables"
+      }
+    },
+    {
+      "name": "Instrument and Robustness Checks",
+      "description": "Whether discontinuities were tested for measurement artifacts and whether claims survived the metamorphic transforms",
+      "weight": 1.2,
+      "scores": {
+        "1": "Discontinuities narrated as world changes with no instrument check; no robustness testing",
+        "2": "Instrument check mentioned but not enumerated across artifact types; no transforms run",
+        "3": "Instrument check run on major discontinuities across the artifact-type list; some transforms run",
+        "4": "Instrument check run on every discontinuity with disposition recorded (re-baselined / killed / checked-and-none-found); all seven transforms run per claim with failures logged to DEAD",
+        "5": "All of the above, plus the forgotten-population pre-check, re-aggregation sign-flip test, change-point forking controlled by pre-registering the scan, time-to-detect computed for survivors, and the transforms explicitly reported as a floor rather than a certificate"
+      }
+    },
+    {
+      "name": "Verification Honesty and Bias Symmetry",
+      "description": "Whether the ledger states plainly that it tracks provenance and verifies nothing, and whether it records the strongest opposing reading rather than defaulting to structure-and-luck",
+      "weight": 1.4,
+      "scores": {
+        "1": "Output claims facts were 'verified', 'fact-checked' or 'confirmed'; no opposing readings recorded",
+        "2": "Verification language avoided inconsistently; no statement of human verification status; agency-based readings absent",
+        "3": "The no-verification statement is present; agency alternatives recorded for some outcome claims",
+        "4": "Explicit no-verification statement with human verification status named; strongest agency-based reading written for each major outcome with a reason for adoption or rejection",
+        "5": "All of the above, plus any human-verified subset named with the verifier, the 'higher truth' rationalisation named as a recognised failure pattern when it arises, anachronism flags raised where present, and adverse positions involving real named parties surfaced for human decision rather than softened"
+      }
+    },
+    {
+      "name": "Apparatus Proportion and Usability",
+      "description": "Whether the ledger produces something a downstream narrative agent can actually use, without drowning the eventual prose in hedges or burying counter-evidence in volume",
+      "weight": 1.0,
+      "scores": {
+        "1": "Output is unusable: either a bare list with no provenance layer, or so hedge-saturated that no claim is legible",
+        "2": "Handoff artefact incomplete; attribution levels assigned without regard to prose cost; L3 used where L1 would carry the same provenance",
+        "3": "Complete handoff artefact; attribution budget not measured; some passages sit above one-in-four at L3+ without diagnosis",
+        "4": "Attribution budget measured; over-budget passages diagnosed as under-reported and sent back to research rather than stripped of attributions; L1 embedded sourcing used as the default carrier",
+        "5": "All of the above, plus the apparatus budget respected with over-budget signalling an architecture change, disclosures placed in the body within two sentences of what they qualify and marked non-removable, and the strongest counter-evidence reachable rather than buried under supportive volume"
+      }
+    }
+  ],
+  "threshold": 3.5,
+  "passing_note": "Average score must be >= 3.5 for the ledger to be handed off to a narrative agent. A score below 3 in 'Provenance Granularity and Externality', 'Causal Grading and Verb Discipline', or 'Verification Honesty and Bias Symmetry' blocks handoff regardless of the average: a circular citation, an ungraded causal spine, or a false verification claim each corrupt everything built on top of them."
+}

--- a/skills/narrative-evidence-ledger/resources/evidence-classes.md
+++ b/skills/narrative-evidence-ledger/resources/evidence-classes.md
@@ -1,0 +1,166 @@
+# Evidence Classes and Attribution Grammar
+
+The A-F class scheme and the L0-L6 attribution ladder are working conventions assembled for this skill. They are not published standards. Cite them as house conventions, tune the boundaries for your domain, and say that you tuned them.
+
+## Table of Contents
+- [The six classes](#the-six-classes)
+- [Pointer granularity](#pointer-granularity)
+- [Source interest and source vintage](#source-interest-and-source-vintage)
+- [The attribution ladder](#the-attribution-ladder)
+- [Decision table: class to grammar](#decision-table-class-to-grammar)
+- [Register porting](#register-porting)
+- [The attribution budget](#the-attribution-budget)
+- [Bad and good, four domains](#bad-and-good-four-domains)
+- [Class F and the open-question conversion](#class-f-and-the-open-question-conversion)
+
+## The six classes
+
+| Class | Definition | Examples by domain |
+|-------|-----------|--------------------|
+| A | Primary artefact. A document, dataset, log, transcript, recording, or instrument reading that itself constitutes the evidence. | 10-K page; signed supply contract; app-server log line; git commit; assay output; meeting minutes; a letter in an archive |
+| B | Direct first-person testimony about the speaker's own experience or action. | "I set the threshold at 40%"; an engineer describing what they did; a founder on their own decision |
+| C | Second-hand testimony. A witness reporting someone else's experience, action, or state. | "My deputy told me he had already decided"; a colleague describing a meeting they heard about |
+| D | Secondary reporting. Someone else's account of the events, where you did not obtain the underlying source. | A trade-press article; a textbook; a retrospective blog post; an analyst note summarising a filing you did not read |
+| E | Analyst or agent inference. The reasoning is yours. | "The sequence is consistent with a capacity constraint" |
+| F | Unsourced. You believe it and cannot point at anything. | Any statement whose pointer field is empty |
+
+Class D is the one that quietly corrupts a ledger. A secondary account that cites nothing, or cites a primary source you never obtained, is still class D. If you can reach the underlying artefact, reach it and re-class to A. If you cannot, D stays D and the attribution must say the underlying source was not obtained.
+
+## Pointer granularity
+
+The test: **can a second person, with only the pointer and no access to your draft, independently produce this finding?**
+
+| Fails | Passes |
+|-------|--------|
+| "the 10-K" | "FY2023 Form 10-K, p.47, Risk Factors — Supply" |
+| "the logs" | "app-server.log, 2024-03-11 02:14:07Z, line 88214" |
+| "the interview" | "interview with R. Okonjo, 2025-11-02, 00:41:15" |
+| "the dataset" | "shipments.parquet, rows 4,102-4,388, column `net_units`, snapshot 2026-01-09" |
+| "their blog" | "engineering blog, 'Scaling the write path', 2023-06-14, para 9, retrieved 2026-02-11" |
+| "the repo" | "commit 8f31ac2, `scheduler/backoff.go`, lines 55-71" |
+
+**The 10% re-derivation sample.** Draw 10% of findings at random. Hide the draft. Re-derive each finding from its pointer alone. If the pointer does not independently yield the finding, the class tag is wrong, not merely imprecise.
+
+This detects the characteristic failure, which is annotation theatre: the ledger fills with citations that point at the wrong layer. At your own research summary. At a secondary article that itself cited nothing. At a document that mentions the topic without establishing the claim. The page looks rigorously sourced and is not.
+
+## Source interest and source vintage
+
+Two fields that most ledgers omit and that change the reading of everything above them.
+
+**Source interest.** Who benefits from this account being believed? A supplier's capacity statement, a regulator's incident count, a vendor's benchmark, a departing executive's version of a decision, a lab's own replication — each has a party with a stake. "None identified" is a legitimate answer. Blank is not.
+
+**Source vintage.** Four values:
+
+| Value | Meaning | Constraint |
+|-------|---------|-----------|
+| `contemporaneous-primary` | Produced at the time, is itself the evidence | Can support any grade |
+| `contemporaneous-secondary` | Produced at the time, reporting on something else | Cannot support L1 alone |
+| `retrospective-primary` | Produced later by a participant about their own action | Memory-marked attribution mandatory |
+| `retrospective-secondary` | Produced later by a non-participant | Cannot support L1 MECHANISM under any circumstance |
+
+"Contemporaneous" is not a clean standard. Contemporaneous sources are produced by interested parties, are selected by survival, and in business and technology domains skew heavily toward promotional material and commentary already coloured by an in-progress halo. Dating a source without annotating its interest moves the bias one step upstream instead of removing it.
+
+## The attribution ladder
+
+| Level | Form | Example |
+|-------|------|---------|
+| L0 | Unmarked assertion | "Revenue fell 18% that quarter." |
+| L1 | Embedded source: the source is a grammatical constituent, not an appendage | "The filing put revenue down 18%." / "The postmortem timestamps the first alert at 02:14." |
+| L2 | Epistemic verb naming the epistemic act | "She recalled thinking the number was wrong." / "The model projected 4.1%." |
+| L3 | Explicit attribution | "According to the former CFO..." |
+| L4 | Contest marker: both values, both sources, one sentence | "The company put the figure at 40%; the regulator's audit found 27%." |
+| L5 | Uncertainty declaration | "The record does not establish why the threshold was set there." |
+| L6 | Methods block or note on sources | Absorbs routine load so L0 and L1 can carry the prose |
+
+**L1 is the workhorse.** It carries full provenance and costs almost no rhythm. Prefer it to "according to" everywhere the source's identity matters but the claim is not contested. Most drafts that read as over-hedged are drafts that skipped L1 and reached for L3.
+
+**L3 is a budget item.** Its scarcity is what makes it a signal. Spend it on contested, self-serving, or consequential claims.
+
+**L4 is mandatory, not optional.** Every CONTESTED finding gets both values in the text. Never average two conflicting figures. Never silently pick the better-sounding one.
+
+**L6 licenses L0 only for what it actually covers.** A methods block is not a blanket. The characteristic abuse is attribution laundering: the agent pushes everything to L0 and justifies it with a methods block the reader will never open. Every sentence is individually "covered"; functionally the piece asserts inference as observation. The symptom is a methods block that describes the reporting in general terms rather than mapping to specific passages. The guard is mechanical: every L0 sentence must trace to a class A finding ID.
+
+## Decision table: class to grammar
+
+| Situation | Required level |
+|-----------|----------------|
+| Class A, uncontested, covered by the methods block | L0 |
+| Class A, consequential, or where the document's identity matters | L1 |
+| Class B, first-person recall, not contested | L2 |
+| Class B, self-serving or contested | L3 |
+| Class C, any | L3 mandatory, plus explicit distance: "his deputy said he had been told..." |
+| Class D, any | L3 mandatory, plus a flag that the underlying source was not obtained. Never L0 or L1 |
+| Class E, any | L5-adjacent marking. "The record does not establish X; the sequence is consistent with..." Never presented as a finding |
+| CONTESTED, any class | L4. Both values, both sources, one sentence |
+| Gap: the structure wanted a fact and none exists | L5 in the text. Not silence, not a bridge sentence |
+| Reconstructed scene or passage | The opening sentence carries the sourcing; the remainder may run unmarked under that cover |
+
+## Register porting
+
+Journalism has a "sources said" convention. Technical, financial, ML, and scientific registers do not — their prose norm is bare assertion backed by a bibliography. An agent tuned on journalistic forms and pointed at a chip-market analysis or a training-run writeup will drop attribution entirely, because the target register does not use it.
+
+Port the **function** — evidentiary status visible in the sentence — into the target register's own forms. Do not import journalism's surface grammar. Do not drop the requirement.
+
+| Register | L1 form | L2 form | L3 form | L5 form |
+|----------|---------|---------|---------|---------|
+| Journalism / narrative nonfiction | "The filing put revenue down 18%." | "He recalled thinking..." | "According to X..." | "No source could say..." |
+| Financial / market analysis | "FY23 filings show revenue down 18%." | "Management guided to 4%." | "The sell-side consensus, per [note], was..." | "The disclosure does not break this out." |
+| ML / systems writeup | "Table 3 reports 3.1 points." | "The authors estimate the gain at..." | "Per the model card, training used..." | "No ablation isolates this component." |
+| Post-mortem / incident | "PagerDuty logs the ack at 02:31Z." | "The on-call reported believing the alert was a duplicate." | "The vendor's RCA attributes it to..." | "Telemetry for the 02:14-02:31 window was not retained." |
+| Science writing | "The 2019 cohort study measured a 12% difference." | "The authors interpret this as..." | "A subsequent replication reported..." | "The effect has not been tested outside this population." |
+| Supply chain / operations | "Customs records show 4,200 units cleared in March." | "The carrier's notice cites port congestion." | "According to the freight forwarder..." | "Transit times for the remaining lanes are not recorded." |
+| Biography / archival | "The 12 June letter says she expected refusal." | "She later described the meeting as..." | "Her secretary's memoir places the call in..." | "The archive contains nothing from that fortnight." |
+
+## The attribution budget
+
+**Derived default, not a published figure.** If more than roughly one sentence in four in a passage sits at L3 or above, the passage is under-reported, not over-attributed.
+
+The correct fix is more reporting, never fewer attributions. The failure mode here is operational, not aesthetic. Prose that reads like a compliance document — "according to" every third sentence, "appears to have" everywhere — gets its hedges stripped wholesale rather than surgically. The reviewer loses the true hedges along with the defensive ones. An over-hedged draft gets the whole apparatus switched off.
+
+Diagnostic sequence when a passage feels hedge-saturated:
+
+1. Count sentences at L3+. Over one in four? Go to 2. Under? The problem is prose rhythm, not attribution — rewrite the L3s as L1s.
+2. Which findings under this passage are class C, D, or E? Those are what forced the L3s.
+3. Can any of them be re-classed to A or B by obtaining the underlying artefact? Do that.
+4. If not, the passage is asserting more than the corpus supports. Cut the passage's ambition, not its attributions.
+
+## Bad and good, four domains
+
+**Supply chain — class D wearing L0 grammar**
+
+Bad: "Congestion forced carriers to reroute through Vancouver in early 2021."
+
+Good: "Carrier filings put Vancouver call volume up 34% between January and April 2021 [F-112, class A]. Two operators cited congestion in their rerouting notices [F-118, class A]; the record does not establish why the others moved."
+
+The bad version asserts a mechanism from a trade-press summary, at L0, with an L1-grade causal verb. Three errors in nine words.
+
+**ML writeup — class E wearing the grammar of a finding**
+
+Bad: "The auxiliary loss is what makes the architecture work at scale."
+
+Good: "Accuracy rose 3.1 points in the run that added the auxiliary loss [F-44]. Three other changes shipped in the same commit [F-45..47]; no ablation isolates the loss. The most plausible reading is that the loss contributes, but the run does not establish it."
+
+**Market history — silent resolution of a contested figure**
+
+Bad: "Industry shipments fell 22% in the third quarter."
+
+Good: "The association's members reported shipments down 22%; the customs series for the same period shows a 9% decline [F-401, F-403]. The association changed its reporting definition that quarter to exclude re-exports [F-402]."
+
+The bad version picked the more dramatic of two conflicting figures and hid the instrument change that probably produced the gap.
+
+**Biography — inference in the grammar of observation**
+
+Bad: "She knew, then, that the appointment would be refused."
+
+Good: "She wrote to her sister on 12 June that she expected the refusal [F-115]." Or, where only the sequence is documented: "The record does not say what she expected. She had already drafted the resignation letter."
+
+## Class F and the open-question conversion
+
+No finding may sit at class F when the ledger is handed off. Class F findings have exactly two dispositions:
+
+1. **Delete.** The statement leaves the ledger and goes nowhere.
+2. **Convert to an open research question.** Write the question in a form someone could actually answer: "Is there any contemporaneous statement by X, between 4 March and 30 April, about the threshold decision?" Not "find out more about the threshold."
+
+There is no third disposition. "Draft it and flag it for review" is not a disposition — flagged drafted text survives review at high rates, because it reads well and the reviewer is checking rather than rewriting.
+
+A ledger that reaches handoff with zero open questions is a red flag rather than a success. Real material always has holes.

--- a/skills/narrative-evidence-ledger/resources/frame-lock.md
+++ b/skills/narrative-evidence-ledger/resources/frame-lock.md
@@ -1,0 +1,240 @@
+# Frame Lock
+
+Every fact in a piece can be true and the piece still be false. In quantitative and semi-quantitative material, falsity lives in the choices — unit, denominator, window, boundary, aggregation level, which measure is foregrounded — not in the facts. Fact-checking cannot detect this. Only a written, frozen frame can.
+
+## Table of Contents
+- [The four locks](#the-four-locks)
+- [The rejected-alternative record](#the-rejected-alternative-record)
+- [Worked frame locks, three domains](#worked-frame-locks-three-domains)
+- [Rate versus count](#rate-versus-count)
+- [Denominator language](#denominator-language)
+- [Denominator drift](#denominator-drift)
+- [The instrument check](#the-instrument-check)
+- [The three vetoes](#the-three-vetoes)
+- [The seven metamorphic transforms](#the-seven-metamorphic-transforms)
+- [The starting-hypothesis diff](#the-starting-hypothesis-diff)
+- [When the protagonist is a person](#when-the-protagonist-is-a-person)
+
+## The four locks
+
+Written before any material is examined. Four lines.
+
+| Lock | The question | Fails when |
+|------|-------------|-----------|
+| UNIT | What is one row? One case, one person, one incident, one shipment, one training run, one episode? | The unit changes mid-analysis: incidents become incident-days become affected users |
+| DENOMINATOR | Per what? Per person, per dollar, per attempt, per unit of exposure, per deploy? | Absolute counts are compared across entities of different size |
+| WINDOW | From when to when, and what justifies each edge? | The start date is the one that makes the trend work |
+| BOUNDARY | Which entities are in the population, and who drew that line — you, the source, or a regulator? | The boundary is inherited from a source without being noticed |
+
+Lock all four in writing. **Any later change re-opens the ledger.** It is not a chart adjustment. A changed denominator can invalidate findings, claims, and beats simultaneously, because it changes what the numbers mean rather than what they are.
+
+## The rejected-alternative record
+
+For each of the four, name one alternative you rejected and give a one-sentence reason. This is the anti-cherry-picking record, and it is the artefact you produce when someone asks why the analysis starts in 2019.
+
+Format:
+
+```
+UNIT: one confirmed incident, as classified by the on-call at declare time.
+  Rejected: one customer-affecting minute. Reason: minute-level data begins
+  only in 2023 and would truncate the window by four years.
+
+DENOMINATOR: per 1,000 production deploys.
+  Rejected: per engineer-month. Reason: headcount data is quarterly and the
+  team boundary moved twice, so the denominator would itself be unstable.
+
+WINDOW: 2019-01-01 to 2025-12-31.
+  Rejected: starting 2017. Reason: the incident classification scheme changed
+  in December 2018 and no re-baselined series exists before it.
+
+BOUNDARY: services owned by the platform group per the 2025 service registry.
+  Rejected: all services in the monorepo. Reason: that set includes 40
+  experiment services with no on-call rotation, which have no incidents by
+  construction and would deflate every rate.
+```
+
+Note what the last entry does. It names a boundary choice that would have moved the headline number in a specific direction, and says why it was rejected on grounds unrelated to the direction. That is the difference between a frame lock and a rationalisation.
+
+## Worked frame locks, three domains
+
+### Public health
+
+```
+UNIT: one laboratory-confirmed case, by specimen collection date.
+  Rejected: one person-episode. Reason: reinfections cannot be linked in this
+  dataset, so person-episodes would be undercounted at an unknown rate.
+
+DENOMINATOR: per 100,000 residents, from the mid-year population estimate.
+  Rejected: per 100,000 tests. Reason: test volume tracks the outbreak itself,
+  so a per-test rate would suppress exactly the signal under study. Both series
+  are shown; the per-test view is a supplementary beat, not the headline.
+
+WINDOW: 2021-W01 to 2024-W52.
+  Rejected: starting 2020-W10. Reason: case ascertainment before 2021 was
+  limited by test availability and is not comparable.
+
+BOUNDARY: residents of the reporting region, by residence not by treatment
+site.
+  Rejected: patients treated in the region. Reason: two tertiary hospitals
+  draw from outside the region and would inflate counts against a resident
+  denominator.
+```
+
+### Manufacturing market history
+
+```
+UNIT: one 300mm wafer start.
+  Rejected: one die. Reason: die counts depend on reticle size, which changed
+  twice in the window, so a die series would mix a demand signal with a
+  geometry change.
+
+DENOMINATOR: per installed tool, for utilisation; absolute starts for the
+capacity beat.
+  Rejected: per fab. Reason: fabs differ in size by more than 10x, so a
+  per-fab rate is dominated by which fabs are in the sample.
+
+WINDOW: 1998-Q1 to 2008-Q4.
+  Rejected: ending 2010. Reason: the 2009 accounting restatement at two of the
+  five reporters makes 2009-2010 non-comparable without a re-baselined series.
+
+BOUNDARY: the five merchant foundries filing quarterly in every year of the
+window.
+  Rejected: all foundries. Reason: entrants and exits would make the panel
+  unbalanced and the "industry" series would move with sample composition.
+```
+
+### ML evaluation writeup
+
+```
+UNIT: one evaluation run at a fixed seed and a fixed prompt template.
+  Rejected: one benchmark item. Reason: items are not independent within a
+  task family and per-item claims would overstate precision.
+
+DENOMINATOR: per 1,000 evaluation items attempted, not per item scored.
+  Rejected: per item scored. Reason: refusals and timeouts drop out of the
+  scored set, which would silently reward a model that refuses more.
+
+WINDOW: model releases from 2024-06 to 2026-03.
+  Rejected: including pre-2024 checkpoints. Reason: the harness changed its
+  tokenisation of the prompt template in May 2024; earlier scores are not
+  comparable.
+
+BOUNDARY: models with published weights or a stable API version string.
+  Rejected: all models evaluated. Reason: three endpoints changed behind the
+  same version string during the window, so their series measure the endpoint,
+  not the model.
+```
+
+## Rate versus count
+
+If entities differ in size by more than roughly 2x, rates are mandatory for comparison and raw counts are a supplementary beat, never the headline. (The 2x figure is a derived default.)
+
+If the **denominator itself is changing** — a shrinking population, a growing user base, a fleet that doubled — show both series. A ratio alone conceals which term moved. A falling incident rate during a period when deploys tripled is a different finding from a falling incident rate at flat deploy volume, and the ratio cannot tell them apart.
+
+**Small-denominator check.** Plot the measure's variance against denominator size. If the extremes all sit in the smallest decile of denominators, the extremes are sampling noise wearing a story's clothes.
+
+This matters because any ranking built on surprise — the rarest configuration, the biggest outlier, the largest percentage change — is maximised by small denominators, coding errors, partial reporting periods, and newly created categories. An agent that picks its protagonist by novelty alone will reliably crown noise, and the resulting narrative will be structurally sound and built on a county of 400 people, a month of incomplete filings, or a benchmark with 12 examples.
+
+## Denominator language
+
+Get the words right. This is the most checkable error in quantitative writing.
+
+- **"Per capita" means per person.** A figure of 2.3 per 1,000 residents is not a per-capita figure. Say "per 1,000 residents".
+- **Percent versus percentage point.** A move from 4% to 6% is a 2 percentage-point rise and a 50% rise. Never conflate them.
+- **Relative versus absolute change.** "Doubled" and "rose by 3" are different claims and the second requires a base.
+- **Precision ceiling.** No figure in prose may exceed the precision of its source. A source saying "roughly a third" can never become "33.4%".
+- **Round for prose, compute from source.** The ledger holds the unrounded value. Derived figures reference the source finding ID, never a rounded prose sentence. Rounding drift compounds: round for readability, use the rounded figure as input to the next ratio, and by the third derivation the number is outside the source's range while still wearing "about".
+- **Hedge words are precision claims.** "About" implies roughly the rounding unit. "Nearly" and "more than" assert a direction and must be true. "Roughly" signals genuine estimate uncertainty. None of them are decoration.
+- **Never manufacture a number from a qualitative source.** "Several" does not become "six". "Many" does not become "dozens".
+
+## Denominator drift
+
+The characteristic sequence-level lie. The piece opens on counts. It pivots to per-capita for the one comparison where per-capita favours the thesis. It returns to counts for the conclusion. Every individual exhibit is defensible. The sequence is false, and it survives fact-checking because no single number is wrong.
+
+**Detection**: build a table of every figure in the piece against the denominator it uses. Any change of denominator between adjacent claims must be either (a) narrated in the text at the point of change, or (b) reverted.
+
+Bad, from an operations writeup:
+
+> Incidents rose from 41 to 58 last year. Our incident rate per deploy remains the lowest in the division. The 58 incidents represent our worst year on record.
+
+Three sentences, two denominators, one unstated switch, and the switch happens exactly where it helps.
+
+Good:
+
+> Incidents rose from 41 to 58 last year, against a deploy volume that rose from 3,900 to 7,100. The rate per 1,000 deploys therefore fell from 10.5 to 8.2. Both the raw count and the rate matter here: the count is what on-call carried, and the rate is what the process improved.
+
+## The instrument check
+
+**Did the world change, or did the measurement change?**
+
+This is the most common catastrophic failure in data narrative. A break in the data-generating process gets narrated as a break in the world. The resulting story is internally consistent, vividly told, well-sourced, and entirely spurious — and it is usually *more* confident and better structured than a correct one, because measurement artifacts produce sharper discontinuities than real transitions do.
+
+Run on every discontinuity before it becomes a finding. Enumerate:
+
+| Artifact type | Examples |
+|--------------|----------|
+| Definitional revision | Reclassification; a metric's formula changed; "active user" redefined; a diagnostic code split |
+| Coverage or sampling change | New reporters added; a survey redesigned; a sensor fleet expanded; a region joined the panel |
+| Methodology restatement | Accounting restatement; seasonal adjustment introduced; a benchmark's scoring changed |
+| Reporting-lag artifact | The most recent periods are incomplete and look like a decline |
+| Entity or boundary change | Merger, demerger, redistricting, team reorganisation, service ownership transfer |
+| Collection-platform change | Reporting moved from email to a form; a logging library upgraded; an API version changed what got counted |
+
+**Dispositions:**
+
+1. The discontinuity coincides with a known instrument change and you can re-baseline on a consistent definition → keep the finding, cite the re-baselined series.
+2. It coincides and you cannot re-baseline → the finding goes to DEAD with `killed_by: instrument check`, verdict DID-NOT-SUPPORT. **The instrument change is now the finding.** Narrate it.
+3. No instrument change identified → keep, and record which artifact types you checked. "Checked and none found" is a real result and it strengthens the finding.
+
+**Change-point forking.** Scanning many series with many methods until a break lands where the thesis wants it is a garden of forking paths. Control it by writing down which series and which methods you will scan, before scanning. Record rejected candidates and why. That list is the defence against a cherry-picked start date.
+
+**Time-to-detect.** For surviving discontinuities, compute when a contemporary observer, with only the data then available, could have seen it. The gap between the event and its detectability is usually the most interesting thing in the material, and it is the honest source of dramatic irony.
+
+## The three vetoes
+
+Applied in order to any measure being considered as the piece's central quantity.
+
+1. **DENOMINATOR VETO.** Can you defend the denominator in one sentence to a hostile reader? No → kill.
+2. **THIN-SUPPORT VETO.** Does the top-ranked finding for this measure rest on fewer than about 5 underlying records, or on a single reporting period? Yes → kill. (The 5-record figure is a derived default.)
+3. **IRRELEVANCE VETO.** Does the audience hold any prior belief about this measure? No prior → nothing can be surprising → kill, or spend a beat establishing the prior first.
+
+Every veto kill goes to DEAD with the veto named. That column is the record of what the story is not.
+
+## The seven metamorphic transforms
+
+Applied per claim, after the ledger is built. Any transform that flips the claim kills it, or promotes the sensitivity itself to being the claim.
+
+1. **Shuffle row order.** The conclusion must be invariant. Catches draw-order and order-dependent aggregation.
+2. **Swap SUM ↔ MEAN and COUNT ↔ RATE.** If the claim flips, state which is correct and why, in the text. Catches aggregation masking.
+3. **Change bin count and bin origin by ±50%.** Distribution claims must survive. Catches binning artifacts.
+4. **Extend and truncate the window by one period at each end.** Trend and change-point claims must survive. Catches start-date cherry-picking.
+5. **Re-aggregate spatial or categorical units at a different boundary.** Catches boundary choice manufacturing the pattern.
+6. **Drop the top 1% of records.** Extreme, outlier, and mean-based claims must be re-checked. Catches thin-support extremes.
+7. **Re-render at two aspect ratios.** Slope and correlation claims must survive. Catches visual slope distortion.
+
+**Before all seven, the forgotten-population check**: who is not in this dataset who should be, and would including them change the sign?
+
+**Also run the re-aggregation test for sign flips.** Re-run the headline at two other aggregation levels and two other filter sets. If the sign flips at any level, that is Simpson's paradox and the disaggregated view is the story, not a footnote.
+
+Record every failure in DEAD with the transform that killed it.
+
+**Metamorphic testing is a floor, never a certificate.** A claim can pass all seven while resting on the wrong population, the wrong denominator, or a definitional break in the source, because all three are upstream of anything the transforms touch. Reporting the transforms as a certificate is worse than not running them.
+
+## The starting-hypothesis diff
+
+Write the starting hypothesis down, verbatim and dated, before examining material. At handoff, diff the current reading against it and write what changed.
+
+The ordering matters and is not stylistic. Suppose the thesis exists before the finding inventory. Then every downstream choice bends toward that sentence: the denominator, the window, the aggregation, which discontinuity gets an instrument check and which gets waved through. The agent doing the bending has no way to notice it. Inventory first, spine second, thesis third, then diff.
+
+If nothing changed, either you were unusually right or you did not look. Say which you believe.
+
+## When the protagonist is a person
+
+The frame lock still applies, and it is easier to skip because personal narrative does not feel quantitative.
+
+- **UNIT**: what is one episode in this life? A job, a year, a project, a relationship, a publication? Biographies that switch silently between these produce careers that look denser or sparser than they were.
+- **DENOMINATOR**: compared with what? Peers of the same cohort, the same institution, the same starting resources? A career described without a comparison class is a career described as unique by construction.
+- **WINDOW**: what justifies where the account starts and stops? Starting at the first success is the biographical equivalent of a cherry-picked start date.
+- **BOUNDARY**: whose accounts are in the population of sources? An archive assembled by the subject's family is a boundary someone else drew.
+
+**Individualization warning.** Framing a distributional finding through one quantified person is a rhetorical technique with real framing power, not a neutral choice. It raises engagement precisely because it invites the reader to reason from a single case. When the real protagonist is a system — a market, a protocol, an institution, a supply chain — an individualized opening will be the most-remembered part of the piece and the least representative. If you use it, the very next beat must restore the distribution, and the text must say explicitly what the individual is and is not typical of.

--- a/skills/narrative-evidence-ledger/resources/ledger-schema.md
+++ b/skills/narrative-evidence-ledger/resources/ledger-schema.md
@@ -1,0 +1,216 @@
+# Ledger Schema
+
+The ledger is four columns, not three. FINDING, CLAIM, BEAT are the promotion path. DEAD is the parallel record of everything that was killed. All four ship with the deliverable.
+
+## Table of Contents
+- [Why four columns](#why-four-columns)
+- [FINDING schema](#finding-schema)
+- [CLAIM schema](#claim-schema)
+- [BEAT schema](#beat-schema)
+- [DEAD schema](#dead-schema)
+- [Promotion rules](#promotion-rules)
+- [Referential integrity](#referential-integrity)
+- [The ratio check](#the-ratio-check)
+- [The omission set](#the-omission-set)
+- [Worked ledger extracts](#worked-ledger-extracts)
+- [Handoff artefact](#handoff-artefact)
+
+## Why four columns
+
+A finding is checkable against a source. A claim is an interpretive commitment that can be wrong even when the finding is right. A beat is a claim that changes the reader's model of the world. Collapsing these is how a narrative acquires the authority of data it does not have.
+
+The two failure modes are symmetrical:
+
+- **Beat inflation**: under pressure to produce narrative, findings get promoted straight to beats and the claim column is skipped. The output reads as a sequence of dramatic reveals with no argument between them, and because the claim column was skipped, no falsification condition was ever written, so nothing in the piece can be checked.
+- **Claim hoarding**: every finding acquires a hedge-laden claim, nothing is ever promoted to a beat, and the result is a competent report nobody finishes. Unread accurate work informs nobody, which is its own accuracy failure.
+
+## FINDING schema
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `id` | yes | Stable, e.g. `F-112`. Never reused after a kill. |
+| `statement` | yes | One verifiable assertion. No addressee, no interpretation, no so-what. |
+| `evidence_class` | yes | A-F. See [evidence-classes.md](evidence-classes.md). |
+| `pointer` | yes | Granular enough to re-find without the draft in hand. |
+| `contested` | yes | If two sources conflict, keep BOTH values. Do not resolve by picking the better-sounding one. |
+| `source_interest` | yes | Who benefits from this account being believed? "None identified" is an answer; blank is not. |
+| `source_vintage` | yes | `contemporaneous-primary` / `contemporaneous-secondary` / `retrospective-primary` / `retrospective-secondary`. |
+| `support_n` | when quantitative | How many underlying records, respondents, runs, or incidents. Thin support is a veto trigger. |
+| `derived` | when quantitative | Observed vs computed. A fitted slope and a raw reading are not the same object. |
+| `precision` | when quantitative or dated | The precision the source actually carries. "In the spring" is not "on a Tuesday in April". |
+| `anachronism_flag` | when applicable | The statement uses a category, metric, or moral frame that did not exist at the time described. |
+
+`source_vintage` is doing more work than it looks. Secondary retrospective material includes books, post-hoc analyses, and incident write-ups authored after the outcome. In all of these, the halo and the teleology were applied upstream, before you arrived. A ledger built on them will re-derive those distortions faithfully while passing every check. So a `retrospective-secondary` finding can never support an L1 MECHANISM causal grade.
+
+`source_interest` matters because "contemporaneous" is not a clean standard either. Contemporaneous sources are produced by interested parties, are themselves selected by survival, and in business and technology domains are dominated by promotional material already contaminated by an in-progress halo. Date annotation without interest annotation moves the bias one step upstream instead of removing it.
+
+## CLAIM schema
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `id` | yes | e.g. `C-14`. |
+| `statement` | yes | The interpretive commitment. |
+| `findings` | yes | >= 1 finding ID. |
+| `leap` | yes | The interpretive step being taken, stated as a step. "From: three fabs reported X. To: the cohort as a whole did X." |
+| `population` | yes | Named precisely. Not "companies" — "the eleven firms in the 2019 cohort that filed in both years". |
+| `falsifier` | yes | What evidence would make this false. A claim with no falsifier is not a claim; send it back to FINDING or delete it. |
+| `causal_grade` | when the claim asserts a link | L1-L5. See [causal-triage.md](causal-triage.md). |
+| `agency_alternative` | for outcome claims | The strongest reading that attributes the outcome to skill, intent, or decision, and why it was or was not adopted. |
+
+The `agency_alternative` field exists because a ledger discipline built on the red-team literature will systematically over-attribute outcomes to luck, structure, and path dependence — the critical literature is asymmetrically stocked with attacks on agency-based explanation. Anti-narrative bias is a real bias. Requiring the strongest agency reading in writing is the correction.
+
+## BEAT schema
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `id` | yes | e.g. `B-3`. |
+| `claims` | yes | >= 1 claim ID. |
+| `prior_overturned` | yes | The belief this beat changes, phrased as a sentence someone actually held. "Readers assume outages cluster around deploys." |
+| `relation_to_previous` | yes | One of: similarity, elaboration (shrink the scope), generalization (enlarge the scope), contrast, temporal, cause-effect. |
+| `mechanism_argument` | when relation is cause-effect | A separate paragraph resting on something other than the data: an institutional fact, a physical constraint, a documented decision. No mechanism, no cause-effect label. |
+
+**Cause-effect is rare in practice and over-produced by models.** In a labelled corpus of 4,186 story pieces from 230 professional data videos, the six relations occurred at roughly: elaboration 34%, similarity 32%, generalization 12%, contrast 10%, temporal 8%, cause-effect 5%. Cause-effect is the rarest and the most attractive, because causal prose reads as the most satisfying and the most confident. Cap it near the observed baseline and audit the mix. The failure is invisible to fact-checking: every individual finding is true and the sequence is false.
+
+**Recontextualisation test**: for each beat, write one sentence stating what the reader believed after the previous beat that this one changes. If that sentence is empty, this is supporting evidence attached to an existing beat, not a beat of its own.
+
+## DEAD schema
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `id` | yes | The original finding or claim ID, preserved. |
+| `killed_by` | yes | The specific veto, check, or transform. "Thin-support veto, support_n = 3" not "weak". |
+| `date` | yes | When. Order matters when reconstructing why the piece looks as it does. |
+| `verdict` | yes | `DID-NOT-SUPPORT` or `CONTRADICTED`. |
+| `original_pointer` | yes | Preserved so the kill is itself re-derivable. |
+
+**The two verdicts are not interchangeable.** DID-NOT-SUPPORT means the evidence was insufficient: thin support, indefensible denominator, an unresolved instrument change, a transform that flipped the sign. CONTRADICTED means a source establishes the opposite. Conflating them lets a contradicted claim re-enter a later pass as merely unproven, which is how killed material comes back to life.
+
+The DEAD column is also the only real defence against subtraction. Refusal training makes a model good at not adding and does nothing about not omitting. A perfectly constrained agent will produce an entirely sourced, entirely false piece by cutting the disconfirming quarter, the failed pilot, the dissenting source — each cut individually defensible on length or flow. The DEAD column plus the omission set, reviewed as a SET rather than per-item, is what catches the pattern.
+
+## Promotion rules
+
+1. Nothing moves right without an explicit promotion step and a written justification.
+2. Promotion is one-way per pass. Nothing may be promoted and then demoted inside a single revision, or the ledger stops tracking anything. Demotion happens in the next pass, logged, with a reason.
+3. A claim with no falsifier goes back to FINDING or is deleted.
+4. A beat that overturns nothing becomes supporting evidence under an existing beat.
+5. A kill is not a demotion. Killed items go to DEAD, not backward along the promotion path.
+
+## Referential integrity
+
+- Every beat cites >= 1 claim.
+- Every claim cites >= 1 finding.
+- Every finding cites an external data location: table and row range, document and page, commit hash, transcript timestamp, instrument log line, URL plus retrieval date.
+- No pointer resolves into this pipeline's own outputs. See the circular-citation check in the main skill.
+
+Check this mechanically by walking the graph. A dangling reference is a defect regardless of how good the sentence reads.
+
+## The ratio check
+
+| Observation | Diagnosis |
+|-------------|-----------|
+| Beats > claims | Narrating without arguing |
+| Findings vastly exceed claims | Reporting without interpreting |
+| Claims exceed findings | Asserting |
+| Zero DEAD entries | The vetoes were not run, or were run and ignored |
+| Zero omissions | The corpus was not larger than the piece, which for real material is implausible |
+
+## The omission set
+
+After the ledger is built, list every corpus item that appears nowhere in it. For each, write one sentence saying why. Then apply the rule: any item that would weaken the emerging spine and lacks a written reason is a cherry-pick and must be reinstated.
+
+This is the expensive check and it is the one that matters. Every per-finding check in this skill can pass while the assembled work misrepresents the drift and proportion of events through selection alone. A ledger that is clean per-item and silent about what it left out is more dangerous than an unchecked draft, because it carries citations and reads as audited.
+
+## Worked ledger extracts
+
+### Post-mortem domain
+
+```
+F-208  statement: The first alert fired at 02:14:07Z on 2024-03-11.
+       class: A  pointer: app-server.log line 88214, retrieved 2024-03-14
+       contested: no  source_interest: none identified
+       source_vintage: contemporaneous-primary  precision: second
+
+F-209  statement: The on-call engineer acknowledged the page at 02:31Z.
+       class: A  pointer: PagerDuty incident 44192, ack event
+       source_vintage: contemporaneous-primary
+
+F-210  statement: The retro document states the delay was caused by a
+       misconfigured escalation policy.
+       class: D  pointer: retro-2024-03-11.md, "Root cause", authored 2024-03-19
+       source_vintage: retrospective-secondary
+       NOTE: cannot support an L1 grade for the escalation link.
+
+C-31   statement: Acknowledgement latency in this incident exceeded the
+       team's own 5-minute target.
+       findings: F-208, F-209
+       leap: from two timestamps to a comparison against a stated target
+       population: this incident only; no claim about the incident population
+       falsifier: a target document dated before 2024-03-11 specifying a
+       different threshold
+       causal_grade: n/a (no link asserted)
+
+DEAD   C-33  statement: Escalation misconfiguration caused the delay.
+       killed_by: L1 downgrade — only source is F-210, retrospective-secondary
+       verdict: DID-NOT-SUPPORT
+       note: re-enters as an L3 SEQUENCE claim, or as an L5 marked inference.
+```
+
+### Market-history domain
+
+```
+F-401  statement: Reported industry shipments fell 22% between Q2 and Q3 1997.
+       class: A  pointer: association annual report 1998, table 4, p.31
+       support_n: 14 reporting members  derived: observed
+       source_interest: the association's members set the reporting standard
+       source_vintage: contemporaneous-primary
+
+F-402  statement: The association changed its member reporting definition in
+       Q3 1997 to exclude re-exports.
+       class: A  pointer: association annual report 1998, methodology note, p.62
+       source_vintage: contemporaneous-primary
+
+DEAD   C-77  statement: Industry demand collapsed in Q3 1997.
+       killed_by: instrument check — F-402 establishes a definitional revision
+       coincident with the discontinuity; no re-baselined series available
+       verdict: DID-NOT-SUPPORT
+       note: the definitional change is itself the finding. Narrate the
+       instrument change, or obtain a consistent series.
+```
+
+### Biography domain
+
+```
+F-115  statement: She wrote in a letter dated 12 June 1953 that she expected
+       the appointment to be refused.
+       class: A  pointer: papers, box 4, folder 9, letter to her sister
+       source_vintage: contemporaneous-primary
+
+C-08   statement: She anticipated the refusal before it arrived.
+       findings: F-115
+       leap: from one written statement to a mental state at that date
+       population: this individual, June 1953
+       falsifier: a contemporaneous document showing she made commitments
+       inconsistent with expecting refusal
+       causal_grade: n/a
+
+DEAD   C-09  statement: The refusal was the turning point of her career.
+       killed_by: retrospective-only — the earliest source treating this event
+       as consequential postdates the outcome by 22 years
+       verdict: DID-NOT-SUPPORT
+       note: may return as an L5 marked inference, never in a climax slot.
+```
+
+## Handoff artefact
+
+The artefact both macro and micro narrative agents consume contains, in this order:
+
+1. **Frame lock**: unit, denominator, window, boundary; one rejected alternative and reason for each.
+2. **Starting hypothesis**, dated, plus the diff against the current reading.
+3. **Ledger**: FINDING, CLAIM, BEAT columns with referential integrity satisfied.
+4. **Causal grade map**: every link, its grade, its permitted verb set.
+5. **DEAD column**, typed.
+6. **Omission set** with a reason per item.
+7. **Integrity check results**, including the circular-citation verdict.
+8. **The no-verification statement**, verbatim: "This ledger records provenance. No claim in it has been verified. Human verification status: none."
+
+If a human did verify a subset, name the subset and the person. Never state verification generically. The correct verb for what this skill does is "sourced". Saying "verified" induces misplaced trust in a reviewer, and unchecked output is safer than output that falsely advertises checking.

--- a/skills/narrative-fallacy-guard/SKILL.md
+++ b/skills/narrative-fallacy-guard/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: narrative-fallacy-guard
+description: Stops a true set of facts from being assembled into a false story. Runs the retrospective slot audit, the outcome-blind rewrite (flip test, separation test), the inevitability audit with its overshoot check, the survivorship graveyard pass, the counterfactual admissibility gate, and the expensive proportion and omission audits. Every check labels and discloses; none deletes. Use when drafting or reviewing history, post-mortems, biography, market or protocol narratives, research writeups, or any account written after the outcome was known, or when user mentions hindsight bias, narrative fallacy, survivorship bias, inevitability, halo effect, outcome bias, just-so story, teleology, or Whig history.
+---
+
+# Narrative Fallacy Guard
+
+## Table of Contents
+- [Core Principles](#core-principles)
+- [Workflow](#workflow)
+- [What Each Failed Check Produces](#what-each-failed-check-produces)
+- [Banned Constructions and Their Licences](#banned-constructions-and-their-licences)
+- [Guardrails](#guardrails)
+- [Quick Reference](#quick-reference)
+
+**Related skills:** Use `writing-structure-planner` for choosing the architecture before this guard tests it, `narrative-opposition-web` for warranting an antagonist. Use `narrative-evidence-ledger` for the causal ladder and the omission set this skill leans on, `causal-inference-root-cause` for building the causal case this skill audits. Use `narrative-fidelity-audit` for the proportion, representativeness, and anachronism questions asked at draft time, `cognitive-fallacies-guard` for chart-level and visual misleads.
+
+## Core Principles
+
+1. **Label, never delete**: every check terminates in a disclosure sentence, a rewrite, or a tag. None of them terminates in a cut claim. A guard used as a delete rule deletes every interesting explanation and ships a chronicle, and chronicles inform nobody.
+2. **The ending is the contaminant**: any structural slot, evaluative adjective, or causal verb selected after the outcome was known is suspect by construction, not by evidence of error.
+3. **The cheap checks are the dangerous ones**: per-sentence passes can all pass while the piece lies through proportion and omission alone. Work that carries citations and reads as audited is more dangerous than unchecked work.
+4. **Disclosure lives in the body**: within two sentences of the claim it qualifies, in the same typographic register. Anything in an endnote, appendix, or methods block is functionally undisclosed.
+5. **Anti-narrative bias is also a bias**: the red-team literature is asymmetrically stocked with attacks on agency. State, for each major outcome, the strongest agency reading you considered and why you did or did not adopt it.
+6. **A date is not a clean standard**: contemporaneous sources are interested parties, selected by survival, and often already carrying an in-progress halo. Annotate date, interest, and primary-vs-secondary together.
+7. **A binding hedge budget is an architecture signal**: when the disclosures crowd the subject out, change the shape of the piece. Do not spend more budget.
+
+## Workflow
+
+Copy this checklist and track your progress:
+
+```
+Narrative Fallacy Guard Progress:
+- [ ] Step 1: Build the source ledger (date + interest + primary/secondary)
+- [ ] Step 2: Audit the structural slots against the outcome date
+- [ ] Step 3: Run the per-sentence passes (outcome-blind rewrite, inevitability audit, overshoot check)
+- [ ] Step 4: Run the expensive passes (graveyard, counterfactual gate, proportion, omission)
+- [ ] Step 5: State the agency reading, place the disclosures, check the budget, ship the log
+```
+
+**Step 1: Build the source ledger**
+
+Step 1.1: For every source, record three fields, not one.
+- DATE: the published date, plus the date of the events it describes.
+- INTEREST: who paid, who benefits, what the author was selling or defending.
+- CLASS: primary and contemporaneous, or secondary and retrospective.
+
+Step 1.2: Apply the hard rule, using the causal grades as defined in `narrative-evidence-ledger`. No causal claim may be tagged L1 MECHANISM on the strength of a purely secondary retrospective account. A later book asserting that a memo caused a decision is evidence about the book. Downgrade to L3 SEQUENCE or L5 CONJECTURE until the memo itself is in hand.
+
+Step 1.3: Write down the SELECTION RULE that produced the corpus, literally: "this corpus consists of firms that survived / papers that were published / systems that still have logs / people who agreed to be interviewed." Carry this sentence into Step 4.
+
+See [resources/audit-procedures.md](resources/audit-procedures.md) for the ledger fields and the primary-vs-secondary downgrade table.
+
+**Step 2: Audit the structural slots**
+
+Step 2.1: List every structural slot the piece uses (inciting incident, each turning point, revelation, climax, resolution) and the event you have placed in each.
+
+Step 2.2: For each slot record four dates: the event date, the date of the EARLIEST source that treats the event as significant, the outcome date, and the date of the source you actually cited. If the earliest-significance date falls after the outcome date, tag the slot RETROSPECTIVE-ONLY.
+
+Step 2.3: For every RETROSPECTIVE-ONLY slot, run the substitution test: name two other events in the same window that a narrator with a different ending would have chosen instead. Cannot name two? You have not searched the corpus; go back.
+
+Step 2.4: Apply the rule. A RETROSPECTIVE-ONLY slot may not carry unhedged causal language. Either downgrade the verb or add one body sentence stating that the significance is visible only in hindsight. Do not demote the slot merely for being retrospective: slow demographic shifts, accumulating technical debt, and gradual definitional drift are real causes that nobody present could see.
+
+Step 2.5: If the subject is quantitative, run the INSTRUMENT CHECK on every candidate inciting incident before accepting it. A definitional revision, a coverage change, a re-classification, a merger that changed the reporting entity, or a logging change produces a sharper, better-timed discontinuity than any real transition.
+
+**Step 3: Run the per-sentence passes**
+
+Step 3.1: OUTCOME-BLIND REWRITE. Extract every evaluative adjective and dispositional noun applied to any actor: visionary, reckless, disciplined, prescient, complacent, bloated, naive. Require a dated source predating the outcome for each, attributed in line with its date; otherwise replace the adjective with the action taken, the information set available at that date, and the alternatives visibly on the table. Then run the FLIP TEST and the SEPARATION TEST. Apply the identical pass to system protagonists: "an efficient market", "a rational consolidation", "an inevitable standardisation" are outcome-derived characterisations of a prior state.
+
+Step 3.2: INEVITABILITY AUDIT. Extract every causal sentence. For each, cite what the actors at the time expected, and name one live alternative someone in the material was actually pursuing. Enforce the banned-without-licence list. Insert at least one forecast-vs-outcome beat: a documented prediction from inside the material that turned out wrong, with the reasoning that made it reasonable at the time.
+
+Step 3.3: OVERSHOOT CHECK. Does the draft contain at least one confidently asserted "X caused Y"? If not, the brake has become hedge fog, which is abdication rather than honesty. The target is a small number of confident causal claims each carrying its counterfactual, not a large number of hedged ones.
+
+Step 3.4: ANACHRONISM FLAG. Where a category, a metric, or a moral frame used in the text did not exist at the time described, say so in the body. Flag the anachronism; do not adjudicate whether present-day categories may be applied. That larger dispute is contested and is not this skill's business.
+
+See [resources/audit-procedures.md](resources/audit-procedures.md) for worked bad-and-good rewrites of each pass across five domains.
+
+**Step 4: Run the expensive passes**
+
+These are the ones that catch the failure the cheap passes cannot see. Under schedule pressure they are the ones that get dropped. Do not drop them: see the warning in [Guardrails](#guardrails).
+
+Step 4.1: GRAVEYARD PASS. For every success attribution, search for at least two entities that took the same action and did not get the same outcome. Three results are legal, and each one appears in the text. Counterexamples found: weaken the claim. Counterexamples searched for and not found: state the search and state the finding. Population is n=1 or unobservable: write "the base rate for this action is unknown" in the body. That third result is first-class and non-embarrassing. Manufacturing a weak analogy to avoid it is a fresh distortion dressed as a correction.
+
+Step 4.2: COUNTERFACTUAL GATE. Any road-not-taken must pass all six admissibility tests (clarity, cotenability, minimal rewrite, historical consistency, theoretical consistency, statistical consistency) and must render as a bounded element: a bracketed passage, a sidebar, a differently-styled paragraph. Never as a dramatised scene. A dramatised counterfactual acquires the vividness of the documented events and readers will not retain the distinction.
+
+Step 4.3: PROPORTION AUDIT. Tabulate words spent against evidence tier and against causal weight. Flag both asymmetries. First: the vivid anecdote that is top quintile by words and bottom quintile by evidence. Second: the well-evidenced driver that is top quintile by causal weight and bottom quintile by words. Each flag needs a written justification, not an automatic rebalance. Fill the causal-weight column BEFORE the arc is chosen. Filled after, it inherits the halo it is meant to catch.
+
+Step 4.4: OMISSION CHECK. List every corpus item appearing nowhere in the draft and state why for each. Any item that would weaken the spine and was omitted without a stated reason is a cherry-pick and must be reinstated.
+
+See [resources/audit-procedures.md](resources/audit-procedures.md) for the six-test counterfactual gate with admitted and rejected examples, and the proportion table format.
+
+**Step 5: State the agency reading, place the disclosures, ship the log**
+
+Step 5.1: Write the AGENCY READING for each major outcome: the strongest reading in which skill, intent, and decision explain the result, and the specific reason you did or did not adopt it. "The lens disfavours agency" is not a reason; it is the bias this step exists to catch.
+
+Step 5.2: Move every disclosure into the body, within two sentences of the claim it qualifies, in the same typographic register. Mark each NON-REMOVABLE. Assume any later "tighten this up" pass will strip them.
+
+Step 5.3: Count hedges, contingency nodes, and disclosure sentences per thousand words against the budget in [resources/disclosure-and-budget.md](resources/disclosure-and-budget.md). Over budget means the architecture is wrong for this evidence, not that the piece needs more caveats. Switch to a shape that does not require the missing slots: chronicle, braided comparison, taxonomy, single-question investigation.
+
+Step 5.4: Ship the audit log with the deliverable: the slot table with its four dates, the flip-test casualties, the graveyard result, the omission list with reasons, the agency reading, and the hedge count.
+
+Validate using [resources/evaluators/rubric_narrative_fallacy_guard.json](resources/evaluators/rubric_narrative_fallacy_guard.json). **Minimum standard**: average score >= 3.5, and no score below 3 on "Expensive Checks Actually Run".
+
+## What Each Failed Check Produces
+
+Every row ends in a label, a rewrite, or a disclosure. No row ends in a deletion.
+
+| Check | Failure looks like | Required output on failure |
+|---|---|---|
+| Retrospective slot audit | Earliest significance date is after the outcome date | Body sentence: "nobody at the time treated this as a turning point", plus a downgraded verb |
+| Substitution test | Cannot name two rival slot-fillers | Return to the corpus; the search was not done |
+| Outcome-blind rewrite | Adjective has no dated pre-outcome source | Replace with action + information set + alternatives, written as vivid specifics |
+| Flip test | Sentence would not have been written that way under the opposite outcome | Rewrite so the evidence, not the ending, supplies the judgment |
+| Separation test | One sentence carries both decision quality and outcome quality | Split into two sentences; the outcome sentence may not supply the decision adjective |
+| Inevitability audit | Banned construction with no live alternative named | Replace with contingency language, or state the binding constraint that made it overdetermined |
+| Overshoot check | Zero confident causal claims in the piece | Restore the best-evidenced causal claim and give it its counterfactual |
+| Graveyard pass | No comparison entities found | State the search and the finding, or state "base rate unknown" in the body |
+| Counterfactual gate | Fails any of the six tests | Reject the node, or narrow the antecedent until it passes |
+| Proportion audit | Words and evidence tier are inverted | Written justification, or rebalance; never a mechanical word quota |
+| Omission check | Corpus item absent with no stated reason | Reinstate it |
+| Source ledger | L1 MECHANISM sourced from a secondary retrospective | Downgrade the tag to L3 or L5 |
+| Hedge budget | Over budget per thousand words | Change the architecture; do not add caveats |
+| Agency reading | Absent, or waved away | Write it, name the evidence for it, and give the reason for rejecting it |
+
+## Banned Constructions and Their Licences
+
+These are banned without a licence earned in Step 3.2:
+
+- "inevitably", "was always going to", "was bound to"
+- "the writing was on the wall", "in retrospect it is obvious"
+- "set the stage for", "paved the way", "the seeds of its own destruction"
+- "primitive", "advanced", "matured into"
+
+The licence is a named live alternative that someone in the material was actually advocating or pursuing at that moment, or a stated binding constraint (physical, accounting, contractual, thermodynamic) that made the path overdetermined. Overdetermination must be stated, never implied.
+
+Replacements that carry the same information without the teleology: "happened to", "persisted given", "survived the conditions of", "nobody on the shift expected", "of the paths then on the table, this was the one funded".
+
+Worked contrast, three domains:
+
+- Outage post-mortem. Bad: "The undersized connection pool inevitably led to the cascade." Good: "The pool was sized for the 2021 traffic profile and never revisited. Two engineers had filed tickets to raise it; both were closed as low priority against the migration deadline. When the retry storm arrived, the pool saturated in ninety seconds."
+- Protocol history. Bad: "The format matured into the industry standard." Good: "Three formats had working implementations in 1997. Two lost their sponsoring vendors within four years; the survivor was the one whose reference implementation shipped inside a widely deployed operating system, which is distribution rather than design."
+- Lab science. Bad: "The 2014 assay result contained the seeds of the eventual retraction." Good: "The 2014 assay produced a result the lab could not replicate on the first attempt. The notebook records it as instrument drift, which was the standard reading for that machine at the time. Nothing in the record shows anyone treating it as a warning until 2019."
+
+## Guardrails
+
+**Requirements:**
+
+1. **No check is a gate that deletes**: the Kahneman predictability test deletes essentially every rich historical explanation, the slot audit flags every structural cause invisible to contemporaries, and the graveyard pass has no valid output at n=1. Each is a label-and-disclose device. An agent that gates on them ships a chronicle, which is its own accuracy failure.
+2. **The expensive checks are mandatory, not optional**: implementing only the cheap per-sentence checks produces work MORE dangerous than unchecked work, because it carries verifiable citations and reads as audited while misrepresenting drift and proportion through selection alone. If Step 4 is skipped, the deliverable must say on its face that it was skipped.
+3. **Disclosure placement is load-bearing**: body text, within two sentences, same register, marked non-removable. Back matter does not count. Readers experience the body.
+4. **Source interest travels with source date**: a dated pre-outcome source produced by a promoter or a defendant has moved the bias one step upstream, not removed it. Say whose interest it served, and whether it is representative of a range you actually sampled or a single cherry-picked booster.
+5. **The agency reading is a required output field**: not optional prose. Missing it fails the rubric regardless of the rest.
+6. **Genre disclosure is not a licence**: naming the shape of your account buys credibility that must be spent on reinstating what the shape suppressed. Any documented mechanism dropped to make the arc work goes back in, even where it damages the arc.
+
+**Common pitfalls:**
+- Neutrality collapse: stripping every adjective and shipping unreadable, unloving prose. The substitution must be vivid specifics ("two quarters of cash and one letter of intent"), never a bureaucratic placeholder.
+- Applying the flip test to sentences about facts. It is valid only for sentences about decisions; elsewhere it produces nonsense.
+- Luck nihilism: attributing everything to path and noise. The cumulative-advantage evidence licenses only the weak claim, that extremes are predictable and the middle is not. The check must produce an apportionment, not a shrug.
+- Contemporaneity fetish: mechanically demoting every retrospective slot, which over-weights whatever happened to be loud at the time. That is salience bias wearing the costume of rigor.
+- Manufacturing comparison cases to satisfy the graveyard pass in an n=1 domain.
+- Defensive over-disclosure: answering an audit with twelve caveats. Volume is not integrity. The operative test is whether a reader who disagrees can find the strongest counter-evidence inside the piece.
+- Dramatising a counterfactual until it reads like a documented scene.
+- Letting a later editing pass strip the disclosures. Mark them; re-count them after every revision.
+
+**Attribution caveats to carry into any output:**
+- The process-tracing test names (straw-in-the-wind, hoop, smoking-gun, doubly decisive) come from Van Evera and Bennett, as presented by Collier.
+- The six-part counterfactual gate is Tetlock and Belkin's. The seven-band likelihood ladder with its numeric ranges is ICD 203's published lexicon.
+- "Graveyard pass", "overshoot check", and "substitution test" are this skill's own labels. They name procedures assembled from several literatures. Do not cite them as canonical terms.
+- Every numeric threshold in [resources/disclosure-and-budget.md](resources/disclosure-and-budget.md) is a derived default for this skill, not a published figure.
+
+## Quick Reference
+
+**Key resources:**
+- **[resources/audit-procedures.md](resources/audit-procedures.md)**: the six audits in full, with slot tables, the flip and separation tests, the counterfactual gate, the proportion table, and bad-and-good rewrites across post-mortems, biography, supply chain, protocol history, and research writeups
+- **[resources/disclosure-and-budget.md](resources/disclosure-and-budget.md)**: disclosure placement rules, hedge budget arithmetic, the likelihood and confidence lexicon, source ledger fields, the agency-reading template, and the ship log format
+- **[resources/evaluators/rubric_narrative_fallacy_guard.json](resources/evaluators/rubric_narrative_fallacy_guard.json)**: quality scoring
+
+**Inputs required:**
+- The draft or the planned structure, with its structural slots identified
+- The corpus, with source dates and provenance available
+- The outcome date (the date after which everything in the piece is written with hindsight)
+
+**Outputs produced:**
+- Slot table with four dates per slot and its retrospectivity tag
+- Rewritten evaluative sentences with the flip and separation tests applied
+- Inevitability audit results, including the forecast-vs-outcome beat and the overshoot verdict
+- Graveyard result, counterfactual nodes admitted and rejected, proportion table, omission list with reasons
+- The agency reading for each major outcome
+- Hedge budget count and, if binding, an architecture recommendation
+- The audit log, shipped with the deliverable

--- a/skills/narrative-fallacy-guard/resources/audit-procedures.md
+++ b/skills/narrative-fallacy-guard/resources/audit-procedures.md
@@ -1,0 +1,277 @@
+# Audit Procedures
+
+The six audits in full, with the tables they produce and worked bad-and-good rewrites. Domains used throughout: incident and outage post-mortems, biography, supply chain, protocol and standards history, lab science, and machine-learning research writeups.
+
+Every audit here ends in a label, a rewrite, or a disclosure sentence. None of them ends in a deletion. That rule is not a softening of the audits. It is what keeps them usable: a delete rule applied to the predictability test removes every rich explanation ever written, and the result is a chronicle that informs nobody.
+
+## Table of contents
+
+- [1. Source ledger and the primary/secondary downgrade](#1-source-ledger-and-the-primarysecondary-downgrade)
+- [2. Retrospective slot audit](#2-retrospective-slot-audit)
+- [3. Outcome-blind rewrite](#3-outcome-blind-rewrite)
+- [4. Inevitability audit and the overshoot check](#4-inevitability-audit-and-the-overshoot-check)
+- [5. Graveyard pass](#5-graveyard-pass)
+- [6. Counterfactual admissibility gate](#6-counterfactual-admissibility-gate)
+- [7. Proportion audit and omission check](#7-proportion-audit-and-omission-check)
+- [8. Causal tier tags and their permitted verbs](#8-causal-tier-tags-and-their-permitted-verbs)
+- [9. Domain-dominant failure modes](#9-domain-dominant-failure-modes)
+
+---
+
+## 1. Source ledger and the primary/secondary downgrade
+
+A date alone is not a clean standard. Contemporaneous sources are produced by interested parties. They survive selectively. In business and technology material they are dominated by promotional copy and by analyst commentary already carrying an in-progress halo. An agent that treats any dated pre-outcome source as clean evidence has moved the bias one step upstream rather than removing it.
+
+Ledger fields, one row per source:
+
+| Field | What goes in it |
+|---|---|
+| ID | Short handle used in the slot table and the tag map |
+| PUB DATE | When the source was published or written |
+| EVENT DATE | The period it describes |
+| CLASS | PRIMARY (contemporaneous record, artifact, log, memo, filing) or SECONDARY (later account) |
+| INTEREST | Who paid, who benefits, what is being sold or defended |
+| SAMPLED | Whether this view is representative of a range you actually read, or a single voice you picked |
+
+Downgrade rules:
+
+- No claim may be tagged L1 MECHANISM on the strength of a secondary retrospective account alone. A later book asserting that a memo caused a decision is evidence about the book. Downgrade to L3 SEQUENCE or L5 CONJECTURE until the memo is in hand.
+- A single quoted booster or a single quoted critic does not discharge the outcome-blind rewrite. Say whether the retained characterisation is representative of a sampled range.
+- If the corpus is entirely secondary, say so in the body, once, early. The halo, the teleology, and the shape have already been applied upstream. You will otherwise re-derive them faithfully while passing every check.
+
+Selection rule sentence. Write it literally, before anything else:
+
+- "This corpus consists of the incident reviews that were written up, which is the subset where someone had time after the fact."
+- "This corpus consists of the suppliers still trading in 2024, which excludes everyone the same shock removed."
+- "This corpus consists of the researchers who agreed to be interviewed."
+
+That sentence feeds the graveyard pass in section 5. If you cannot write it, you do not know what your evidence is a sample of.
+
+---
+
+## 2. Retrospective slot audit
+
+A structural slot is a claim that a moment mattered. The audit separates "mattered to the people in it" from "matters because we know the ending".
+
+Produce this table. It ships with the deliverable; it is not scratch.
+
+| Slot | Event | (a) event date | (b) earliest source treating it as significant | (c) outcome date | (d) source cited | Tag |
+|---|---|---|---|---|---|---|
+| Inciting incident | ... | ... | ... | ... | ... | RETROSPECTIVE-ONLY / CONTEMPORANEOUS-PARTIAL / CONTEMPORANEOUS |
+
+Tag rule: if (b) is after (c), the slot is RETROSPECTIVE-ONLY. If (b) sits between the event and the outcome, it is CONTEMPORANEOUS-PARTIAL. If a source dated at or before the event names it as consequential, it is CONTEMPORANEOUS.
+
+Substitution test, run on every RETROSPECTIVE-ONLY slot: name two other events in the same window that a narrator with a different ending would have picked. If you cannot name two, you have not searched the corpus.
+
+Worked example, supply chain. The piece opens on a 2019 decision to single-source a component, because a 2022 shortage made that decision famous. Earliest source treating the 2019 decision as significant: a 2022 trade-press retrospective. That is after the outcome date. Tag RETROSPECTIVE-ONLY. Substitution test produces two rivals: the 2018 qualification of a second supplier that was then never ordered from, and the 2020 decision to cut safety stock by a third. A narrator whose story ended in a successful cost programme would have opened on either.
+
+Required output once tagged: either downgrade the verb, or add one body sentence. "Nothing in the 2019 record treats the single-source decision as a risk event; the first document that does is dated three months after the shortage began."
+
+The failure mode to avoid is contemporaneity fetish. Some genuinely causal events are invisible to everyone present: a slow demographic shift, accumulating technical debt, a definitional drift in a metric, a mutation. Mechanically demoting every RETROSPECTIVE-ONLY slot over-weights whatever happened to be loud at the time. That is salience bias wearing the costume of rigor. The tag is a disclosure requirement.
+
+### Instrument check for quantitative slots
+
+When the inciting incident is a discontinuity in a series, ask one question before accepting it: did the world change, or did the instrument change?
+
+Enumerate the instrument candidates: definitional revisions, coverage or sampling changes, methodology restatements, reporting-lag artifacts, entity or boundary changes (mergers, re-classification, redistricting), and collection-platform changes.
+
+Reject any candidate whose date coincides with a known instrument change, unless the effect survives re-baselining on a consistent definition. If you cannot re-baseline, the instrument change is the story and must be narrated as such.
+
+Bad: "Defect reports tripled in Q3, and the team never recovered." Good: "Defect reports tripled in Q3. The intake form changed on 1 July, and the new form auto-filed a ticket for every crash the old one had batched. On a consistent definition the underlying rate rose by about a fifth."
+
+Record the rejected candidates and the reason. That list is the defence against the charge of cherry-picking a start date.
+
+---
+
+## 3. Outcome-blind rewrite
+
+Reconstruct every characterisation using only the information set available at the decision date. This is the direct countermeasure to the halo effect and to outcome bias, which replicates at large effect sizes even in subjects who state that outcomes should not affect their evaluation of decisions.
+
+Procedure:
+
+1. Extract every evaluative adjective and dispositional noun applied to any actor: visionary, reckless, disciplined, arrogant, prescient, complacent, focused, bloated, brilliant, naive.
+2. For each, look for a dated source predating the outcome that used that characterisation. Found: keep it and attribute it inline with its date. Not found: delete the adjective and replace it with three specifics. The ACTION taken. The INFORMATION SET available at that date. The ALTERNATIVES visibly on the table.
+3. FLIP TEST. Rewrite the sentence assuming the opposite outcome occurred. If you would obviously not have written it that way, the outcome is supplying the judgment, not the evidence.
+4. SEPARATION TEST. State decision quality and outcome quality in different sentences. The outcome sentence may not supply the adjective for the decision sentence.
+5. QUOTE-LAUNDERING CHECK. Is the surviving dated characterisation representative of a range you sampled, or one cherry-picked voice? Say which.
+6. SYSTEM PASS. Apply all of the above to non-person protagonists.
+
+Worked rewrites:
+
+- Biography. Bad: "Her reckless 1998 expansion drained the reserves." Good: "In 1998 she committed the reserves to a second site. The company had two quarters of cash, one signed anchor tenant, and a competing proposal to lease rather than build. The site did not fill for four years." (Separation test satisfied: the decision sentence and the outcome sentence are distinct, and the outcome does not supply the adjective.)
+- Post-mortem. Bad: "The on-call engineer complacently ignored the alert." Good: "The alert fired at 02:14 alongside eleven others from the same dependency. The runbook for that alert had been marked 'known noisy' in March. She acknowledged it and continued on the incident she was already working."
+- ML writeup. Bad: "The team made the prescient choice of a larger context window." Good: "The team chose a 4k context against a 2k baseline. Two of the three benchmarks they were tracking were insensitive to context length at the time, and the compute cost was roughly double. The internal design note gives the reason as headroom for a planned retrieval feature that was later cancelled."
+- System halo. Bad: "An efficient market consolidated around two clearing venues." Good: "Two clearing venues held ninety per cent of volume by 2011. Four others had exited; three of the four cited the same capital rule. Whether the surviving two were the lowest-cost providers is not established by the record."
+
+The failure mode is neutrality collapse. Strip every adjective and you produce prose nobody finishes, and unread accurate work informs nobody. The substitution must be vivid specifics ("two quarters of cash and one signed anchor tenant"), never a bureaucratic placeholder ("the decision was taken in a constrained information environment"). Placeholders fail the pass as surely as adjectives do.
+
+Second failure: the flip test is valid only for sentences about decisions. Applied to sentences about facts it produces nonsense.
+
+---
+
+## 4. Inevitability audit and the overshoot check
+
+Run over every causal sentence in the draft. A causal sentence is any sentence containing: because, so, led to, drove, forced, triggered, resulted in, as a result, which is why, meant that, set the stage for, inevitably, was bound to, the seeds of, paved the way.
+
+Also scan the places the causal claim hides when the connectives are policed: figure captions, chart annotations, section headings, pull-quotes, chapter titles, scene cuts, and paragraph breaks between two events. A juxtaposition is a causal claim made without words.
+
+For each causal sentence:
+
+1. What did the actors at the time believe would happen? Cite a contemporaneous forecast, plan, budget, or projection.
+2. Name one live alternative that was genuinely available, and that someone in the material was advocating or pursuing at that moment.
+3. If no live alternative exists, the outcome may genuinely have been overdetermined. Say so explicitly and give the binding reason: a physical limit, an accounting identity, a contractual obligation, a regulatory deadline. Do not leave overdetermination implied.
+4. Enforce the banned list. Replace with contingency language: "happened to", "persisted given", "survived the conditions of", "nobody on the shift expected", "of the paths then on the table, this was the one funded".
+
+Then insert the FORECAST-VS-OUTCOME BEAT. Find one documented prediction from inside the material that turned out wrong, and give the reasoning that made it reasonable at the time. One such beat does more anti-inevitability work than any quantity of hedging, because it lets the reader feel the uncertainty rather than being told about it.
+
+Examples of the beat:
+
+- Protocol history: the 1996 working-group minutes in which three of five participants expect the competing encoding to win, and the throughput numbers they were looking at.
+- Lab science: the grant renewal that budgeted two years for a result that took nine, and the pilot data that made two years look generous.
+- Supply chain: the demand plan that assumed a 4% decline, signed by people with the order book in front of them.
+
+### The overshoot check
+
+Does the draft contain at least one confidently asserted "X caused Y"? If not, the brake has become hedge fog, which is abdication rather than honesty.
+
+The correct output of this audit is a small number of confidently asserted causal claims, each carrying its counterfactual, and not a large number of hedged ones. Count them. Zero is a failure of this audit, not a success of it.
+
+### Anachronism flag
+
+Where a category, a metric, or a moral frame used in the text did not exist at the time described, say so in the body. "The 1974 filings contain no figure comparable to what is now reported as scope-2 emissions; the estimate below is reconstructed and is not what anyone measured then."
+
+Flag the anachronism. Do not adjudicate whether present-day categories may be applied to past actors. That dispute is live and politically contested, and it is not this skill's business. The narrow operation is checkable; the larger argument is not.
+
+---
+
+## 5. Graveyard pass
+
+Every "X did A and won" claim implies a population. The pass forces a search for the non-survivors who also did A, or a declaration that the base rate is unknown.
+
+1. State the selection rule from section 1.
+2. For every success attribution, search for at least two entities that took the same action and did not get the same outcome.
+3. Report one of three results in the body text.
+   - Counterexamples found: name them and weaken the claim.
+   - Counterexamples searched for and not found: state the search and the finding. This strengthens the claim, and is worth saying for that reason.
+   - Population is n=1 or unobservable: write "the base rate for this action is unknown".
+4. Inversion, for any "the lesson is" inference: what would the record look like if the decisive factor were present only in the cases that did not survive, and therefore are not in your corpus?
+5. Never let an implied prescription stand on a corpus whose selection rule is survival.
+
+Worked example, ML writeup. Claim: "the win came from curriculum ordering of the training data." Graveyard search finds two contemporaneous groups that used the same ordering scheme and reported no gain, and one that reported a loss. Required text: "Two other groups applied the same ordering and reported no improvement; a third reported a small regression. Whatever the ordering contributed here, it is not sufficient on its own."
+
+Worked example, biography. The subject's habit of writing to strangers is credited with the career break. The graveyard is unobservable: nobody records the letters that were never answered. Required text: "the base rate for this is unknown, and the people whose letters went unanswered did not leave archives."
+
+Failure mode: false symmetry. Some events genuinely have no comparison class. An agent required to produce counterexamples will manufacture weak analogies and present them as base rates, which is a fresh distortion dressed as a correction. Result three must be a first-class, non-embarrassing output.
+
+### Cumulative-advantage apportionment
+
+Where the outcome involves observable prior adoption influencing later adoption (market share, standards, citations, downloads, funding, hiring, platform effects), add an apportionment sentence.
+
+The experimental evidence licenses only the weak claim: the best rarely does badly and the worst rarely does well, and between those bounds many results are possible. So establish the quality bounds the record supports. Was the winner top-tier on the merits, or merely not bottom-tier? Name at least one near-peer that was comparable and did not win, and say what differed. If the difference is timing, an early endorsement, a distribution accident, or a rival's unrelated stumble, that is path, not property.
+
+Apportionment sentence: "On the merits it was among several credible options; its win owed materially to shipping inside a widely installed runtime."
+
+Ban the retro-justification form: any sentence of the shape "X won because it was [attribute]" where the same attribute was present in a loser.
+
+Failure mode: luck nihilism. Applied everywhere, this concludes that nothing is explicable and produces a piece that shrugs. The check must produce an apportionment, not a dismissal. It is also simply wrong in domains without social feedback: a materials failure analysis, a contract dispute, a compiler bug.
+
+---
+
+## 6. Counterfactual admissibility gate
+
+A contingency node marks a decision point where the outcome was genuinely open. All six tests must pass, or the node is rejected.
+
+| Test | Passes | Fails |
+|---|---|---|
+| CLARITY | "If the second supplier had been qualified before the Q3 order" | "If things had gone differently" |
+| COTENABILITY | You can list what else would have to be true: the tooling, the audit, the lead time | You cannot enumerate the connecting principles |
+| MINIMAL REWRITE | Exactly one thing changes | Requires altering a second independent fact, which describes a different world |
+| HISTORICAL CONSISTENCY | The antecedent was physically, technically, and institutionally possible at that date, and someone proposed it | The antecedent needs a capability that did not exist |
+| THEORETICAL CONSISTENCY | The link uses a mechanism already established in the piece with L1 or L2 evidence | The link is asserted only here |
+| STATISTICAL CONSISTENCY | Where base rates exist, the counterfactual outcome falls inside them | The counterfactual outcome is an outlier nobody achieved |
+
+Rendering rules:
+
+- Bounded element only: a bracketed passage, a sidebar, a marginal note, a differently-styled paragraph. Never a dramatised scene with sensory detail. A dramatised counterfactual acquires the vividness of the documented events, and readers will not retain which was which.
+- Density cap: at most one contingency node per major structural section. Contingency nodes are punctuation, not texture.
+- Inevitability disclaimer at the node: state what the actors at that moment believed the odds to be, if the record says.
+
+Failure modes. First, the counterfactual as consolation: a decorative "what if" so implausible that the actual path looks overdetermined by comparison, which strengthens the inevitability it was meant to break. Second, unbounded cotenability: "if the firm had shipped a competing product in 1988" silently requires a different firm, at which point the counterfactual is about a fictional company. Minimal rewrite is the load-bearing constraint and the one most often violated.
+
+Admitted example, outage post-mortem: "[Two config lines: the pool size and the retry backoff. Both were in a pending change request opened eight days earlier and unreviewed. With either merged, the saturation curve stays under the ceiling for the observed traffic. The reviewer queue was six deep that week.]"
+
+Rejected example: "Had the platform team adopted a service mesh in 2019, the cascade could not have propagated." Fails minimal rewrite (a mesh adoption implies a different platform team, budget, and migration), and fails historical consistency unless someone actually proposed it at that date.
+
+---
+
+## 7. Proportion audit and omission check
+
+These are the expensive checks. They are the ones schedule pressure removes. They are also the only checks that catch the failure where every sentence is true and the piece as a whole misrepresents the drift and proportion of events.
+
+Implementing only the cheap per-sentence checks produces work more dangerous than unchecked work, because it carries verifiable citations and reads as audited.
+
+### Proportion table
+
+| Claim | Words spent | Evidence tier (L1-L5) | Causal weight (filled BEFORE the arc was chosen) | Flag | Justification |
+|---|---|---|---|---|---|
+
+Flag both asymmetries:
+
+- Top quintile by words, bottom quintile by evidence tier. These are the colourful anecdotes carrying the reader's belief.
+- Top quintile by causal weight, bottom quintile by words. These are the boring drivers the arc suppressed. Usually a price change, a regulatory filing, a base rate, a demographic trend, a compiler flag, a contract renewal date.
+
+Every flag needs a written justification. "This anecdote gets 800 words because it is the only surviving first-hand account of the mechanism" is legitimate. No justification means rebalance.
+
+Do not equalise mechanically. Redistributing word count produces something with the rhythm of a spreadsheet, and readability collapse is itself an accuracy failure. The audit terminates in a justification, not in an automatic edit.
+
+Fill the causal-weight column before the arc is chosen. Filled afterwards, it inherits the same halo the audit exists to catch.
+
+### Omission check
+
+List every corpus item that appears nowhere in the draft. For each, state why. Any item that would weaken the spine and was omitted without a stated reason is a cherry-pick, and it goes back in.
+
+Add the forgotten-population question for quantitative material: who is not in this dataset who should be, and would including them change the sign?
+
+Final gate for both checks: a reader who disagrees with your conclusion, can they find the strongest evidence against you inside your piece? If not, you have obfuscated, whatever you intended.
+
+The mirror failure is defensive over-disclosure. Answering an audit with twelve caveats and four hedging paragraphs buries the damaging material among weak supportive material, which is itself a recognised deception pattern. Volume is not integrity.
+
+---
+
+## 8. Causal tier tags and their permitted verbs
+
+Tag every causal assertion before writing the sentence. The tag governs the verb.
+
+| Tag | What it means | Permitted verbs | Banned |
+|---|---|---|---|
+| L1 MECHANISM | The linking step itself is documented: a memo, a contract, a physical process, an accounting identity, a commit, a transcript | caused, forced, triggered, led to, because, resulted in | — |
+| L2 CORRELATION | Quantitative co-movement documented, mechanism absent | moved with, tracked, coincided with, accompanied | because, drove, forced |
+| L3 SEQUENCE | Only temporal order established | then, afterwards, in the following quarter, subsequently | every causal connective |
+| L4 ADJACENCY | Co-present, no link established | must be separated in the text, or carry the inline disclaimer "the two were concurrent; no link is documented" | all |
+| L5 CONJECTURE | The author's inference | must carry an explicit marker: "the most plausible reading is", "no source says why, but" | may never occupy a climax, revelation, or thesis sentence |
+
+Requirements per tier: an L1 tag needs a source for the LINK, not merely for the two endpoints. An L2 claim must name at least one other thing that moved the same way. An L3 claim needs both dates. For any L1 claim, state the DELAY: causes and effects separated by months read as unrelated, and effects that arrive instantly are usually not caused by the thing that just happened.
+
+Two failures to watch:
+
+- Because-laundering. When the connectives are policed, the causal claim moves where the check cannot see it. It hides in a metaphor ("the dam broke"), in a scene cut, in a chapter title, in a chart annotation, or in a quoted source who asserts the causality on the author's behalf.
+- Type laundering. A correlation is introduced with hedges early, then referred back to later as established mechanism: "as we saw, the fee change drove the migration." Check every back-reference against the type of the original claim. A back-reference may not upgrade the tier. This is fully mechanical to detect and it is the most common integrity failure in long analytical pieces.
+
+Rendering: L1 and L4/L5 must be distinguishable to the reader without opening the notes. A glyph, a class, a colour, an inline parenthetical. If the reader cannot see the difference, the tagging did nothing.
+
+---
+
+## 9. Domain-dominant failure modes
+
+One uniform checklist misses the locally dominant error. Run all the audits; weight these.
+
+| Domain | Dominant failure | Weight these audits |
+|---|---|---|
+| Market, industry, and technology history | Retrospective inevitability; winner's attributes explaining a draw from a distribution | Slot audit, inevitability audit, cumulative-advantage apportionment |
+| Product and incident post-mortems | Hindsight plus individual blame | Outcome-blind rewrite, counterfactual gate, source ledger |
+| Biography | Systemic framing used to excuse the subject, or halo applied to everything before the outcome | Outcome-blind rewrite, agency reading, graveyard pass |
+| Supply chain and operations | A cherry-picked traversing unit presented as typical | Proportion audit, omission check, instrument check |
+| Lab and field science | Omitted failed experiments; the retrospective coherence of a messy search | Omission check, forecast-vs-outcome beat, proportion audit |
+| ML research writeups | Correlation laundered into mechanism; intentional verbs applied to models | Causal tier tags, graveyard pass, type-laundering back-reference check |
+| Standards and protocol history | "Matured into"; the survivor's design credited for the survivor's distribution | Inevitability audit, apportionment sentence, graveyard pass |
+| Policy and regulatory chronologies | Law-office history: facts selected so the past resolves into the present's shape | Slot audit, omission check, anachronism flag |

--- a/skills/narrative-fallacy-guard/resources/disclosure-and-budget.md
+++ b/skills/narrative-fallacy-guard/resources/disclosure-and-budget.md
@@ -1,0 +1,197 @@
+# Disclosure, Budget, and the Ship Log
+
+Where the disclosures go, how many the piece can carry, how to phrase uncertainty without turning the prose into an intelligence product, and what ships with the deliverable.
+
+The audits in [audit-procedures.md](audit-procedures.md) produce findings. This file governs what happens to them on the page. Both halves matter: a finding disclosed in the wrong place is not disclosed, and a piece that carries too many disclosures has become about the author's epistemics rather than about the subject.
+
+## Table of contents
+
+- [1. Disclosure placement](#1-disclosure-placement)
+- [2. The hedge budget](#2-the-hedge-budget)
+- [3. Likelihood and confidence lexicon](#3-likelihood-and-confidence-lexicon)
+- [4. The agency reading](#4-the-agency-reading)
+- [5. Empty slot decision table](#5-empty-slot-decision-table)
+- [6. The ship log](#6-the-ship-log)
+
+---
+
+## 1. Disclosure placement
+
+The rule, stated once and enforced everywhere: a disclosure lives in the body, within two sentences of the claim it qualifies, in the same typographic register as the surrounding prose.
+
+Anything disclosed only in an endnote, a footnote, an appendix, a methods block, or a "sources and limitations" section is functionally undisclosed. Readers experience the body. Confining conjecture to back matter is the practice critics of narrative nonfiction attack most often, and they are right to.
+
+Three placements, only one of which is legal:
+
+| Placement | Verdict |
+|---|---|
+| Body, adjacent to the claim, same register | Legal. This is the only one. |
+| Body, but pushed to the end of the section, or to a framing paragraph two pages earlier | Illegal for claim-level disclosures. Legal only for the one piece-level framing disclosure (see below). |
+| Endnote, appendix, methods block, footnote, caption in smaller type | Illegal. The claim reads as unqualified to every reader who does not turn to the back. |
+
+Register matters as much as position. A disclosure set in smaller type, in a grey box, in italics, or in a differently voiced "methods" register reads as optional. Write it in the same voice as the sentence beside it.
+
+### Non-removability
+
+Assume any later "tighten this up" pass will strip the disclosures first. They are the sentences that read as friction.
+
+Protect them:
+
+- Mark each disclosure sentence NON-REMOVABLE in the working draft, with the audit that produced it. `[NR: slot-audit]`, `[NR: graveyard]`, `[NR: apportionment]`.
+- After every revision pass, re-count. The count may not drop. If a disclosure is genuinely no longer needed because the claim it qualified is gone, record that.
+- If the marker cannot survive into the production format, carry the disclosures as a checklist and re-verify each one against the final text before publication.
+
+### The one piece-level disclosure
+
+Exactly one disclosure is allowed to sit away from its claim, in a framing paragraph, an author's note, or a head note: the statement of what shape you have given the material and what a rival reading would emphasise.
+
+Phrase it as a claim about emphasis, not as a genre label:
+
+- "This account treats the procurement decision as the decisive one. A reading that treated the freight market as decisive would emphasise the 2020 rate collapse, which appears here only in passing."
+- "This is told as the story of one lab. A reading centred on the funding cycle would put the 2016 renewal at the centre and the personalities at the edges."
+
+Naming the shape buys credibility. That credibility must then be spent on reinstatement, not on distortion. Any documented mechanism dropped to make the shape work goes back into the text, even where it damages the shape. Losing a weakly evidenced anecdote to the shape is acceptable. Losing a documented mechanism is not. Without the reinstatement rule, the disclosure is a confession booth.
+
+---
+
+## 2. The hedge budget
+
+**These numbers are derived defaults for this skill, not published thresholds.** Calibrate them to the outlet and the reader. What is not negotiable is that a budget exists and that a binding budget triggers an architecture change.
+
+Per thousand words of body text, count:
+
+| Element | Default cap |
+|---|---|
+| Hedged causal claims (any claim carrying a likelihood band or a qualifying clause) | 8 |
+| Contingency nodes (admitted counterfactuals) | 1 per major section |
+| Disclosure sentences produced by the audits | 6 |
+| Inference-filled structural slots | 1 per piece, never at the climax |
+| Deliberate flagged personifications of a system | 1 per major section |
+
+When the budget binds, do not spend more budget. A piece that is sixty per cent epistemic apparatus and forty per cent subject is unreadable, and it misleads in a fresh way: it makes the author's uncertainty the story.
+
+A binding budget means the architecture is wrong for this evidence. Change the shape:
+
+| Symptom | Architecture to switch to |
+|---|---|
+| Two or more structural slots are empty or inference-filled | Chronicle: sequence without a resolution claim |
+| The causal spine needs a hedge on every link | Single-question investigation: pose the question, show what the record can and cannot settle |
+| Multiple entities, none with a full arc | Braided comparison: the same three questions asked of each |
+| Rich description, thin causation | Taxonomy: organise by kind rather than by cause |
+
+Any of these is a successful outcome. "This material does not support an arc" is a finding, not a failure, and an agent that cannot return it will always build the arc anyway.
+
+### The opposite failure
+
+Defensive over-disclosure is itself a deception pattern. Burying the damaging item among many weakly supportive ones is a documented technique, and adding caveats until nobody can locate the objection is a version of it.
+
+The operative test is not how much apparatus surrounds the claim. It is whether a reader who disagrees can find the strongest counter-evidence inside the piece, within one exhibit or one screen of where they would look for it.
+
+---
+
+## 3. Likelihood and confidence lexicon
+
+Use the published seven-band ladder. Do not invent bands, and do not mix two synonym rows without saying that the rows are equivalent.
+
+| Band | Range |
+|---|---|
+| almost no chance / remote | 01-05% |
+| very unlikely / highly improbable | 05-20% |
+| unlikely / improbable | 20-45% |
+| roughly even chance | 45-55% |
+| likely / probable | 55-80% |
+| very likely / highly probable | 80-95% |
+| almost certain / nearly certain | 95-99% |
+
+Rules:
+
+1. LIKELIHOOD is about the world. CONFIDENCE is about the evidence base: source quantity, source quality, corroboration, and your own grasp of the domain. Confidence is not a probability.
+2. Never combine them in one sentence. "We have high confidence that it is likely" is banned. Split into two sentences, or carry one of them in the annotation layer.
+3. Band only load-bearing judgments: the spine, the causal claims occupying structural slots, and any forecast. Leave descriptive material unbanded.
+4. Do not band things that are not probabilistic: definitions, value judgments, measurements.
+5. State the causes of uncertainty: age of information, gaps in the record, contested measurement, ambiguity of the phenomenon. Say which judgments depend on which assumptions.
+6. State the indicators: what future evidence would move a judgment up or down a band. For a reader who disagrees with you, this is the single most useful thing in the piece.
+
+Rendering rule. The band survives in the annotation layer; the sentence reads as English. This output has failed regardless of how well calibrated it is:
+
+> "It is likely (55-80%, moderate confidence) that the firm probably responded to what may have been competitive pressure."
+
+This has not:
+
+> "The clearest reading of the order book is that the price move came first and the capacity cut followed. Two of the four mills are missing from the data, and both were the ones most exposed, so this reading could change if their records surface."
+
+### Linchpin assumptions
+
+For each major judgment, name the assumptions that must hold for it to stand, and say what follows if they are wrong. Push past the trivial layer. "We assume the revenue figures are accurate" is not a linchpin. These usually are:
+
+- That the actor's stated motive was the actual motive.
+- That the source describing the meeting was present at it.
+- That the metric means the same thing across the whole period.
+- That the entity is the same entity across a rename, a merger, or a re-classification.
+- That the absence of records means the absence of events.
+
+Require at least one assumption about a stated motive, one about the completeness of the archive, and one about metric continuity over time. Each surviving linchpin appears explicitly in the body where it bridges a gap.
+
+---
+
+## 4. The agency reading
+
+This is a required output field, not optional prose. Anti-narrative bias is a real bias. The red-team literature is asymmetrically stocked with attacks on agency-based explanation, so an agent steeped in it will systematically over-attribute outcomes to luck, structure, and path dependence, and under-attribute them to skill, intent, and decision.
+
+For each major outcome, write:
+
+```
+OUTCOME: <what happened>
+STRONGEST AGENCY READING: <the account in which skill, intent, and decision explain this>
+EVIDENCE FOR IT: <the specific documents, decisions, and dated records supporting it>
+ADOPTED / NOT ADOPTED: <which>
+REASON: <the specific evidentiary reason>
+```
+
+"The lens disfavours agency" is not a reason. Neither is "outcomes are mostly luck". The reason must be evidentiary and specific: a comparison case that did the same thing and failed, a documented constraint that would have produced the outcome whoever was in the chair, an instrument artifact, a base rate.
+
+The reverse check runs at the same time. Systemic framing can launder responsibility. "The system failed" is often a sentence written to avoid naming someone. For each systemic attribution, ask whether a specific named actor had both the authority and the information to do otherwise. If one did, name them. Systemic explanation is additive to individual accountability, not a substitute for it.
+
+And the mirror of that: an institutions-as-fate frame is teleology with the sign flipped. The inevitable march of decay is the same error as the inevitable march of progress, because both treat the outcome as foreordained. If the piece argues that a system could not have done otherwise, it must contain either one documented partial success or an explicit statement of the conditions under which that system has changed.
+
+---
+
+## 5. Empty slot decision table
+
+When the record cannot fill a structural slot, choose in this order.
+
+| Move | What it is | When |
+|---|---|---|
+| MOVE 1 (default) | Declare the absence in the body. "No source records what was decided in that room." "The record is silent on why the threshold was set at forty per cent." | Always the first option. A named absence is a legitimate beat and creates tension rather than destroying it. |
+| MOVE 2 | Downgrade and substitute. Fill with the best-documented adjacent event and reduce its weight in the same sentence: "the nearest thing to a turning point in the record is the March re-org, though nobody at the time treated it as one." | When an adjacent event exists and the slot genuinely carries structural load. |
+| MOVE 3 | Change the architecture. Re-run the shape selection over structures that do not need the missing slots. | When two or more major slots are empty. The material does not have this shape. |
+| ILLEGAL | Fill by inference and disclose only in back matter. | Never. |
+| ILLEGAL | Fill by invention of any kind, including "representative" detail and detail flagged as illustrative. | Never. |
+
+Budget: at most one inference-filled slot per piece, and never at the climax.
+
+Log every empty slot and the move chosen. The log ships.
+
+---
+
+## 6. The ship log
+
+The audits produce artifacts. The artifacts ship with the deliverable, separately from the prose. This is what makes the difference between a piece that has been audited and a piece that says it has been audited.
+
+Required sections:
+
+1. **Source ledger.** One row per source: ID, publication date, event date, class, interest, sampled.
+2. **Selection rule.** The one-sentence statement of what the corpus is a sample of.
+3. **Slot table.** Every structural slot with its four dates and its retrospectivity tag. For each RETROSPECTIVE-ONLY slot, the two rival events named in the substitution test.
+4. **Rejected inciting incidents.** For quantitative material, the change-point candidates rejected by the instrument check, with the instrument change that killed each.
+5. **Flip-test casualties.** Every evaluative sentence rewritten, with the before and after.
+6. **Inevitability audit.** The count of licensed and unlicensed causal sentences, the forecast-vs-outcome beat used, and the overshoot verdict (how many confident causal claims survive).
+7. **Graveyard result.** Which of the three legal outcomes applies to each success attribution, with the comparison entities named.
+8. **Counterfactual nodes.** Admitted and rejected, with the failing test for each rejection.
+9. **Proportion table.** Words, evidence tier, causal weight, flags, and the written justification for each flag.
+10. **Omission list.** Every corpus item absent from the draft, with the reason.
+11. **Agency reading.** One block per major outcome, in the format above.
+12. **Budget count.** Hedges, contingency nodes, and disclosure sentences per thousand words, plus the architecture recommendation if the budget binds.
+13. **Skipped checks.** Any audit not run, stated plainly on the face of the log.
+
+That last section is the one that matters most under schedule pressure. A deliverable whose log says "proportion audit and omission check not run" is honest. A deliverable that runs the cheap per-sentence passes, ships a log full of green checks, and stays silent about the expensive ones is the specific failure this whole skill exists to prevent.

--- a/skills/narrative-fallacy-guard/resources/evaluators/rubric_narrative_fallacy_guard.json
+++ b/skills/narrative-fallacy-guard/resources/evaluators/rubric_narrative_fallacy_guard.json
@@ -1,0 +1,104 @@
+{
+  "name": "Narrative Fallacy Guard Rubric",
+  "description": "Evaluation criteria for an audited narrative: whether the retrospective, halo, inevitability, survivorship, proportion, and omission checks were actually run, whether they produced labels rather than deletions, and whether the disclosures survive in the body text.",
+  "criteria": [
+    {
+      "name": "Retrospective Slot Audit Completed",
+      "description": "Whether each structural slot carries its four dates, its retrospectivity tag, and the substitution test where required",
+      "weight": 1.0,
+      "scores": {
+        "1": "No slot audit; the inciting incident and turning points were chosen without asking when they became significant",
+        "2": "Slots listed but only the event dates recorded; no earliest-significance date, so no tag is possible",
+        "3": "All four dates recorded and slots tagged, but the substitution test was skipped on retrospective slots",
+        "4": "Slots tagged, substitution test run with two rival events named per retrospective slot, verbs downgraded where required",
+        "5": "All of level 4, plus the rejected candidates recorded with reasons, the instrument check run on any quantitative discontinuity, and the slot table shipped with the deliverable"
+      }
+    },
+    {
+      "name": "Outcome-Blind Characterisation",
+      "description": "Whether evaluative language rests on dated pre-outcome sources or on the outcome itself, and whether the flip and separation tests were applied to people and to systems alike",
+      "weight": 1.2,
+      "scores": {
+        "1": "Evaluative adjectives throughout (visionary, reckless, disciplined) with no dated support; the outcome supplies every judgment",
+        "2": "Some adjectives attributed, most not; system characterisations ('an efficient market', 'an inevitable standardisation') untouched",
+        "3": "Adjectives audited and either dated or replaced, but replacements are bureaucratic placeholders rather than vivid specifics",
+        "4": "Adjectives dated or replaced with action plus information set plus alternatives, written as specifics; flip and separation tests applied",
+        "5": "All of level 4, applied equally to system protagonists, with quote-laundering checked and the sampling of each retained characterisation stated"
+      }
+    },
+    {
+      "name": "Inevitability Control Without Overshoot",
+      "description": "Whether causal sentences carry live alternatives or stated overdetermination, whether the forecast-vs-outcome beat is present, and whether the piece still asserts anything",
+      "weight": 1.2,
+      "scores": {
+        "1": "Teleological language throughout ('inevitably', 'matured into', 'the seeds of'), or the mirror failure: hedge fog with zero asserted causal claims",
+        "2": "Banned constructions mostly removed but replaced with vagueness; no contemporaneous expectations cited",
+        "3": "Causal sentences carry live alternatives or a stated binding constraint, but no forecast-vs-outcome beat and no overshoot count",
+        "4": "Live alternatives named, overdetermination stated where it applies, one documented wrong prediction included with the reasoning that made it reasonable",
+        "5": "All of level 4, plus the overshoot check passed with a small number of confidently asserted causal claims each carrying its counterfactual, and juxtaposition-level causal claims (headings, captions, scene cuts) audited"
+      }
+    },
+    {
+      "name": "Survivorship and Apportionment",
+      "description": "Whether the corpus selection rule is stated and whether success attributions were tested against entities that did the same thing and failed",
+      "weight": 1.0,
+      "scores": {
+        "1": "Winner's attributes explain the win; no selection rule stated; prescriptions drawn from a survivor corpus",
+        "2": "Selection rule stated but no graveyard search performed",
+        "3": "Graveyard search performed but the result appears only in working notes, not in the text",
+        "4": "Two comparison entities named in the text, or the search-and-not-found result stated, or 'base rate unknown' declared without embarrassment",
+        "5": "All of level 4, plus a cumulative-advantage apportionment sentence where the domain warrants one, and no manufactured comparison cases where the population is genuinely n=1"
+      }
+    },
+    {
+      "name": "Expensive Checks Actually Run",
+      "description": "Whether the proportion audit and the omission check were performed, since the cheap per-sentence checks can all pass while the piece misleads through emphasis and selection alone",
+      "weight": 1.5,
+      "scores": {
+        "1": "Neither run, and the deliverable does not say so; the cheap checks alone make the work read as audited",
+        "2": "Neither run, but the log states plainly that they were skipped",
+        "3": "One of the two run; word counts or omissions tabulated but no written justifications",
+        "4": "Both run: proportion table with both asymmetries flagged, omission list with a reason for every absent corpus item",
+        "5": "All of level 4, with causal weight filled before the arc was chosen, written justification for each flagged asymmetry rather than mechanical rebalancing, and the strongest counter-evidence reachable inside the piece"
+      }
+    },
+    {
+      "name": "Disclosure Placement and Survival",
+      "description": "Whether disclosures sit in the body within two sentences of their claims, in the same register, and whether they survived the revision passes",
+      "weight": 1.2,
+      "scores": {
+        "1": "Disclosures confined to endnotes, an appendix, or a methods block; the body reads as unqualified",
+        "2": "Some disclosures in the body but placed sections away from the claims they qualify",
+        "3": "Disclosures adjacent to claims but in a different register (small type, grey box, methods voice) that reads as optional",
+        "4": "Disclosures in the body, within two sentences, same register, marked non-removable",
+        "5": "All of level 4, with counts re-verified after every revision pass, and one piece-level framing disclosure naming what a rival reading would emphasise"
+      }
+    },
+    {
+      "name": "Agency Reading Stated",
+      "description": "Whether the strongest skill-and-intent explanation was considered and answered on evidence, rather than dismissed because the lens disfavours agency",
+      "weight": 1.0,
+      "scores": {
+        "1": "Absent; every outcome attributed to structure, path, or luck by default",
+        "2": "Mentioned in passing and waved away with a general claim that outcomes are mostly luck",
+        "3": "Written for one major outcome only, or written without naming the evidence supporting it",
+        "4": "One block per major outcome: the reading, the evidence for it, the adopt-or-reject decision, and a specific evidentiary reason",
+        "5": "All of level 4, plus the reverse check: for each systemic attribution, whether a named actor had the authority and information to do otherwise, and either a documented partial success or the conditions under which the system has changed"
+      }
+    },
+    {
+      "name": "Budget and Readability",
+      "description": "Whether the apparatus stayed within budget and whether a binding budget triggered an architecture change rather than more caveats",
+      "weight": 1.0,
+      "scores": {
+        "1": "Either unhedged throughout, or the apparatus has eaten the subject and the author's uncertainty has become the story",
+        "2": "Hedges and disclosures uncounted; likelihood and confidence mixed in the same sentences",
+        "3": "Counted and roughly within budget, but uncertainty rendered as stacked qualifiers rather than as English",
+        "4": "Within budget, likelihood banded only on load-bearing judgments, confidence stated separately, prose reads as prose",
+        "5": "All of level 4, and where the budget bound, the architecture changed (chronicle, braided comparison, taxonomy, single-question investigation) rather than absorbing more caveats"
+      }
+    }
+  ],
+  "threshold": 3.5,
+  "passing_note": "Average score must be >= 3.5. A score below 3 on 'Expensive Checks Actually Run' fails the audit outright regardless of the average, because per-sentence rigor without the proportion and omission checks produces work that reads as audited while misrepresenting drift and emphasis. A score of 1 on 'Disclosure Placement and Survival' or on 'Agency Reading Stated' also requires revision before shipping."
+}

--- a/skills/narrative-fidelity-audit/SKILL.md
+++ b/skills/narrative-fidelity-audit/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: narrative-fidelity-audit
+description: Runs the hard gate on invention in fact-based narrative — a bright-line refusal sweep, an interior-state provenance ladder ([A] said-so / [B] contemporaneous document / [C] behavioural inference / [D] unsourced, where any [D] blocks publication), an LLM-specific fabrication red-flag scan, a three-altitude "How do you know?" prosecution at sentence, paragraph and passage level, a subtraction-log set review, and a note on sources generated from the deviation log. Use before shipping any narrative built on real evidence — market history, incident post-mortem, biography, ML writeup, supply-chain reconstruction, science writing — or when the user mentions fact-check, fidelity audit, fabrication check, invented detail, sourcing pass, did I make this up, composite scene, note on sources, or is this defensible.
+---
+
+# Narrative Fidelity Audit
+
+## Table of Contents
+- [Core Principles](#core-principles)
+- [Workflow](#workflow)
+- [The Bright Lines](#the-bright-lines)
+- [The Interiority Provenance Ladder](#the-interiority-provenance-ladder)
+- [The Three Altitudes](#the-three-altitudes)
+- [Gate Verdict](#gate-verdict)
+- [Guardrails](#guardrails)
+- [Quick Reference](#quick-reference)
+
+**Related skills:** Use `narrative-evidence-ledger` to build the source ledger this gate imports. It owns pointers, evidence classes, the circular-citation check and register porting at build time. Use `narrative-fallacy-guard` for passage-level proportion and omission, `numbers-in-narrative` for quantitative fidelity, `scene-construction-scam` for a candidate scene *before* drafting where this skill audits a finished draft. Use `writing-structure-planner` for architecture before drafting, `claim-extractor` and `citation-form-check` for harvesting and formatting claims, `scout-mindset-bias-check` for motivated reasoning in the analysis, `writing-pre-publish-checklist` for non-fidelity final checks.
+
+## Core Principles
+
+1. **The agent sources, it does not verify**: You cannot confirm a fact. You can only record where a claim came from and how far the prose sits from it. Any output saying "fact-checked", "verified", or "confirmed" is false and turns this apparatus into a trust-laundering machine. The permitted verb is **sourced**.
+2. **Do not add; do not deceive**: Roy Peter Clark's two axioms. Nonfiction may legitimately distort by subtraction (selecting, cropping, condensing). It becomes fiction the moment anything enters the text that was not in the record.
+3. **Vividness is not the signal; a missing pointer is**: The scan keys on claims with no source pointer, never on how good a sentence sounds. A well-sourced vivid detail survives untouched no matter how beautiful.
+4. **Subtraction is the unguarded flank**: Refusal training makes you good at not adding and does nothing about not omitting. A fully sourced, entirely false piece is produced by cutting the disconfirming quarter, the failed pilot, the dissenting engineer — each cut individually defensible.
+5. **Sentence-local checking is what you do well and will default to**: Every documented case of a fully-checked-but-false narrative failed at the paragraph or passage level — ordering, adjacency, proportion, omission.
+6. **These are label-and-disclose devices, not delete rules**: An audit that strips every claim it cannot make bulletproof ships a chronicle. Chronicles inform nobody, which is its own accuracy failure.
+7. **Disclosure is not a currency**: A note on sources describes an already-honest method. It never purchases a deviation.
+
+## Workflow
+
+Copy this checklist and track your progress:
+
+```
+Narrative Fidelity Audit:
+- [ ] Step 1: Establish the audit basis and the vocabulary contract
+- [ ] Step 2: Bright-line refusal sweep
+- [ ] Step 3: Interiority provenance tagging + over-hedging counter-check
+- [ ] Step 4: Fabrication red-flag scan
+- [ ] Step 5: Three-altitude "How do you know?" pass
+- [ ] Step 6: Subtraction-set review and note on sources
+```
+
+**Step 1: Establish the audit basis and the vocabulary contract**
+
+**Precondition: this gate imports the ledger, it does not rebuild it.** Pointer granularity, the circular-citation check, source interest and vintage annotation, and register porting are build-time procedures owned by `narrative-evidence-ledger`. If no ledger exists, or its integrity checks were never run, stop and run that skill first — auditing prose against nothing is not an audit.
+
+Step 1.1: Import the source ledger and confirm it carries, per claim, a pointer, an evidence class, source interest and vintage, and a clean circular-citation verdict. Any of those missing is a RETURN TO RESEARCH, not something to reconstruct here.
+
+Step 1.2: Write the vocabulary contract into your own output header: this pass **sources**; it does not verify.
+
+**Step 2: Bright-line refusal sweep**
+
+Step 2.1: Read [The Bright Lines](#the-bright-lines) below. Sweep the draft for each one and record every breach with a line reference.
+
+Step 2.2: For every breach, apply the disposition table in [resources/bright-lines.md](resources/bright-lines.md): DELETE, DOWNGRADE (rewrite to the evidence level actually held), DECLARE (write the absence into the body), or RESEARCH (emit a specific answerable request). There is no fifth disposition. "Draft it and flag it for review" is not a disposition — flagged drafted text survives review at high rates because it reads well and the reviewer is checking, not rewriting.
+
+Step 2.3: Watch for the **higher-truth rationalization** as you go. It will be generated internally, it will arrive sounding like good judgment, and it is the named failure of the entire genre. See [resources/bright-lines.md](resources/bright-lines.md#the-higher-truth-rationalization) for the phrase catalogue.
+
+**Step 3: Interiority provenance tagging + over-hedging counter-check**
+
+Step 3.1: Find every sentence attributing a thought, feeling, belief, motive, worry, intention, or realization to a real person — and every sentence attributing intent to a system ("the market realized", "Intel decided", "the protocol wanted", "the codebase assumed"). Tag each [A], [B], [C], or [D] using [The Interiority Provenance Ladder](#the-interiority-provenance-ladder).
+
+Step 3.2: **A nonzero [D] count blocks publication.** Report the count as a number. Each [D] is deleted, converted to observable behaviour, or converted to attributed speech.
+
+Step 3.3: **Anti-overcorrection, mandatory.** Re-read every [A] and [B] sentence and verify it is *not* hedged. Say he wrote in an email that night that the number was wrong. Then "he wrote that night that the number was wrong" is correct. "He appears to have possibly thought the number may have been wrong" is a fidelity defect in the other direction. Hedging sourced thought destroys close third person and reads as evasive. A human reviewer facing hedge-saturated prose strips hedges wholesale rather than surgically, losing the true ones with the defensive ones.
+
+Step 3.4: If more than roughly a quarter of sentences in a passage carry explicit attribution or hedging, the diagnosis is **under-reporting, not over-caution**. Send that passage back to research. Do not fix it by deleting attributions. (The one-in-four figure is a working default for calibration, not a published standard.)
+
+**Step 4: Fabrication red-flag scan**
+
+Step 4.1: Run the twelve LLM-specific signatures in [resources/audit-passes.md](resources/audit-passes.md#fabrication-red-flag-scan). Every hit is guilty until it produces a pointer.
+
+Step 4.2: The five highest-yield signatures, because they trip no ordinary fact-check:
+- A **quotation that lands the theme too cleanly**, or is too well-formed for speech (no disfluency, no hedge, no irrelevance).
+- A **transition asserting a state change**: "by then it was clear", "the mood had shifted", "the team, now convinced". These carry no proper nouns and no numbers, so nothing catches them.
+- An **ending that rhymes with the opening**, or three examples forming a suspiciously clean progression.
+- A **causal verb sitting exactly at the seam** between two sourced facts: "led to", "forced", "triggered", "which is why".
+- **Detail so good you would have led with it, and did not** — because it arrived in drafting rather than in reporting.
+
+Step 4.3: Key every judgment on the missing pointer, never on the vividness. Stripping genuinely reported detail alongside the fabrications is how writers learn to switch this scan off.
+
+**Step 5: Three-altitude "How do you know?" pass**
+
+Step 5.1: Run the sentence-level, paragraph-level, and passage-level question sets in [The Three Altitudes](#the-three-altitudes). Run them as an adversarial pass: you have the ledger and the draft, not the draft's rationale.
+
+Step 5.2: Output a **defect list, not a rewrite**. Fixing and checking must be separate acts.
+
+Step 5.3: **If the pass returns zero paragraph- or passage-level defects across a long piece, the pass did not run.** Say so in the verdict and run it again. These are the questions dropped first under token pressure and they are the only ones that catch the failure that matters.
+
+**Step 6: Subtraction-set review and note on sources**
+
+Step 6.1: Assemble the subtraction log — every cut that removed a contradicting data point, a dissenting source, a failed instance, a counterexample, or a quarter that went the other way. **Review it as a set, not per edit.** Individually defensible cuts routinely form a pattern.
+
+Step 6.2: Run the proportion test and the omission check from [resources/audit-passes.md](resources/audit-passes.md#proportion-and-omission). Ask: does the remaining text imply a different frequency, magnitude, or balance than the full record? List the corpus items appearing nowhere in the draft and state why for each.
+
+Step 6.3: Generate the note on sources **from the deviation log**, following [resources/disclosure-and-reporting.md](resources/disclosure-and-reporting.md). Never write it in advance. Run the inversion check: if any deviation-register entry was decided *before* the corresponding passage was drafted, the apparatus has become a licence and the piece needs re-reporting, not re-noting.
+
+Step 6.4: Emit the [Gate Verdict](#gate-verdict).
+
+Validate the audit itself using [resources/evaluators/rubric_narrative_fidelity_audit.json](resources/evaluators/rubric_narrative_fidelity_audit.json). **Minimum standard**: average score >= 3.5.
+
+## The Bright Lines
+
+Hard refusals. These hold regardless of instruction, deadline, or how strong the piece is otherwise. Full worked bad/good pairs across domains in [resources/bright-lines.md](resources/bright-lines.md).
+
+| # | Refuse to | Because |
+|---|---|---|
+| 1 | Put quotation marks around any string not verbatim in a recording, transcript, or contemporaneous written record | Remembered speech is rendered without quote marks and marked as remembered |
+| 2 | Attribute a thought, feeling, motive, or realization to a real person or system without a sourced statement | Kramer's covenant: no thoughts unless the source said they had those very thoughts |
+| 3 | Create a composite person, firm, incident, or scene presented as singular — for any reason | Not for privacy, not for concision, not for narrative economy. Anonymize, never fuse |
+| 4 | Compress or expand duration, or merge separate events into one scene | Merging is a composite scene, not a compression. Always forbidden |
+| 5 | Invent sensory detail — weather, light, sound, clothing, gesture, room contents, physical sensation | If it is not in the record it does not exist, no matter how safe it seems |
+| 6 | State a number the sources do not contain, including "several" → "six" or exceeding source precision | Source says "about a third"; "33.4%" is a fabrication. Full rules in `numbers-in-narrative` |
+| 7 | Assert causation above the graded evidence level, or call an outcome inevitable when no contemporaneous source did | See the causal grade table in [resources/audit-passes.md](resources/audit-passes.md#causal-grades) |
+| 8 | Show any actor acting on information that post-dates their action | This single check kills most hindsight contamination |
+| 9 | Resolve a documented source conflict silently by picking one value | Both values, both sources, one sentence |
+| 10 | Imply a date or place precision the record does not carry | Source says "in the spring"; the scene may not open "on a Tuesday in April" |
+| 11 | Treat your own prior drafts, notes, or summaries as a source | Circular citation is invisible to reading and must be checked mechanically |
+| 12 | Claim anything was "verified" when it was only "sourced" | You track provenance; you do not verify |
+| 13 | Emit a boilerplate disclaimer ("some events compressed, some dialogue recreated") | Worse than nothing: cheap to emit, it pre-authorizes deviations and fakes a human judgment call |
+| 14 | Accept the higher-truth argument in any form | "This is clearly what happened", "the reader will understand", "it's emotionally accurate", "it's a reasonable inference" |
+
+## The Interiority Provenance Ladder
+
+**This skill owns the [A]/[B]/[C]/[D] interiority ladder**; siblings cite this definition rather than restating it. Tag before you write the sentence, and tag again in the audit. The labels are this skill's working convention for compressing the practitioner ladder (Kramer, Clark), not a published four-tier standard.
+
+| Tag | Evidence | Person example | System example | Permitted grammar |
+|---|---|---|---|---|
+| **[A]** | Subject stated the thought — contemporaneous note, email, message, recorded remark, or later on-record recall | Diary entry that night; "she recalled thinking the number was wrong" | Stated strategy in a filing, roadmap, board minutes, RFC, design doc | Direct rendering, cited. For later recall, memory-mark it. **Do not hedge** |
+| **[B]** | A contemporaneous artefact stands in for the state | The cancelled order, the 03:00 commit, the resignation letter dated that day | The price move, the allocation shift, the reverted config, the halted line | Narrate the artefact; let it carry. **Do not hedge**. Write the alternative reading first: a resignation letter proves a resignation, not a disillusionment |
+| **[C]** | Behavioural inference, or an on-record third party's belief | "His deputy believed he had already decided" | Revealed preference across many actors, labelled as aggregate behaviour | Attributed inference, or marked authorial inference. Rare enough to stay visible |
+| **[D]** | Nothing. The state arrived in drafting | "He felt the ground shift." "She knew, then, that it was over." | "The market realized." "The protocol wanted." "The industry decided" | **None. Refuse.** Includes dead subjects and includes when the realization is the whole point of the scene |
+
+When the record has no [A] or [B] for a required realization beat, pick one of five substitutes:
+
+- **Behavioural turn** — narrate the documented change in action. The strategy reversed. The hiring stopped. The parameter was halved.
+- **Artefact pivot** — an object dated to the moment: the revised deck, the deleted section, the new metric in the next board pack.
+- **Attributed witness** — someone on the record says they saw the change.
+- **Deferred revelation** — the reader understands at the end what the subject never did. This is the strongest move for system protagonists.
+- **Named absence** — "No one recorded when the decision was made. By March it had been."
+
+Then strike every noun and verb in the beat not traceable to a pointer. See whether the beat survives. If it collapses, it was invention wearing a substitute's clothes.
+
+## The Three Altitudes
+
+**SENTENCE** — what you are good at and what you will default to:
+1. What does this sentence assert, including what it implies but does not state?
+2. Which pointers support it? None means defect.
+3. Did I observe, get told, read, or conclude this — and which one does the grammar tell the reader?
+4. Which single word carries more certainty, specificity, or vividness than the source supports? Name the word.
+5. What is the strongest reading of the source under which this sentence is false?
+6. Does this verb make a causal claim, and does its grade support it?
+
+**PARAGRAPH** — catches what sentence checking cannot:
+7. Every sentence here is supported. Is the *implicature* supported? What will the reader believe after this paragraph that no sentence in it claims?
+8. Does the ordering assert a causality no source asserts? Narrative adjacency reads as cause.
+9. Does any transition sentence assert a state change nobody documented?
+
+**PASSAGE** — where the documented failures live:
+10. Would each person and institution depicted recognize this as a fair account? On what specific point would they object, and is that point in the text?
+11. What did I cut here, and does the remainder imply a different frequency, magnitude, or balance than the full record?
+12. Is this scene typical of the period it represents, or atypical and vivid? If atypical, does the text say so?
+13. Does a category, metric, or moral frame used here postdate the events described? If so, does the text say so?
+
+## Gate Verdict
+
+Emit these fields verbatim. No field may be omitted.
+
+```
+BRIGHT-LINE BREACHES: n   (must be 0 to clear)
+INTERIORITY [D]-COUNT: n  (must be 0 to clear)
+UNRESOLVED POINTERS / CIRCULAR CITATIONS: n  (must be 0 to clear)
+RED-FLAG HITS WITHOUT POINTERS: n
+PASSAGE-LEVEL DEFECTS FOUND: n  (0 across a long piece = pass did not run)
+SUBTRACTION SET VERDICT: <pattern found | no pattern | log absent>
+HEDGE LOAD: <under budget | over budget -> passage is under-reported>
+NOTE ON SOURCES: <generated from deviation log | not generated>
+INVERSION CHECK: <pass | fail — deviation decided before drafting>
+VERDICT: BLOCKED | RETURN TO RESEARCH | CLEARED AS SOURCED
+```
+
+"CLEARED AS SOURCED" is the strongest verdict available. There is no "verified".
+
+## Guardrails
+
+**Requirements:**
+1. **Vocabulary discipline**: Never write "verified", "fact-checked", or "confirmed" about your own output. Use "sourced", "pointer resolves", "traced to".
+2. **Zero-D gate**: A nonzero [D] count blocks publication. Report it as a number, not a description.
+3. **Passage-level proof of work**: A clean report with no paragraph- or passage-level defect on a long piece is evidence the pass was skipped, not evidence the piece is clean.
+4. **Subtraction reviewed as a set**: Per-edit review of cuts always passes. The pattern only appears in aggregate.
+5. **Disclosure in the body, near the claim**: Any inference or reconstruction occupying a structural slot is disclosed within two sentences of itself, in the same typographic register. Endnote-only disclosure is functionally undisclosed. Mark those sentences non-removable; assume any later "tighten this up" pass will strip them.
+6. **Label and disclose, do not delete**: The output of an asymmetry finding is a written justification requirement, not an automatic edit.
+7. **Surface, do not adjudicate**: Where a real named person or active institution occupies an adversarial role, flag it for human decision. Quietly softening the language while keeping the structure makes the problem invisible rather than solving it.
+
+**Common pitfalls:**
+- Running only the sentence-level questions and reporting a clean piece.
+- Stripping vivid detail that *is* in the record, teaching the writer to disable the scan.
+- Hedging [A] and [B] material until the prose reads like a compliance document, after which a human strips all hedges wholesale.
+- Accepting an internally generated "this is clearly what happened" as a reason rather than recognizing it as the named rationalization.
+- Writing the note on sources first, so it becomes permission rather than description.
+- Letting the aggregate ("the representative fab", "the median advertiser", "a typical incident") accrete a name, a date, a room, or a decision over the length of the piece.
+- Spending audit budget on epistemic apparatus when the real signal is that the evidence does not support this architecture. Over-budget hedging means change the shape, not add more caveats.
+- Over-attributing outcomes to luck and structure because the red-team literature is stocked with attacks on agency. State the strongest agency-based reading you considered and why it was not adopted.
+
+## Quick Reference
+
+**Key resources:**
+- **[resources/bright-lines.md](resources/bright-lines.md)**: the fourteen refusals with bad/good pairs across post-mortem, market history, biography, supply chain and science writing; the higher-truth phrase catalogue; the breach disposition table; composite and aggregate discipline; chronology rules
+- **[resources/audit-passes.md](resources/audit-passes.md)**: fabrication red-flag scan, evidence-class to attribution-grammar decision table, causal grade table with permitted verbs, chronology audit, proportion and omission audit, subtraction log format. Quantitative fidelity is handed off to `numbers-in-narrative`
+- **[resources/disclosure-and-reporting.md](resources/disclosure-and-reporting.md)**: note-on-sources generator, deviation register, inversion check, gate report template, worked examples
+- **[resources/evaluators/rubric_narrative_fidelity_audit.json](resources/evaluators/rubric_narrative_fidelity_audit.json)**: quality scoring
+
+**Inputs required:**
+- The draft under audit
+- The source ledger produced by `narrative-evidence-ledger`: claims with pointers granular enough to re-find, each source annotated with date *and* interest, and the circular-citation check already run
+- The subtraction log, if one was kept (its absence is itself a finding)
+- Register and domain, so the ledger's ported attribution forms can be checked against the prose
+
+**Outputs produced:**
+- Bright-line breach list with dispositions
+- Interiority tag map with [D] count
+- Red-flag hit list, each resolved to a pointer or deleted
+- Three-altitude defect list, separated by altitude
+- Subtraction-set verdict and omission check
+- Note on sources generated from the deviation log
+- Gate verdict block

--- a/skills/narrative-fidelity-audit/resources/audit-passes.md
+++ b/skills/narrative-fidelity-audit/resources/audit-passes.md
@@ -1,0 +1,190 @@
+# Audit Passes
+
+The scans and question sets. Run them in this order: red flags, then the three altitudes, then proportion and omission. Cheap checks first, but never stop at the cheap checks — that is the documented way a rigorous-looking narrative lies.
+
+## Table of Contents
+- [Fabrication Red-Flag Scan](#fabrication-red-flag-scan)
+- [The Three Altitudes in full](#the-three-altitudes-in-full)
+- [Evidence Class to Attribution Grammar](#evidence-class-to-attribution-grammar)
+- [Causal Grades](#causal-grades)
+- [Numbers in Narrative](#numbers-in-narrative)
+- [Chronology Audit](#chronology-audit)
+- [Proportion and Omission](#proportion-and-omission)
+- [Subtraction Log Format](#subtraction-log-format)
+
+## Fabrication Red-Flag Scan
+
+Twelve signatures, tuned to how a language model fabricates rather than how a human does. **Every hit is guilty until it produces a pointer.** A hit that produces a pointer survives untouched, however good it sounds.
+
+| # | Signature | Why it is a signature | Domain example |
+|---|---|---|---|
+| 1 | Quotation that lands the theme too cleanly, or is too well-formed for speech — no disfluency, no hedge, no irrelevance | Real speech is messy. Generated speech is on-topic | "We were solving yesterday's problem with tomorrow's budget," the former VP said |
+| 2 | Sensory or physical detail doing thematic work | The record almost never contains it; the scene wants it | "The fab floor was silent for the first time in nine years" |
+| 3 | Transition or summary sentence asserting a state change | No proper nouns, no numbers, trips no fact-check, pure invention | "By then it was clear the architecture would not scale" |
+| 4 | Ending that rhymes with the opening; an arc that completes; three examples in clean progression | Symmetry arrives in drafting, not in reporting | Closing image mirroring the lede |
+| 5 | Absolutes and superlatives | Cheapest sentences to write, most expensive to defend | "the first", "the only", "the largest", "never before" |
+| 6 | Unnamed minor character voicing the thesis | Exists because the argument needed a mouth | "One engineer put it simply:" |
+| 7 | Causal verb at the seam between two sourced facts | Both facts check out; the join is invented | "which triggered", "led to", "forced", "which is why" |
+| 8 | A number more precise than its neighbours, or suspiciously round | Precision that did not come from a source | "roughly 40%" next to "38.62%" |
+| 9 | A date or time more precise than the surrounding chronology | The scene wanted a clock | "at 4:15 that afternoon" in a piece dated only by month |
+| 10 | Interior-state verb attached to a real person | The single most common fabrication | "realized", "knew", "felt", "understood", "feared", "wanted" |
+| 11 | Intentional verb attached to a market, protocol, institution, or codebase | Hidden causal claim about collective intent | "the market decided", "the protocol wanted", "the industry accepted" |
+| 12 | Detail so good you would have led with it, and did not | It arrived in drafting rather than in reporting. This is the sharpest single tell | Any of the above that you like best |
+
+**Anti-overcorrection.** Key every judgment on the missing pointer, never on the vividness. If the scan strips genuinely reported detail — the detail that makes the piece worth reading and that *is* in the record — the writer learns to switch the scan off, and you have made things worse. Report the sourced-and-kept count alongside the deleted count so the scan's precision is visible.
+
+## The Three Altitudes in full
+
+Run as an adversarial pass. You hold the ledger and the draft. You do not hold the draft's rationale, and you do not accept "I remember sourcing that."
+
+Output a **defect list, not a rewrite**. Fixing and checking must be separate acts.
+
+### Sentence level
+
+1. What does this sentence assert, including everything it implies but does not state?
+2. Which pointers support it? If none, why does it exist?
+3. Did I observe this, get told this, read this, or conclude this? Which one does the grammar tell the reader?
+4. Is the attribution level correct for the evidence class, or is inference wearing the grammar of observation?
+5. Which single word carries more certainty, specificity, or vividness than the source supports? Name the word.
+6. What is the strongest reading of the source under which this sentence is false?
+7. If a hostile, well-informed reader challenged this sentence, what exactly would I show them, and would it settle it?
+8. Does the verb make a causal claim? At what grade? Does the grade support the verb?
+
+### Paragraph level
+
+9. Every sentence here is supported. Is the *implicature* supported? What will the reader believe after this paragraph that no sentence in it claims?
+10. Does the ordering assert a causality no source asserts? Narrative adjacency reads as cause.
+11. Does any transition sentence assert a state change nobody documented?
+12. Does the paragraph's shape (setup, turn, payoff) come from the evidence or from the shape?
+
+### Passage level
+
+13. Would each person and institution depicted recognize this as a fair account of what happened? On what specific point would they object, and is that point in the text?
+14. What did I cut here, and does the remainder imply a different frequency, magnitude, or balance than the full record?
+15. Is this scene typical of the period it represents, or atypical and vivid? If atypical, does the text say so?
+16. Does a category, metric, or moral frame used here postdate the events described? If so, does the text say so? (Encode only this narrow, checkable operation. Do not encode a general position on presentism, which is contested territory.)
+17. Name two entities that took the same actions as the protagonist and did not get the same outcome. Are they in the text?
+18. What is the strongest agency-based reading of this material, and why was it not adopted? If the answer is "the structural reading is more fashionable", that is anti-narrative bias, not rigor.
+
+**The proof-of-work rule.** Sentence-local checking is what a language model does well and what it will default to. Every documented case of a fully-checked-but-false narrative failed at the paragraph or passage level. If this pass returns only sentence-level defects across a long piece, it did not run questions 9 to 18. Report that as a finding about the audit, not as a clean bill for the draft.
+
+## Evidence Class to Attribution Grammar
+
+Evidence classes: **(A)** primary artefact — document, filing, transcript, dataset, log, recording. **(B)** direct first-person testimony about own experience. **(C)** second-hand testimony. **(D)** secondary reporting. **(E)** analyst or agent inference. **(F)** unsourced.
+
+Attribution levels, weakest signal to strongest:
+
+| Level | Form | Example |
+|---|---|---|
+| L0 | Unmarked assertion | "Revenue fell 18% that quarter." |
+| L1 | Embedded source — the source is a grammatical constituent, not an appendage | "The filing put revenue down 18%." "The postmortem timestamps the first alert at 02:14." |
+| L2 | Epistemic verb naming the act | "reported", "recalled", "estimated", "projected", "claimed" |
+| L3 | Explicit attribution | "according to X" |
+| L4 | Contest marker, both values in one sentence | "The company put the figure at 40%; the regulator's audit found 27%." |
+| L5 | Uncertainty declaration | "The record does not establish…", "no source could say…" |
+| L6 | Methods block or note on sources | Absorbs the routine load so L0 and L1 can carry the prose |
+
+**Mapping:**
+
+| Evidence | Required level |
+|---|---|
+| (A) uncontested, covered by methods block | L0 |
+| (A) consequential, or the document's identity matters | L1 |
+| (B) present-tense recall | L2 |
+| (B) self-serving or contested | L3 |
+| (C) second-hand | L3 mandatory, plus explicit distance: "his deputy said he had been told…" |
+| (D) secondary reporting | L3 mandatory, plus a flag that the underlying source was not obtained. Never L0 or L1 |
+| (E) inference | L5-adjacent marking. "The record does not establish X; the sequence is consistent with…" Never presented as finding |
+| Contested, any class | L4. Both values, both sources, one sentence |
+| Gap | L5 in the body. Not silence, not a bridge sentence |
+
+**Rules.**
+- L1 is the workhorse. Prefer it to "according to". It costs no rhythm and carries full provenance.
+- L3 scarcity is what makes it a signal. Spend it deliberately on contested, self-serving, or consequential claims.
+- The opening sentence of a reconstructed scene carries its sourcing. The remainder may run unmarked under that cover.
+- A methods block licenses L0 only for claims it actually covers. It is not a blanket. Symptom of abuse: a methods block describing the reporting in general terms rather than mapping to specific passages.
+- **Budget (working default, not a published figure):** if more than about one sentence in four in a passage sits at L3 or above, the passage is under-reported. Fix by reporting. Never fix by deleting attributions.
+
+**Register porting.** Technical, financial and ML domains have no "sources said" convention. Their prose norm is bare assertion backed by a bibliography. Port the function, not the grammar:
+
+| Journalism form | Financial or technical equivalent |
+|---|---|
+| "according to the filing" | "(10-K FY23, p.47)" or "the FY23 10-K reports" |
+| "sources said" | "three of five interviewed operators reported" |
+| "he recalled" | "the postmortem author's own account records" |
+| Methods block | Data and methods section, with per-figure definitions |
+
+An agent tuned on journalism and pointed at a technical writeup will drop attribution entirely because the target register does not use it. That is the silent failure to watch for.
+
+## Causal Grades
+
+Grade every link in the narrative spine. Force the prose verb to match the grade.
+
+| Grade | Evidence | Permitted verbs | Forbidden |
+|---|---|---|---|
+| **G1** | Mechanism documented — contract terms, physical process, code path, stated and executed decision | "caused", "triggered", "forced" | — |
+| **G2** | Stated intent plus execution — an actor said they would do X because of Y, and did | "in response to", "citing", "after which" | Presenting the stated reason as the real reason |
+| **G3** | Correlation plus argued mechanism. You are reasoning | "appears to have", "is consistent with", "plausibly" | Any G1 verb. Must be marked as the author's argument |
+| **G4** | Temporal sequence only | "then", "subsequently", "by which point" | Anything causal |
+| **G5** | Post-hoc pattern, visible only in retrospect and only to the analyst | Must be labelled as retrospective reading | Presenting as contemporaneous insight |
+
+**Counterweights, all mandatory:**
+- **Counterfactual log.** For every G1/G2 link on the spine, record what else could have produced the outcome. If the alternative is live, downgrade to G3.
+- **Survivorship check.** Does the narrative follow only the cases that reached the ending? Name the comparable cases that did not, or state that the comparison was not made.
+- **Inevitability ban.** The outcome may not be foreshadowed as certain.
+- **Contemporaneous-knowledge fence.** No actor acts on information post-dating their action.
+
+**Verb creep is the failure.** Grades get assigned honestly at outline stage, then a line-editing pass upgrades the verbs for punch: G4's "then" becomes "which forced", G3's "appears to have" becomes "did". The structural document still says G3/G4 and no longer describes the text. Treat causal verbs as protected tokens carrying their grade. Any line edit changing a causal verb must re-cite the grade.
+
+**Secondary-source guard.** A G1 mechanism tag may not come from a purely secondary retrospective account. If the material is books, articles, and retrospectives, the halo and the teleology were already applied upstream, and you will faithfully re-derive them while passing every other check. Record per source: primary/contemporaneous or secondary/retrospective.
+
+## Numbers in Narrative
+
+Quantitative fidelity is owned by `numbers-in-narrative` — precision ceiling, rounding drift, hedge words as precision claims, denominators, percent versus percentage point, contested figures, ranges, and model output versus measurement all live in its Fidelity Refusals. Run that skill on any passage carrying figures; do not restate its rules here.
+
+## Chronology Audit
+
+Run on the diff between the master timeline and the narrative order.
+
+- Is there a master timeline, held separately from the narrative order, with explicit date-precision tags (exact / day / week / month / quarter / year / "before X" / unknown)?
+- Every reordering: does the text give a date anchor at the seam?
+- Any compression of duration? Forbidden in analytic and journalistic registers. Disclosure-only in memoir register. Never silent.
+- Any two events merged into one scene? Always forbidden. That is a composite scene, not a compression.
+- Any event placed at a time the record does not support?
+- Does any sentence imply finer date precision than the timeline records?
+- After reordering, does narrative adjacency imply a causality that reality's order does not?
+- Did any temporal anchor get deleted during line editing?
+- Does any actor act on information that post-dates their action?
+- Does the piece foreshadow the outcome as inevitable using knowledge unavailable at that point in the timeline?
+
+## Proportion and Omission
+
+The expensive checks. They are the ones that matter, and they are the ones that get dropped under schedule pressure. Implementing only the cheap per-sentence checks produces work that is *more* dangerous than unchecked work, because it carries verifiable citations and reads as audited.
+
+**Proportion audit:**
+
+1. Build a table: for each claim in the piece, WORDS SPENT, EVIDENCE TIER, and CAUSAL WEIGHT (your estimate of contribution to the outcome).
+2. Fill the causal-weight column **before** the arc was chosen where possible. Weight estimated afterwards is contaminated by the same halo the audit exists to catch.
+3. Flag every claim in the top quintile by words and the bottom quintile by evidence tier. These are the colourful anecdotes carrying the reader's belief.
+4. Flag the inverse: top quintile by causal weight, bottom quintile by words. These are the boring drivers the arc suppressed. Usually a price change, a regulatory filing, a base rate, a demographic trend, a compiler flag, a staffing level.
+5. Require a written justification for each flagged asymmetry. "This account gets 800 words because it is the only surviving first-hand record of the mechanism" is legitimate. No justification means rebalance.
+6. **Do not equalise mechanically.** The output is a justification requirement, not a word-count quota. Redistributing word count produces prose with the rhythm of a spreadsheet, and readability collapse is itself an accuracy failure, because unread accurate work informs nobody.
+
+**Omission check:** list every item in the corpus appearing nowhere in the draft. For each, state why. Any item that would weaken the spine and was omitted without justification is a cherry-pick and must be reinstated.
+
+## Subtraction Log Format
+
+Refusal training makes you good at not adding. Nothing makes you good at not omitting. A perfectly constrained agent produces an entirely sourced, entirely false piece by cutting the disconfirming quarter, the failed pilot, and the dissenting source — each cut individually defensible for length or flow.
+
+Log every cut that removes a contradicting data point, a dissenting source, a failed instance, a counterexample, or a period that went the other way.
+
+```
+| ID | What was cut | Which way it cut | Stated reason | Direction relative to the spine |
+```
+
+**Review the log as a SET, not per edit.** Per-edit review always passes; that is the entire problem. Two questions:
+
+1. Do the cuts share a direction? If every removal happens to weaken the counter-case, the reason "length" is not the real reason.
+2. Does the remaining text imply a different frequency, magnitude, or balance than the full record? If yes, the subtraction has become deception and must be reversed or offset.
+
+**The absence of a subtraction log is itself a finding.** Report it as such: a piece assembled without one cannot pass this step, and the correct verdict is RETURN TO RESEARCH.

--- a/skills/narrative-fidelity-audit/resources/bright-lines.md
+++ b/skills/narrative-fidelity-audit/resources/bright-lines.md
@@ -1,0 +1,188 @@
+# The Bright Lines
+
+Hard refusals for fact-based narrative, with worked bad/good pairs. Sources: Roy Peter Clark's two axioms (Do Not Add, Do Not Deceive) and his ten-rule "Vow of Chastity"; Mark Kramer's "Breakable Rules for Literary Journalists" covenant. Where a rule below is a working default rather than a published standard, it says so.
+
+## Table of Contents
+- [The Higher-Truth Rationalization](#the-higher-truth-rationalization)
+- [Line 1: Invented dialogue](#line-1-invented-dialogue)
+- [Line 2: Unsourced interior state](#line-2-unsourced-interior-state)
+- [Line 3: Composites](#line-3-composites)
+- [Line 4: Compressed and merged events](#line-4-compressed-and-merged-events)
+- [Line 5: Invented sensory detail](#line-5-invented-sensory-detail)
+- [Line 6: Numbers not in the sources](#line-6-numbers-not-in-the-sources)
+- [Line 7: Causation above the evidence](#line-7-causation-above-the-evidence)
+- [Line 8: The contemporaneous-knowledge fence](#line-8-the-contemporaneous-knowledge-fence)
+- [Line 9: Silently resolved source conflicts](#line-9-silently-resolved-source-conflicts)
+- [Lines 10 to 14](#lines-10-to-14)
+- [Aggregates: the one legal cousin of the composite](#aggregates-the-one-legal-cousin-of-the-composite)
+- [Breach disposition table](#breach-disposition-table)
+
+## The Higher-Truth Rationalization
+
+This is the most important section in the file. When a beat cannot be filled and the piece is otherwise strong, you will generate a reason to fill it anyway. The reason will not feel like a rationalization. It will feel like editorial judgment. An unnamed rationalization is indistinguishable from a good reason, so here is the catalogue.
+
+Treat any of these as an automatic refusal trigger, not an argument to weigh:
+
+| The thought | What it actually means |
+|---|---|
+| "This is clearly what happened." | No source says it happened. |
+| "The reader will understand this is illustrative." | The reader experiences the body text, not your intent. |
+| "This is emotionally accurate even if the details aren't." | You have chosen fiction and are calling it truth. |
+| "It's a reasonable inference." | Then mark it as an inference, in the body, next to itself. |
+| "Any writer would fill this in." | Fabrication is common. That is not a defence. |
+| "Removing it makes the piece worse." | Correct. A worse true piece beats a better false one. |
+| "It's a small detail, not the argument." | The small details are what make the argument feel observed. |
+| "I'll flag it in the notes." | Flagged drafted text survives review at high rates. |
+| "The subject is dead / the firm is defunct, so nobody is harmed." | The reader is harmed. |
+| "The alternative is a boring chronicle." | The alternative is the named-absence beat, which is not boring. |
+
+John D'Agata's public defence of this position — that accuracy and truth diverge, and truth wins — is the exact reasoning to expect internally. Clark names it and forbids it.
+
+## Line 1: Invented dialogue
+
+**Refuse** quotation marks around any string not verbatim in a recording, transcript, contemporaneous written record, or your own direct capture.
+
+Remembered conversation gets rendered without quotation marks and marked as remembered. Clark's convention uses dashes or paraphrase.
+
+- BAD (post-mortem): `"We should have rolled back an hour ago," the on-call engineer said.`
+- GOOD: `The on-call engineer recalled arguing for a rollback well before the decision was made.`
+- GOOD (if the channel log exists): `At 02:41 he wrote in the incident channel: "rolling back now, this is not converging."`
+
+- BAD (supply chain): `"There's no container coming," the plant manager told the line supervisors that morning.`
+- GOOD: `The morning shift briefing, recorded in the plant log, listed no inbound container.`
+
+- BAD (biography): `"You've never once asked me what I wanted," she told him.`
+- GOOD: `In her account, given forty years later, she told him he had never asked what she wanted.`
+
+## Line 2: Unsourced interior state
+
+**Refuse** to attribute a thought, feeling, belief, motive, worry, intention, or realization to a real person without a sourced statement, and refuse to attribute intent to a system.
+
+Kramer: no attribution of thoughts to sources unless the sources have said they'd had those very thoughts.
+
+- BAD (market history): `By the summer the market realized the inventory glut was structural.`
+- GOOD: `Between June and September, four of the six largest buyers cut forward orders. Two cited a structural glut in their quarterly calls.`
+
+- BAD (ML writeup): `The team knew the eval set was contaminated and pushed ahead anyway.`
+- GOOD: `The contamination check appears in the repository on 14 April. The training run started on 9 April and was not halted.`
+
+- BAD (institutional history): `The agency wanted to preserve its budget above all.`
+- GOOD: `The agency's submitted budget grew in each of the six years, and its published priorities placed the program above three programs it later cut.`
+
+**System variant.** "The market realized", "Intel decided", "the protocol wanted", "the codebase assumed", "the supply chain panicked" are hidden causal claims. Each either misleads the reader about agency or smuggles in an unsourced claim about collective intent. Rewrite as an aggregate of documented actor behaviour, or mark it explicitly as shorthand at first use and never again. An audit that checks facts but not intentionality verbs will pass a piece that is wrong in its every load-bearing sentence.
+
+## Line 3: Composites
+
+**Refuse** to merge two or more real people, firms, incidents, or datasets into one entity presented as singular. Not for privacy. Not for concision. Not for narrative economy.
+
+Composite characters are a technique of fiction with no place in journalism. If privacy requires protection, anonymize — "a senior engineer, who asked not to be named" — never fuse. Pseudonyms are themselves a deviation requiring disclosure, and Clark's stricter rule bars fake names entirely.
+
+- BAD (user research): `Maria, a mid-market buyer, evaluates three vendors and abandons the process after the security review.` (Maria is four interviewees.)
+- GOOD: `Three of the eleven mid-market buyers abandoned evaluation at the security review. One, who asked not to be named, described the review as "the point where it stopped being worth it."`
+
+- BAD (clinical narrative): `A typical patient presents at 62 with a six-month history and no family record.`
+- GOOD: `The median age at presentation was 62. Six of the nineteen had no family record. No single patient in the cohort had all the modal features.`
+
+## Line 4: Compressed and merged events
+
+**Refuse** to compress or expand duration. **Refuse** to merge separate events into one scene, always. Merging is a composite scene, not a compression.
+
+Reordering is different and is permitted: tell events out of sequence with durations intact, provided the text gives the reader a date anchor at the seam. Every flashback and flash-forward opens with a temporal marker.
+
+- BAD (incident narrative): `The three escalation calls that week became increasingly urgent.` rendered as one call.
+- GOOD: `Three escalation calls took place between Tuesday and Friday. The Friday call is the only one with a recording.`
+
+- BAD (product history): `Over the following week the team rebuilt the pipeline.` when the record shows eleven weeks.
+- GOOD: `The rebuild took eleven weeks, from the 3 February branch to the 22 April merge.`
+
+**Protected tokens.** Temporal anchors are non-deletable. A later line-editing pass may reword an anchor but may not remove it. Anchors read as clunky, so they are exactly what a "tighten this up" pass strips, after which the whole piece silently flattens into one present tense and the reader mis-dates the causality.
+
+## Line 5: Invented sensory detail
+
+**Refuse** weather, light, sound, clothing, gesture, room contents, physical sensation, time of day. If it is not in the record it does not exist, no matter how safe it seems.
+
+This is the line an automated writer crosses most often, because scene craft rewards exactly what documentary sources lack. Every individual addition looks like good writing.
+
+- BAD (market history): `On a grey Tuesday morning in the Frankfurt office, the desk watched the bid evaporate.`
+- GOOD: `The bid fell 40% between 09:12 and 09:19 Frankfurt time, according to the exchange tape.`
+
+- BAD (science writing): `She looked again at the gel, the hum of the cold room behind her, and saw the second band.`
+- GOOD: `The lab notebook entry for 6 March records a second band and is circled twice.`
+
+**System variant.** In technical and quantitative registers the equivalent of invented sensory detail is the undated metric: a number in a scene with no source, no unit, no date, and no definition. Treat it identically.
+
+## Line 6: Numbers not in the sources
+
+**Refuse** any figure the sources do not contain. This includes converting a qualitative quantifier into a numeral, and exceeding the source's precision.
+
+- BAD: source says "several suppliers" → draft says "six suppliers".
+- BAD: source says "roughly a third" → draft says "33.4%".
+- GOOD: source says 23.7% → "about a quarter" is fine; "23.74%" is a fabrication.
+
+Full numeric handling — rounding drift, digit budget, denominators, percent versus percentage point, ranges — lives in [audit-passes.md](audit-passes.md#numbers-in-narrative).
+
+## Line 7: Causation above the evidence
+
+**Refuse** a causal verb whose grade the evidence does not support, and refuse to describe an outcome as inevitable when no contemporaneous source did.
+
+Delete every "was always going to", "inevitably", "the writing was on the wall" not attributed to a source writing at the time. The grade table and permitted verb sets are in [audit-passes.md](audit-passes.md#causal-grades).
+
+- BAD (supply chain): `The port closure forced the plant shutdown.` when the only evidence is that one followed the other.
+- GOOD: `The port closed on 9 March. The plant stopped the line on 21 March. The shutdown notice does not name the port closure.`
+
+## Line 8: The contemporaneous-knowledge fence
+
+**Refuse** to show any actor acting on information that post-dates their action. This single check kills most hindsight contamination.
+
+- BAD (post-mortem): `Knowing the retry storm was coming, the team raised the timeout.` The retry storm was diagnosed two days later.
+- GOOD: `The team raised the timeout at 02:58. The retry storm was not identified until the 14 March review.`
+
+State explicitly what a contemporaneous participant could not have known. System narratives are where hindsight contamination is hardest to see and does the most damage.
+
+## Line 9: Silently resolved source conflicts
+
+**Refuse** to pick one value when two sources disagree. Both values, both sources, one sentence. Never average.
+
+- BAD: `Adoption reached 40%.`
+- GOOD: `The company put adoption at 40%; the regulator's audit found 27%.`
+
+## Lines 10 to 14
+
+**Line 10 — false precision.** No sentence may imply a date, time, or place precision finer than the record carries. Source says "in the spring"; the scene may not open "on a Tuesday in April".
+
+**Line 11 — circular citation.** Your own prior drafts, notes, summaries, and recollection are never a source. Check this mechanically by resolving pointers, not by reading. It is invisible to reading, and no single agent in a pipeline has to do anything wrong for it to happen.
+
+**Line 12 — the verb.** Never write that anything was "verified", "fact-checked", or "confirmed" by this pass. It was sourced. The failure mode of the false claim is worse than no checking at all, because unchecked output at least looks unchecked.
+
+**Line 13 — boilerplate disclaimers.** "Some events have been compressed and some dialogue recreated" is refused in both directions: as a lie when nothing was compressed, and as too vague to be a disclosure when something was. Generate the note from the deviation log. See [disclosure-and-reporting.md](disclosure-and-reporting.md).
+
+**Line 14 — the higher-truth argument.** See the catalogue at the top of this file.
+
+## Aggregates: the one legal cousin of the composite
+
+Analytical domains legitimately need aggregates: the representative fab, the median advertiser, the typical incident, the modal patient. The rule is not "no aggregates". It is that an aggregate may never acquire the properties of an individual.
+
+**Permitted** if labelled at first use and constructed transparently: "a representative 200mm fab", "the median customer in this cohort", "an aggregate built from the twelve incidents in the dataset".
+
+**An aggregate may not:** take a proper name; appear in a scene; be given dialogue; be given interiority or intent; be given a specific date or location; be described with sensory detail. The moment an aggregate gets a Tuesday and a phone call it has become a fabricated character.
+
+**Property check:** every property attributed to the aggregate must hold for the aggregate as computed. It may not be a union of properties from different members. A median firm does not have the largest member's revenue and the smallest member's headcount.
+
+**Persistent marker.** Aggregates carry a marker through the whole piece. Any scene-level verb attached to one is a hard defect. The characteristic failure: the aggregate is honestly labelled at first use, then over ten pages accretes a founding date, a CEO's temperament, and a decisive meeting, because narrative wants a character and the aggregate is standing in the character slot. The disclosure is thirty paragraphs back and the reader is now reading fiction.
+
+If the piece needs a single vivid exemplar, find a real one and name it, or accept the aggregate's flatness. Refuse the third option.
+
+## Breach disposition table
+
+Every breach gets exactly one of four dispositions, recorded.
+
+| Disposition | When | Example output |
+|---|---|---|
+| **DELETE** | The sentence exists only because it sounded right | Cut. No replacement needed. |
+| **DOWNGRADE** | A real claim is dressed above its evidence | "forced" → "then"; "she knew" → "she later said she suspected"; "33.4%" → "about a third" |
+| **DECLARE** | The gap is structural and the absence is honest material | "The record is silent on why the threshold was set at 40%." |
+| **RESEARCH** | A specific, answerable question would close it | "Any contemporaneous statement by X between 1 and 30 March about the yield target." |
+
+There is no fifth disposition. "Draft it and flag it for review" does not exist here. Flagged drafted text survives review at high rates, because it reads well and the reviewer is checking rather than rewriting.
+
+**Budget rule (working default, not a published figure):** at most one inference-filled slot per piece, and never at the climax. If two or more major slots are empty, the material does not have this shape — change the architecture rather than spending more disclosure budget.

--- a/skills/narrative-fidelity-audit/resources/disclosure-and-reporting.md
+++ b/skills/narrative-fidelity-audit/resources/disclosure-and-reporting.md
@@ -1,0 +1,156 @@
+# Disclosure and Reporting
+
+How the note on sources gets generated, where disclosures must sit, and what the gate report looks like.
+
+## Table of Contents
+- [The core rule](#the-core-rule)
+- [Note-on-sources generator](#note-on-sources-generator)
+- [Worked example: a clean piece](#worked-example-a-clean-piece)
+- [Worked example: a piece with deviations](#worked-example-a-piece-with-deviations)
+- [Placement rules](#placement-rules)
+- [The inversion check](#the-inversion-check)
+- [Gate report template](#gate-report-template)
+
+## The core rule
+
+**Generate the disclosure FROM the deviation log. Never write it in advance.**
+
+Disclosure describes an already-honest method. It does not purchase deviations. The apparatus must never become negotiable — "we'll note that dialogue was recreated, so we can recreate dialogue" is the inversion, and once it happens the whole system is a laundering machine.
+
+Boilerplate disclaimers are worse than nothing in an automated pipeline. They are cheap to emit, they pre-authorize the deviations, and they make the reader believe a human weighed a trade-off that nobody weighed.
+
+## Note-on-sources generator
+
+Produce the six sections in this order. Each is generated from a log, not composed.
+
+**1. SCOPE OF EVIDENCE** — what the account is built from. Document types, counts, date ranges, datasets, interviews, direct observation. Specific, not gestural.
+
+- BAD: "This account draws on extensive research including public filings and interviews."
+- GOOD: "This account draws on 14 quarterly filings (FY19–FY23) and the incident timeline kept by the on-call rota. It also uses 31,000 rows of shipment data from the customs feed (Jan 2021–Mar 2024), plus recorded interviews with six of the eleven people named."
+
+**2. RECONSTRUCTION STATEMENT** — which passages are reconstructed rather than observed, and from exactly what.
+
+- GOOD: "The account of the March review is reconstructed from the minutes, two participants' contemporaneous notes, and interviews with three attendees. No recording exists."
+
+**3. DEVIATION REGISTER** — one line per deviation, generated from the chronology, composite, and empty-slot logs. **If the register is empty, say so affirmatively.** G. Wayne Miller's model sentence is the positive template: "This is entirely a work of nonfiction; it contains no composite characters or scenes, and no names have been changed. Nothing has been invented."
+
+**4. UNCERTAINTY REGISTER** — what the account could not establish; where sources conflicted and how that was handled; what a contemporaneous observer could not have known.
+
+**5. INTERESTS AND ACCESS** — funding, access arrangements, prior relationships, anything given in exchange, editorial control conceded. For analytical and financial domains: positions held, client relationships, and any data supplied by an interested party.
+
+**6. AI DISCLOSURE** — state that drafting was machine-assisted. State that provenance was human-checked **only if it actually was**. Do not write that anything was verified. The apparatus tracks provenance; it does not verify.
+
+## Worked example: a clean piece
+
+Deviation log empty. Post-mortem of a systems incident.
+
+> **On sources.** This account is built from the incident channel transcript (02:04–07:52 UTC, 11 March), the service's own alert log, and the two deploy records covering the window. It also draws on recorded interviews with four of the six responders, conducted 18–22 March.
+>
+> Nothing here is invented. There are no composite people, no composite scenes, and no names have been changed. Every quoted string appears verbatim in the transcript or in a recorded interview; where a responder described their reasoning at the time, the text says so rather than narrating it directly.
+>
+> Three things the account could not establish. Who first proposed the rollback: the channel shows the decision, not the proposal. Whether the 02:41 config change was applied before or after the failover: the two logs disagree by roughly ninety seconds, and both timestamps appear in the text. And what the on-call engineer's escalation path was: the rota document for that week was not retained.
+>
+> Drafting was machine-assisted. Source pointers were checked by a human against the original artefacts.
+
+Note what this does: the deviation register is *affirmatively empty*, the uncertainty register is specific, and the conflicting timestamps are named rather than resolved.
+
+## Worked example: a piece with deviations
+
+Market history where one anonymization was needed.
+
+> **On sources.** [Scope paragraph.]
+>
+> Two departures from standard practice. One source is identified only as "a former desk head at one of the three clearing banks", at their request; the description is accurate and no details have been altered to obscure them further. And the sequence in the second section is told out of chronological order — the 2019 filing is discussed before the 2017 acquisition that produced it. Both dates are given at the seam and no duration has been compressed.
+>
+> There are no composite entities in this piece. No dialogue has been recreated.
+
+Note what this does *not* do: it does not say "some events have been compressed and some dialogue recreated". It names exactly two deviations, both of which happened, and affirmatively denies the categories that did not occur.
+
+## Placement rules
+
+**Anything that changes how the reader should read the text goes at the FRONT.** Routine sourcing detail may go at the back.
+
+**Any inference, conjecture, reconstruction, or empty-slot fill occupying a structural slot must be disclosed within two sentences of itself, in the body, in the same typographic register as the surrounding prose.** Disclosure confined to endnotes, footnotes, an appendix, or a methods block is functionally undisclosed. Readers experience the body.
+
+This is the disclosure that degrades. Under a "tighten this up" or "make it flow" instruction, the disclosure sentence is the first thing an editing pass removes, or it drifts to the back matter — restoring exactly the false impression the protocol existed to prevent. Mark those sentences non-removable, or carry them as annotations the renderer is required to emit. Assume any later pass will strip them unless they are structurally protected.
+
+**Budget.** Cap the total hedges, contingency nodes, and disclosure sentences per thousand words. When the budget binds, that is a signal to change the architecture, not to spend more budget. A piece that is sixty percent epistemic apparatus and forty percent subject is unreadable and misleading in a new way: it makes the analyst's uncertainty the story. (The specific cap is a project decision; there is no published figure.)
+
+## The inversion check
+
+Run this last, and run it honestly.
+
+**Was any entry in the deviation register decided BEFORE the corresponding passage was drafted?**
+
+If yes, the apparatus has inverted. The note stopped describing the method and started licensing it. The piece needs re-reporting, not re-noting. Report `INVERSION CHECK: fail` and block.
+
+Symptoms:
+- The note on sources exists in the working directory before the draft does.
+- A deviation register entry is phrased in the future or conditional ("dialogue may be reconstructed where transcripts are unavailable").
+- The register uses category language rather than instance language. Real entries name the specific passage and the specific deviation.
+
+## Gate report template
+
+Emit verbatim. Every field, every run.
+
+```
+NARRATIVE FIDELITY AUDIT — <piece title>
+This pass SOURCED the draft against the ledger. It did not verify anything.
+
+BASIS
+  Ledger claims:                 n
+  Pointers unresolved:           n
+  Pointers resolving into this pipeline (circular): n
+  Sources annotated with interest as well as date:  n of n
+  Sources that are secondary retrospectives:        n
+
+BRIGHT LINES
+  Breaches:                      n     [must be 0 to clear]
+  By line: 1:n 2:n 3:n 4:n 5:n 6:n 7:n 8:n 9:n 10:n 11:n 12:n 13:n 14:n
+  Dispositions applied:          DELETE n / DOWNGRADE n / DECLARE n / RESEARCH n
+
+INTERIORITY
+  [A] n   [B] n   [C] n   [D] n     [D must be 0 to clear]
+  Sourced-but-hedged defects (over-correction): n
+  Intentionality verbs on systems: n
+
+RED FLAGS
+  Hits: n     Resolved to a pointer and kept: n     Deleted: n
+  (If deleted >> kept, the scan is keying on vividness rather than pointers.)
+
+THREE ALTITUDES
+  Sentence-level defects:  n
+  Paragraph-level defects: n
+  Passage-level defects:   n     [0 across a long piece = pass did not run]
+
+SUBTRACTION
+  Log present:             yes / no        [no = RETURN TO RESEARCH]
+  Cuts logged:             n
+  Set verdict:             pattern found / no pattern
+  Omission check items unjustified: n
+  Proportion asymmetries unjustified: n
+
+HEDGE LOAD
+  Sentences at L3+:        n of n  (n%)
+  Verdict:                 under budget / over budget -> passage under-reported
+
+DISCLOSURE
+  Note on sources:         generated from deviation log / not generated
+  Deviation register:      n entries / affirmatively empty
+  In-body disclosures within two sentences of their claim: n of n
+  Inversion check:         pass / fail
+
+SURFACED FOR HUMAN DECISION (not resolved here)
+  - <real named party in an adversarial structural role, and on what evidence class>
+  - <right-of-reply gaps: adverse specific claims about living people or active institutions>
+
+VERDICT: BLOCKED | RETURN TO RESEARCH | CLEARED AS SOURCED
+```
+
+**Verdict definitions:**
+
+- **BLOCKED** — a bright-line breach, a nonzero [D] count, a circular citation, or a failed inversion check. Not shippable in this form.
+- **RETURN TO RESEARCH** — no bright-line breach, but the evidence does not support the piece: hedge load over budget, subtraction log absent, unjustified omissions, or two or more empty structural slots. The fix is reporting, not editing.
+- **CLEARED AS SOURCED** — every claim traces to a pointer outside this pipeline, the three altitudes ran and produced defects at all three, and the note on sources was generated from the deviation log. This is the strongest verdict available. There is no "verified".
+
+**What this pass does not adjudicate.** Where a real named person or an active institution occupies an adversarial structural role, surface it and stop. Adverse inference about a living person creates real exposure, and a subject who consented to an interview did not consent to a structural role. Quietly softening the language while keeping the structure makes the problem invisible rather than solving it. The same applies to right-of-reply gaps: note them in the report and let a human decide.

--- a/skills/narrative-fidelity-audit/resources/evaluators/rubric_narrative_fidelity_audit.json
+++ b/skills/narrative-fidelity-audit/resources/evaluators/rubric_narrative_fidelity_audit.json
@@ -1,0 +1,104 @@
+{
+  "name": "Narrative Fidelity Audit Rubric",
+  "description": "Evaluation criteria for the quality of a fidelity audit run over a fact-based narrative. Scores the AUDIT, not the draft. An audit that reports a clean draft without evidence of having run the expensive passes scores low regardless of how tidy its output looks.",
+  "criteria": [
+    {
+      "name": "Bright-Line Coverage and Disposition",
+      "description": "Whether all fourteen bright lines were swept, breaches recorded with line references, and each breach given one of the four dispositions (DELETE, DOWNGRADE, DECLARE, RESEARCH) rather than being drafted-and-flagged",
+      "weight": 1.2,
+      "scores": {
+        "1": "No systematic sweep; breaches noted impressionistically or not at all",
+        "2": "Some lines swept; breaches listed without line references or dispositions",
+        "3": "All lines swept; most breaches have a disposition, but some are left as 'flag for review'",
+        "4": "All lines swept, breaches referenced to specific text, every breach dispositioned, no fifth disposition used",
+        "5": "All lines swept with per-line counts; every breach dispositioned with the replacement text or the specific research request written out"
+      }
+    },
+    {
+      "name": "Interiority Provenance Rigor",
+      "description": "Whether every interior-state and intentionality claim (person and system) was tagged [A]/[B]/[C]/[D], the [D] count reported as a number, and the zero-D gate enforced",
+      "weight": 1.2,
+      "scores": {
+        "1": "Interior states not tagged; 'he realized', 'the market decided' pass unchallenged",
+        "2": "Person interiority tagged; system intentionality verbs missed entirely",
+        "3": "Both tagged, [D] count reported, but some [D] items left in the draft with a caveat instead of removed",
+        "4": "Both tagged, [D] count reported as a number, gate enforced, each [D] converted to observable behaviour or attributed speech",
+        "5": "As 4, plus every [B] artefact carries its written alternative reading, and substitutes for unfillable realization beats were chosen and stress-tested by striking untraceable nouns and verbs"
+      }
+    },
+    {
+      "name": "Over-Correction Control",
+      "description": "Whether the audit checked in the other direction: that [A] and [B] material is NOT hedged, that hedge load was measured, and that hedge saturation was diagnosed as under-reporting rather than fixed by deleting attributions",
+      "weight": 1.0,
+      "scores": {
+        "1": "No over-correction check; sourced thought left hedged, or attributions added indiscriminately",
+        "2": "Notices hedging in passing but offers no measurement and no diagnosis",
+        "3": "Hedge load measured; some sourced-but-hedged sentences flagged",
+        "4": "Hedge load measured against a stated budget, all sourced-but-hedged sentences flagged and unhedged, diagnosis of saturation is under-reporting",
+        "5": "As 4, plus red-flag deletions are reported alongside sourced-and-kept counts, demonstrating the scan keyed on missing pointers rather than on vividness"
+      }
+    },
+    {
+      "name": "Multi-Altitude Verification",
+      "description": "Whether the How-Do-You-Know pass ran at paragraph and passage level, not only at sentence level, and whether the absence of higher-altitude defects was treated as evidence the pass did not run",
+      "weight": 1.5,
+      "scores": {
+        "1": "Sentence-level checking only; reports a clean piece",
+        "2": "Paragraph questions nominally asked but produce no findings and no comment on that fact",
+        "3": "Defects found at sentence and paragraph level; passage level thin or skipped",
+        "4": "Defects reported separately at all three altitudes, including implicature, ordering-as-causation, and fairness-to-subject findings",
+        "5": "As 4, plus the audit explicitly states that zero higher-altitude defects would mean the pass did not run, and reports counts per altitude to prove it did"
+      }
+    },
+    {
+      "name": "Subtraction and Proportion",
+      "description": "Whether the subtraction log was assembled and reviewed AS A SET, the omission check listed corpus items absent from the draft, and proportion asymmetries were given written justifications rather than mechanical rebalancing",
+      "weight": 1.5,
+      "scores": {
+        "1": "No subtraction log, no omission check; only additions were policed",
+        "2": "Cuts reviewed individually; each found defensible; no set-level question asked",
+        "3": "Log assembled and reviewed as a set, but no omission check or no proportion table",
+        "4": "Set review asks whether cuts share a direction, omission check lists absent corpus items with reasons, proportion asymmetries flagged",
+        "5": "As 4, plus written justifications required for each asymmetry, causal weights recorded independently of the arc, and the absence of a log reported as a RETURN TO RESEARCH finding"
+      }
+    },
+    {
+      "name": "Provenance Integrity",
+      "description": "Whether pointers were resolved mechanically, circular citations into the pipeline's own outputs caught, sources annotated with interest as well as date, and secondary retrospectives barred from carrying documented-mechanism causal tags",
+      "weight": 1.2,
+      "scores": {
+        "1": "Pointers accepted on sight; no resolution attempted",
+        "2": "Pointers checked by reading; granularity not enforced ('the 10-K' accepted)",
+        "3": "Pointers resolved and granularity enforced; circular-citation check not run mechanically",
+        "4": "Mechanical circular-citation check run and reported; pointer granularity enforced throughout",
+        "5": "As 4, plus per-source interest annotation and primary/secondary tagging, with any G1 mechanism tag sourced from a retrospective downgraded"
+      }
+    },
+    {
+      "name": "Disclosure Discipline",
+      "description": "Whether the note on sources was generated from the deviation log after drafting, boilerplate refused, empty registers stated affirmatively, in-body placement enforced within two sentences of the claim, and the inversion check run",
+      "weight": 1.2,
+      "scores": {
+        "1": "Boilerplate disclaimer emitted, or no note produced",
+        "2": "Note produced but written as prose in advance of the deviation log; generic category language",
+        "3": "Note generated from the log; placement rules not enforced or inversion check skipped",
+        "4": "Generated from the log, empty registers stated affirmatively, in-body placement enforced, inversion check run and reported",
+        "5": "As 4, plus disclosures marked non-removable, hedge/disclosure budget reported, and over-budget treated as a signal to change architecture rather than add caveats"
+      }
+    },
+    {
+      "name": "Vocabulary and Verdict Honesty",
+      "description": "Whether the audit consistently says 'sourced' rather than 'verified', emits the full gate verdict block with no omitted fields, and surfaces rather than resolves questions about named parties in adversarial roles",
+      "weight": 1.3,
+      "scores": {
+        "1": "Claims the draft was 'fact-checked' or 'verified'; no verdict block",
+        "2": "Verdict given informally; verification language appears at least once",
+        "3": "Correct vocabulary; verdict block present but with fields omitted",
+        "4": "Correct vocabulary throughout, full verdict block, CLEARED AS SOURCED used as the strongest available verdict",
+        "5": "As 4, plus named parties in adversarial roles and right-of-reply gaps surfaced for human decision rather than quietly softened in the prose"
+      }
+    }
+  ],
+  "threshold": 3.5,
+  "passing_note": "Average score must be >= 3.5 for the audit to count as run. A score below 3 in 'Multi-Altitude Verification' or 'Subtraction and Proportion' invalidates the audit outright regardless of the average: those are the two passes that catch the fully-sourced-but-false piece, and an audit missing them is more dangerous than no audit, because its output reads as checked."
+}

--- a/skills/narrative-form-triage/SKILL.md
+++ b/skills/narrative-form-triage/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: narrative-form-triage
+description: Decides which narrative form a body of researched material can actually support, before any structure is imposed. Runs a six-question form-triage gate producing STORY NARRATIVE, EXPLANATORY NARRATIVE, MULTI-NODE GATHERING, or DO NOT NARRATE; runs the ABT (And/But/Therefore) spine diagnostic; selects a spine from a thirteen-structure table covering Truby arc, layer cake, pyramid/SCQA, OCAR, PR/FAQ, sparkline, Raskin five-slot, martini glass, drill-down, inverted pyramid and braided/mosaic; and writes an immutable spine contract with a boredom budget. Use before outlining or drafting any long-form nonfiction, report, post-mortem, market history, research writeup or case study, or when user mentions find the narrative, what's the story here, narrative arc, story structure, how should I structure this, does this have a story, or storytelling with data.
+---
+
+# Narrative Form Triage
+
+## Table of Contents
+- [Core Principles](#core-principles)
+- [Workflow](#workflow)
+- [The Six-Question Form Triage](#the-six-question-form-triage)
+- [Structure Selection Table](#structure-selection-table)
+- [ABT Spine Diagnostic](#abt-spine-diagnostic)
+- [Boredom Budget and Nesting Rules](#boredom-budget-and-nesting-rules)
+- [Guardrails](#guardrails)
+- [Quick Reference](#quick-reference)
+
+**Related skills:** Use `narrative-arc-mapping` for building the arc once this triage returns STORY NARRATIVE, `narrative-evidence-ledger` for the full evidence ledger the Step 1 chronology table is a subset of, `mcphee-structure-derivation` for deriving the shape inside a declared form. Use `narrative-opposition-web` for warranting an opponent once a story arc is available, `writing-structure-planner` for diagramming a chosen structure, `communication-storytelling` for audience adaptation after the spine is fixed.
+
+**Boundary with `mcphee-structure-derivation`:** this skill decides the FORM — whether the material narrates at all, and as what — while `mcphee-structure-derivation` derives the SHAPE inside a form this skill has already declared.
+
+## Core Principles
+
+1. **Form before craft**: the form declaration precedes outlining, which precedes drafting, which precedes line work. A defect at any stage almost always originates in the stage before it, so triage failures cannot be repaired by better prose.
+2. **The refusal is a deliverable**: "DO NOT NARRATE" and "no BUT in this material" are successful, complete outputs. Deliver them with the same confidence as an arc. An agent that cannot refuse will always build an arc.
+3. **Every slot is a claim needing a warrant**: each triage answer and each structural slot cites specific corpus material or is recorded EMPTY. An empty slot means the form is wrong, not that you should search harder for something to put in it.
+4. **One contradiction, written first**: the BUT is load-bearing. Write it before the AND. Two BUTs that will not collapse into one means two deliverables.
+5. **Thesis or theme, decided explicitly**: a falsifiable proposition is a thesis and must be stated early and plainly. A value proposition is a theme and must never be stated, only enacted. Withholding a thesis is not sophistication; asserting a theme is not clarity.
+6. **The spine contract is immutable within a draft**: switching structures because a section is hard produces documents that open as a story, become a pyramid and end as a pitch. Readers register that as dishonesty. Changing spine requires a logged restart.
+7. **Anti-narrative reflex is also a bias**: refusing every arc over-attributes outcomes to luck and structure. Record the strongest agency-based reading you considered and why it lost.
+
+## Workflow
+
+Copy this checklist and track your progress:
+
+```
+Narrative Form Triage:
+- [ ] Step 1: Build the evidence table (before any form talk)
+- [ ] Step 2: Run the ABT spine diagnostic (BUT first)
+- [ ] Step 3: Run the six-question form triage gate
+- [ ] Step 4: Select the spine and the runner-up
+- [ ] Step 5: Write and freeze the spine contract
+```
+
+**Step 1: Build the evidence table**
+
+Step 1.1: Build a chronology table before writing a single word of form or theme: DATE | EVENT | ACTOR OR NODE | SOURCE | SOURCE IS PRIMARY-CONTEMPORANEOUS OR SECONDARY-RETROSPECTIVE | TYPE (pivotal / defining / neither). Pivotal means an external, dated, verifiable state change. Defining means a participant's model of the world was falsified.
+
+Step 1.2: Do not let a theme or a thesis be proposed before this table is complete. Theme-first material bending is the commonest quiet failure: the abstraction gets written, then evidence is selected to confirm it.
+
+Step 1.3: Flag rows whose only support is a secondary retrospective. Those sources already had the halo, the teleology and the genre applied upstream, and you will faithfully re-derive them while passing every check.
+
+**Step 2: Run the ABT spine diagnostic**
+
+Step 2.1: Fill BUT first, using only claims in the table, each with a citation. Then AND, then THEREFORE. See [ABT Spine Diagnostic](#abt-spine-diagnostic).
+
+Step 2.2: Classify: zero contradictions (AAA), exactly one (ABT), two or more that will not collapse (DHY). AAA forbids all story structures. DHY requires a split or a disclosed set-aside.
+
+Step 2.3: If you cannot fill BUT without importing a fact not in the corpus, output "NO BUT IN MATERIAL" and stop the story branch. This is a pass, not a failure.
+
+**Step 3: Run the six-question form triage gate**
+
+Step 3.1: Answer each of the six questions YES-with-citation or NO. An answer with no citation is a NO. See [The Six-Question Form Triage](#the-six-question-form-triage).
+
+Step 3.2: Score to one of four forms. Record the failing question numbers alongside the form. The declaration binds every downstream pass.
+
+Step 3.3: For any slot the chosen form requires and the evidence cannot fill, apply the Empty Slot Protocol in [resources/form-triage-gate.md](resources/form-triage-gate.md). Never fill by inference disclosed only in back matter; never fill by invention.
+
+**Step 4: Select the spine and the runner-up**
+
+Step 4.1: Key the [Structure Selection Table](#structure-selection-table) on five facts: contradiction count, person or system subject, obligated or voluntary audience, outcome already known or not, audience hostile or trusting.
+
+Step 4.2: Name the runner-up structure and why it lost. The runner-up is the fallback when a section refuses to fit, and naming it in advance is what stops mid-draft shopping.
+
+Step 4.3: If the subject is a system, apply the system remap in [resources/structure-catalog.md](resources/structure-catalog.md) before adopting any agentic template. Unmapped templates are how prose ends up attributing intent to markets, protocols and institutions.
+
+**Step 5: Write and freeze the spine contract**
+
+Step 5.1: Emit the full contract using the template in [resources/form-triage-gate.md](resources/form-triage-gate.md). Eleven fields are required:
+
+```
+1. Form declaration       5. Thesis-or-theme + its sentence   9. Set-aside log
+2. Failing question nums  6. Boredom budget sentence         10. Rejected agency reading
+3. ABT sentence, cited    7. Nesting declaration             11. Attribution note
+4. Structure + runner-up  8. Empty-slot log
+```
+
+Step 5.2: Freeze it. Downstream passes may not add, remove or reframe claims, and may not change structure. A structural defect discovered later escalates back to a logged re-run of Step 3, never a quiet substitution.
+
+**How to know if the triage is working:**
+
+If working: the contract fits on one page, a reader can predict which sections the draft will contain, and at least some triage runs end in DO NOT NARRATE or a demoted form.
+
+If not working: every corpus somehow turns out to contain a story, contracts are written after drafting, or the boredom-budget line is missing (which means no structure was actually chosen).
+
+Validate using [resources/evaluators/rubric_narrative_form_triage.json](resources/evaluators/rubric_narrative_form_triage.json). **Minimum standard**: Average score >= 3.5.
+
+## The Six-Question Form Triage
+
+Answer each YES-with-citation or NO. No citation means NO. These mechanize the story-versus-explanatory distinction Jack Hart draws in *Storycraft* chapters 11 to 13; the six-question form and its scoring are a derived instrument, not a gate Hart publishes. Do not cite "the Oregon Method" as a codified canon — it is a retrospective label for a newsroom practice, not a named system.
+
+| # | Question | Fails when |
+|---|----------|-----------|
+| 1 | Is there a single continuous entity, person or system, whose state is tracked start to finish? | The material is a set of independent findings |
+| 2 | Does that entity want something specific and reachable, documented in the record? | Motive is inferred from outcome |
+| 3 | Is there a dated, sourced rupture of the status quo? | The "inciting incident" is only visible in hindsight |
+| 4 | Do you hold a continuous sourced action sequence, granular enough that at least three moments could be rendered as scenes? | You have conclusions, not events |
+| 5 | Is there an evidenced point of insight, a moment the entity or its participants saw the world differently? | You can name it but nobody's behavior changed after it |
+| 6 | Is there a resolution: a new stable state? | The situation is ongoing |
+
+**Scoring:**
+- YES to 1-6 → **STORY NARRATIVE**. Build the arc.
+- YES to 1-4, NO to 5 and/or 6 → **EXPLANATORY NARRATIVE**. You have an action line and no transformation. Use the action line as a spine to hang explanation on. Do not manufacture a climax.
+- YES to 1-2 only, or the action sequence is discontinuous → **MULTI-NODE GATHERING**. 3-5 nodes, all instantiating the same causal verb.
+- NO to 4 → **DO NOT NARRATE**. Write analytical prose with narrative texture (a concrete opener, specific detail) and no arc. Say so explicitly in the plan.
+
+Question 5 has a hard evidential test: a point of insight exists only if behavior demonstrably changed after it, with a source. Otherwise record "NO POINT OF INSIGHT" and downgrade the form. Promoting the largest number in the dataset or the most recent event into a turning point is the single most common way an honest analysis becomes a false dramatic claim.
+
+## Structure Selection Table
+
+Key on: contradiction count (AAA/ABT/DHY), subject (person or system), audience (obligated or voluntary), outcome (known or not), audience stance (trusting or hostile). Full slot lists, system remaps and worked examples across market history, ML writeups, incident review, supply chain, biography and policy live in [resources/structure-catalog.md](resources/structure-catalog.md).
+
+| Structure | Select when | Boredom permitted | Refuse when |
+|-----------|-------------|-------------------|-------------|
+| **Truby / full story arc** | ABT + person subject + documented desire + warranted opponent + documented change of state + outcome unknown to audience | Nowhere; exposition must be blended | Any of the four evidence conditions is missing |
+| **Explanatory narrative (layer cake)** | ABT + system subject + a followable action line + voluntary audience + dense material | Inside a digression a preceding scene paid for, up to that scene's length | No action line exists (a traveling unit that touches 4+ nodes) |
+| **Pyramid / SCQA** | Obligated audience must decide; or AAA material; or outcome already known | Below the key line only | The governing thought is not falsifiable in one sentence |
+| **OCAR / LDR** | Peer or technical audience, empirical claim, authority comes from method | In Action (methods, results); O, C and R must survive alone | Deleting the Action still leaves a finding — that means there was no Challenge |
+| **PR/FAQ (working backwards)** | Obligated audience, subject does not exist yet, decision is go/no-go | Nowhere in the body; density exiled to appendices | No internal-FAQ answer materially weakens the proposal |
+| **Duarte sparkline** | Audience must act and feel; a change is already underway they half-believe | Nowhere; any stretch without an oscillation is a leak | The "what is" beats are one problem in several costumes |
+| **Raskin five-slot** | Audience must be repositioned; the audience is the protagonist; no human protagonist in the material | Nowhere before the evidence slot | The enemy slot can only be filled by a named party whose intent is undocumented |
+| **Martini glass** | Reader must understand before exploring; a dataset, model or appendix is attached | After the handoff, at the reader's discretion | The stem lacks a stated thesis and stated limitations |
+| **Drill-down** | Reader arrives with their own case and wants to find themselves in the data | Everywhere outside the entry frame | The reader could reach a wrong opposite conclusion unaided |
+| **Inverted pyramid** | Reader may exit at any point without penalty; outcome already known | Increasingly, top to bottom | The material's value depends on accumulation |
+| **Braided / mosaic (gathering)** | 3-5 nodes, no single spanning entity, all sharing one causal verb | At node boundaries only | Node 4 proves nothing node 1 did not — then it is a list, format it as one |
+| **Chronicle** | Two or more major structural slots are empty and the record is genuinely thin | Throughout, by design | You are using it to avoid taking a position you have evidence for |
+| **Taxonomy** | Independent findings, no causal chain, DHY that will not collapse | Within categories | You are hiding a real contradiction behind categories |
+
+Cross-cutting overrides:
+- **Outcome already known to the audience** (quarterly results, a published finding, a shipped incident): all suspense structures are wasted. Lead with the answer.
+- **Hostile or low-trust audience**: use inductive grouping, which is failure-tolerant, and put evidence before conclusion. A deductive chain hands a hostile reader one link to break.
+- **Independent findings with no causal chain**: an arc here fabricates causality. That is a correctness failure, not a style choice.
+
+## ABT Spine Diagnostic
+
+One sentence: `___ AND ___, BUT ___, THEREFORE ___.` Randy Olson's framework; the Narrative Spectrum bands (AAA / ABT / DHY) are his.
+
+Procedure, in this order:
+1. **BUT first.** Skip AND entirely on the first pass. Ask "why has this not already been solved?" — the answer is usually the real BUT.
+2. **Check the causal level.** Is the contradiction the proximate harm or the condition that permits it? Test both; keep the level at which the THEREFORE is actionable.
+3. **Then AND**, with two elements: an uncontested status quo, and what is at stake stated as a number or a named consequence, never "X is important."
+4. **WHAT before HOW.** Good: "the fleet lost 40% of its capacity in eleven weeks, through three unrelated failures." Bad: "three unrelated failures across eleven weeks cost the fleet 40% of its capacity." Analytical writers default to the wrong order because they were trained to show method before result.
+5. **Citation per slot.** A slot with no corpus citation is empty; the material is AAA.
+6. **Truth check.** The ABT is a form test, not a truth test. Olson is explicit that the form is identical on either side of a true/false divide. A well-formed ABT makes a false claim more persuasive, so structural scoring must always be paired with a claim-to-citation audit.
+
+**Worked contrast (post-mortem):** AAA — "The service scaled AND we added regions AND latency rose." No contradiction; this is a status report, route to inverted pyramid. ABT — "The service hit its latency target every month AND the team added three regions, BUT the target measured a p99 that excluded the retry path, where 80% of user-visible delay lived, THEREFORE redefine the target before adding capacity." One contradiction, cited, actionable.
+
+## Boredom Budget and Nesting Rules
+
+**Boredom budget.** Name the structure, then state in one sentence where it permits the reader to be bored. If you cannot, you have not chosen a structure — you have chosen a label. Per-structure rules are in the selection table above. Then mark every consecutive run of undramatized evidence longer than three paragraphs; each must sit in a permitted zone, or be moved to an appendix, compressed to claim-plus-citation, or paid for with a scene. Measure the distance from document start to the first statement of the governing thought: more than one screen of evidence before it means the budget has already failed.
+
+**Nesting rules.** A story scene may nest inside an explanatory spine at any depth. An explanatory spine may nest inside a story at **one level only** — the nut graf. Deeper nesting is structure-shopping wearing a disguise.
+- Every nested scene must be an instance of a specific claim stated within two paragraphs of it. If the scene could be swapped for a different scene without changing any claim, it is decoration; cut it.
+- Attach each digression to the moment the reader feels the lack, not where the information is logically prior, and never before tension exists.
+- The nut graf arrives before the reader decides whether to continue, states stakes and claim rather than scope, and never appears in a story narrative at all.
+- Label every opening anecdote's position in the corpus distribution: median, tail or unique. Do not open with a tail case unless the piece is about the tail.
+
+## Guardrails
+
+**Requirements:**
+1. **Citation per triage answer**: six questions, six answers, each YES carrying a specific corpus reference. Uncited YES is NO.
+2. **Refusal outputs are first-class**: DO NOT NARRATE, NO BUT IN MATERIAL, and NO POINT OF INSIGHT are delivered as findings with reasons, never softened into a weaker arc.
+3. **Empty slots change the form**: at most one inference-filled slot per piece, never at the climax, and its disclosure lives in the body within two sentences of the inference, in the same typographic register. Endnote-only disclosure is illegal.
+4. **Opponent warrant before any antagonist**: competition, awareness and directed action, each documented. Two of three makes a rival, one or zero makes environmental pressure with no verbs of intent. For system subjects the slot takes a binding constraint, a regulatory regime, a physical limit or a countervailing incentive.
+5. **Set-aside log**: when DHY material is reduced to one contradiction, name the contradictions dropped and why. Distinguish evidence that merely failed to support the spine from evidence that contradicted it; the second category is always surfaced to the reader.
+6. **Immutable spine**: no structural change within a draft. Escalate for a logged restart.
+7. **Attribution honesty**: cite Olson for ABT, Minto for the pyramid, Schimel for OCAR, Duarte for the sparkline, Raskin for the five slots, Segel and Heer for martini glass and drill-down, Hart for the story/explanatory distinction. Do not attribute the six-question instrument, the numeric thresholds, or "the Oregon Method" to Hart.
+
+**Common pitfalls:**
+- Declaring a form and then drifting back into arc language ("the crisis reached its climax") in a piece that has no climax.
+- Choosing the opening anecdote for vividness, generalizing from it in the nut graf, and letting the body's evidence describe a different distribution.
+- Anthropomorphizing the subject. Systems have states, constraints and incentives; only people have wants. "The market decided" smuggles in a causal claim the analysis has not established.
+- Crowning a modest finding with universal significance. A piece is allowed to mean something small.
+- Treating the tests as delete rules. They are label-and-disclose devices; an agent that gates on all of them ships chronicles, and chronicles inform nobody.
+- Passing every per-sentence check while misrepresenting proportion through selection and emphasis alone. Word count against evidentiary weight is the expensive check and the one that matters.
+- Producing a document that scans as rigorous because the headings are parallel. Run the read-through test: strip everything but the headlines and read them in sequence.
+
+## Quick Reference
+
+**Key resources:**
+- **[resources/form-triage-gate.md](resources/form-triage-gate.md)**: six-question gate with worked runs, ABT development card, Empty Slot Protocol, refusal catalogue, spine contract template, thesis-vs-theme adjudication
+- **[resources/structure-catalog.md](resources/structure-catalog.md)**: all thirteen structures with slot lists, system remaps, boredom rules, failure signatures and cross-domain worked examples
+- **[resources/evaluators/rubric_narrative_form_triage.json](resources/evaluators/rubric_narrative_form_triage.json)**: quality scoring
+
+**Inputs required:**
+- The assembled corpus, with sources
+- Audience: obligated or voluntary, trusting or hostile, and what they must do (decide, understand, act)
+- Whether the outcome is already known to the audience
+- Medium constraints: can the reader exit early, can the reader explore afterwards
+
+**Outputs produced:**
+- Chronology table with source-type flags
+- Form declaration with failing question numbers
+- ABT spine sentence with a citation per slot, or an explicit NO BUT IN MATERIAL
+- Spine contract: structure, runner-up and why it lost, thesis-or-theme, boredom budget, nesting declaration
+- Empty-slot log, set-aside log, rejected agency reading, attribution note

--- a/skills/narrative-form-triage/resources/evaluators/rubric_narrative_form_triage.json
+++ b/skills/narrative-form-triage/resources/evaluators/rubric_narrative_form_triage.json
@@ -1,0 +1,102 @@
+{
+  "name": "Narrative Form Triage Rubric",
+  "description": "Evaluation criteria for a form-triage run and the spine contract it produces. Scores the gate, not the eventual prose. Minimum standard: average >= 3.5.",
+  "criteria": [
+    {
+      "name": "Gate Ran Before Structure",
+      "description": "Whether the six-question triage and the ABT diagnostic were completed on the assembled evidence before any structure, theme or outline was proposed",
+      "weight": 1.3,
+      "scores": {
+        "1": "No gate; a structure was chosen or an arc was described from the outset",
+        "2": "Gate mentioned but run after a structure was already assumed, as justification",
+        "3": "Gate run before structure selection, but the chronology table was thin or partly assembled afterward",
+        "4": "Chronology table complete first, then ABT, then the six questions, in order",
+        "5": "Full order held, source-type flags recorded per row, and no theme or thesis proposed before the table was complete"
+      }
+    },
+    {
+      "name": "Citation Discipline on Every Slot",
+      "description": "Whether each triage answer and each ABT slot carries a specific corpus reference, with uncited answers treated as NO",
+      "weight": 1.3,
+      "scores": {
+        "1": "No citations; answers are assertions and the ABT reads well while citing nothing",
+        "2": "Some slots cited, others asserted, with no distinction drawn between them",
+        "3": "Most slots cited; a few uncited YES answers survived into the form declaration",
+        "4": "Every YES carries a reference; uncited answers were converted to NO",
+        "5": "Every slot cited, sources tagged primary-contemporaneous or secondary-retrospective, and no mechanism claim rests on a secondary retrospective alone"
+      }
+    },
+    {
+      "name": "Refusal Capability",
+      "description": "Whether DO NOT NARRATE, NO BUT IN MATERIAL and NO POINT OF INSIGHT are available and used when the evidence warrants, without being softened into a weaker arc",
+      "weight": 1.5,
+      "scores": {
+        "1": "An arc was produced regardless of evidence; empty slots were filled by inference or invention",
+        "2": "Weaknesses noted in passing, then a story form adopted anyway",
+        "3": "Form correctly downgraded, but the refusal is buried or apologetic rather than delivered as a finding",
+        "4": "Refusal delivered as a first-class output with reasons and failing question numbers, and empty slots logged with a chosen move",
+        "5": "As 4, plus the counter-check: the strongest agency-based reading is named and its rejection reasoned, so the refusal is not anti-narrative reflex"
+      }
+    },
+    {
+      "name": "Structure Fit and Runner-Up",
+      "description": "Whether the selected spine is keyed on contradiction count, subject type, audience obligation, outcome knowledge and audience stance, with a named runner-up and a stated reason it lost",
+      "weight": 1.2,
+      "scores": {
+        "1": "Structure named with no rationale, or a default arc applied to system material",
+        "2": "Rationale given for one or two keys only; no runner-up recorded",
+        "3": "Most keys applied; runner-up named but with no reason it lost",
+        "4": "All five keys applied explicitly; runner-up named with a reason",
+        "5": "As 4, plus the system remap applied where the subject is not a person, and any agentic template either remapped slot by slot or abandoned"
+      }
+    },
+    {
+      "name": "Boredom Budget and Nesting Declared",
+      "description": "Whether the contract states in one sentence where the chosen structure permits low-engagement prose, and declares nesting depth within the one-level limit for explanation inside story",
+      "weight": 1.0,
+      "scores": {
+        "1": "Neither stated; the structure is a label with no operating rules",
+        "2": "Boredom zone gestured at vaguely ('keep it engaging'); nesting unaddressed",
+        "3": "Boredom sentence present and correct for the structure; nesting mentioned without depth",
+        "4": "Both stated precisely, and the one-nut-graf limit on explanation inside story is respected",
+        "5": "As 4, plus dense evidence runs marked and each placed in a permitted zone, appendixed, compressed, or paid for with a scene"
+      }
+    },
+    {
+      "name": "Warranted Antagonists and Non-Agentic Language",
+      "description": "Whether any opponent meets the competition, awareness and directed-action tests, with verbs matching the tier, and whether systems are kept free of wants and intent",
+      "weight": 1.2,
+      "scores": {
+        "1": "A named party is assigned intent with no documentary support, or the subject system decides, wants or believes",
+        "2": "An opponent is asserted with one evidence type; agency language appears unremarked",
+        "3": "Opponent tier assessed but verbs not constrained to the tier",
+        "4": "Tier assigned from the three tests, verbs constrained accordingly, and the empty case declared where nothing reaches two of three",
+        "5": "As 4, plus every system-level force cashed out into its mechanism in the same sentence, with no anthropomorphism anywhere in the contract"
+      }
+    },
+    {
+      "name": "Set-Aside and Contradiction Handling",
+      "description": "Whether DHY material was split or explicitly demoted with disclosure, and whether evidence that contradicts is distinguished from evidence that merely fails to support",
+      "weight": 1.2,
+      "scores": {
+        "1": "Multi-causal material silently flattened to one elegant mechanism; nothing logged",
+        "2": "A single spine chosen with a passing acknowledgment that other factors exist",
+        "3": "Set-aside log present but does not separate contradicting from not-supporting evidence",
+        "4": "Contradictions named, the reduction reasoned, and the two evidence categories separated",
+        "5": "As 4, plus contradicting evidence routed into the body of the plan rather than an appendix, and one thing the chosen lens does not explain stated outright"
+      }
+    },
+    {
+      "name": "Contract Completeness and Immutability",
+      "description": "Whether all eleven contract fields are present, attribution caveats carried, and the spine frozen against mid-draft substitution",
+      "weight": 1.0,
+      "scores": {
+        "1": "No contract; the output is prose or an outline",
+        "2": "Partial contract; several required fields absent",
+        "3": "Most fields present; attribution caveats missing or sources misattributed",
+        "4": "All eleven fields present, attributions correct, and the freeze stated",
+        "5": "As 4, plus derived defaults and the Hart, Oregon Method and SCAM caveats carried verbatim, and a logged restart path defined for structural change"
+      }
+    }
+  ]
+}

--- a/skills/narrative-form-triage/resources/form-triage-gate.md
+++ b/skills/narrative-form-triage/resources/form-triage-gate.md
@@ -1,0 +1,205 @@
+# Form Triage Gate: Full Procedure
+
+Reference matter for `narrative-form-triage`. The SKILL.md body holds the gate and the selection table. This file holds the worked runs, the protocols, and the contract template.
+
+## Contents
+- [Attribution notes](#attribution-notes)
+- [The six questions, with evidence tests](#the-six-questions-with-evidence-tests)
+- [Three worked triage runs](#three-worked-triage-runs)
+- [ABT development card](#abt-development-card)
+- [Handling DHY material](#handling-dhy-material)
+- [Thesis vs theme adjudication](#thesis-vs-theme-adjudication)
+- [Opponent warrant tiers](#opponent-warrant-tiers)
+- [Empty Slot Protocol](#empty-slot-protocol)
+- [The refusal catalogue](#the-refusal-catalogue)
+- [Spine contract template](#spine-contract-template)
+- [Pre-ship gate](#pre-ship-gate)
+
+## Attribution notes
+
+Carry these into any output that names a source.
+
+- **Hart.** *Storycraft* separates story narrative (ch. 11), explanatory narrative (ch. 12) and other narratives (ch. 13). Hart's warning is that writers force explanatory material into "a full-blown story narrative, with a narrative arc and a climax and a denouement." Hart also writes that explanatory narrative "seldom" produces a point of insight and that "not every narrative has a resolution." The six-question instrument here mechanizes those distinctions. Hart does not publish it. Cite the books, not a gate.
+- **"The Oregon Method" is not a codified canon.** It is a retrospective label for the newsroom coaching practice Hart ran. Citing named rules to it is fabricating a source. What is real and citable: story-conference-first, theme statement before drafting, editor as structural partner, structural revision before line revision.
+- **SCAM (Setting, Character, Action, Meaning) is not Hart's acronym.** It comes from journalism pedagogy at Dynamics of Writing. It is compatible with Hart's scene chapter. Do not attribute it to him.
+- **Numeric thresholds here are derived defaults.** Three scenes minimum at question 4, three paragraphs of undramatized evidence, five or six paragraphs to the nut graf, 3-5 nodes in a gathering, one screen to the governing thought. These are tunable operating defaults for mechanization. They are not published figures from any of the named authors.
+- **ABT and the Narrative Spectrum** are Randy Olson's. **Pyramid and SCQA** are Barbara Minto's. **OCAR, LDR and ABDCE** are Joshua Schimel's. **The sparkline** is Nancy Duarte's. **The five-slot strategic narrative** is Andy Raskin's. **Martini glass, interactive slideshow and drill-down** are Segel and Heer's. **PR/FAQ** is Amazon's, documented by Bryar and Carr.
+
+## The six questions, with evidence tests
+
+Each question takes YES-with-citation or NO. An uncited YES is a NO.
+
+**Q1. A single continuous entity whose state is tracked start to finish?**
+Person or system both qualify. The system version is a traveling unit: one container of potatoes, one packet, one dollar of a fee, one patient sample, one training batch, one purchase order, one wafer. Test: does it appear in the record at both ends of the period the piece covers?
+
+**Q2. Does the entity want something specific and reachable, documented?**
+The failure is reading the want backward from the outcome. Ask: what dated source, written before the outcome, states the goal? A strategy memo, a filing, a design doc, a commit message, an interview given at the time. For a system subject, "want" is remapped to a design objective or an equilibrium, and it still needs a source.
+
+**Q3. A dated, sourced rupture of the status quo?**
+Run the inciting-incident test. Record four dates: the event; the earliest source treating the event as significant; the outcome; the source you cited. If the earliest source treating it as significant postdates the outcome, tag the slot RETROSPECTIVE-ONLY. Then name two other events in the same window that a narrator with a different ending would have chosen instead. If you cannot name two, you have not searched.
+
+A RETROSPECTIVE-ONLY tag is a disclosure requirement, not a deletion rule. Genuinely causal events are often invisible to everyone present: a demographic shift, an accumulating design compromise, a slow change in a cost curve. The rule is that no RETROSPECTIVE-ONLY slot may carry unhedged causal language. Either downgrade the verbs, or add one sentence in the body saying the significance is visible only in hindsight.
+
+**Q4. A continuous sourced action sequence, at least three renderable moments?**
+Renderable means: a place, a time, named participants, and documented actions. Not "the team debated the tradeoff" but a meeting with a date, attendees and a recorded outcome. Three is the derived floor. Below it, the alternation that carries explanatory narrative has nothing to alternate with.
+
+Most document-corpus work fails here, and that is the expected result. Hart writes for people who can go stand on the corner and ask the source what they were thinking. An agent working from filings, papers and post-hoc write-ups usually finds the scenic and interior material simply is not there. The correct response is to shift form, not to lower the evidentiary bar to keep the form.
+
+**Q5. An evidenced point of insight?**
+Hard test: name the behavior that changed after it, and the source showing the change. A realization with no behavioral consequence in the record is not a point of insight. Two specific failure shapes:
+- *Promotion.* The largest number in the dataset, or the most recent event, gets nominated because the template has a slot.
+- *Wrong subject.* The insight belongs to the analyst reading the corpus, not to anyone inside the material. Hart's point of insight is inside the story.
+
+If no row qualifies, record NO POINT OF INSIGHT and downgrade to explanatory narrative.
+
+**Q6. A resolution: a new stable state?**
+If the situation is ongoing, say so in the piece rather than inventing closure. An unresolved ending is a legitimate ending. A manufactured one is a false claim about the world.
+
+## Three worked triage runs
+
+**Run A — a market history (semiconductor capacity, 2019-2024).**
+Q1 YES: a single fab's capacity, tracked quarterly, sourced to filings. Q2 NO: the fab operator's "want" appears only in retrospective analyst commentary; contemporaneous filings state capital plans, not goals. Q3 YES: an export-control rule with a date and a text. Q4 YES: eleven dated events, four with named participants and recorded actions. Q5 NO: no source shows any participant's model being falsified and their behavior changing. Q6 NO: ongoing.
+→ **EXPLANATORY NARRATIVE**, failing 2, 5, 6. Action line is the wafer. Structure: layer cake. Runner-up: pyramid, which lost because the audience is voluntary and the material rewards accumulation.
+
+**Run B — an ML research writeup.**
+Q1 YES: one model family across six training runs. Q2 YES: the project's stated objective is in the original proposal, dated before results. Q3 YES: run 4 diverged, logged. Q4 NO: two renderable moments, not three; the rest is metrics without participants.
+→ **DO NOT NARRATE**, failing 4. Deliverable is OCAR mapped to IMRaD, opened with the one strong concrete moment as texture. No arc language anywhere. The team wanted "the story of how we found it"; the honest output is that the record supports a finding, not a story.
+
+**Run C — a supply-chain incident review.**
+Q1 YES. Q2 YES. Q3 YES. Q4 YES: six renderable moments across four sites. Q5 YES: the shift supervisor's own incident note records that she stopped trusting the sensor reading, and the log shows her procedure changed that night. Q6 YES: a new stable state, the revised procedure, in force since.
+→ **STORY NARRATIVE**, all six pass. Now run the opponent warrant before writing anything: the "opponent" here is a calibration drift, so it is environmental pressure, not an adversary. Verbs restricted accordingly.
+
+## ABT development card
+
+Fill in this order. Every slot cites the corpus.
+
+| Slot | Contents | Test |
+|------|----------|------|
+| BUT (first) | The single contradiction | Is there exactly one? Two that will not collapse = DHY |
+| BUT, level check | Proximate harm, or the condition that permits it? | Pick the level where the THEREFORE is actionable |
+| BUT, blocker check | Why has this not already been solved? | The answer is usually the real BUT |
+| AND, ordinary world | Uncontested status quo | Could the reader have written this sentence? |
+| AND, stakes | A number, a dollar figure, or a named consequence | Never "X is important" |
+| THEREFORE | The consequence that follows from BUT | Does it follow from the BUT, or from what you wanted to recommend anyway? |
+
+Then two whole-sentence checks:
+- **WHAT before HOW.** Right: "the reserve is now severely degraded, after fifty years of clearing, pollution and parcel sales." Wrong: "over fifty years, trees were cleared, pollution rose and parcels were sold, leaving the reserve degraded."
+- **Dobzhansky check.** "Nothing in [domain] makes sense except in the light of [one mechanism]." If blank two needs an "and," you have two narratives. Also state one thing blank two does *not* explain, and name the second-best lens you rejected. The test rewards a single lens, so it will over-fit genuinely multi-causal material and produce a confident, elegant, wrong explanation.
+
+**AAA output template:** "This material contains no contradiction. It is [n] independent findings with no causal chain between them. A narrative arc would fabricate the chain. Recommended form: pyramid, inductive grouping, key line of [n] items."
+
+## Handling DHY material
+
+Two or more simultaneous contradictions read as confusing. The standard advice is to reduce to one. That advice is right for communication and dangerous for analysis: genuinely multi-causal findings get flattened into one elegant mechanism.
+
+Choose one:
+1. **Split into separate deliverables.** Preferred when both contradictions have full evidence.
+2. **Elect one spine, demote the rest to an appendix**, with a named set-aside note in the body: "A second contradiction runs through this material — [X]. It is set aside here because [reason], and treated in [location]."
+3. **Switch to taxonomy**, which does not require a single spine.
+
+Never reduce silently. The set-aside log is a required contract field.
+
+## Thesis vs theme adjudication
+
+Write the organizing idea as one sentence, then apply the falsifiability test.
+
+- **Falsifiable → thesis.** Route to pyramid, OCAR, PR/FAQ or SCQA. State it early and plainly. Defend it with evidence that is mutually exclusive and collectively exhaustive. Cap at three take-home messages, each one sentence.
+- **A claim about meaning or value → theme.** Examples: "institutions defend their own metabolism," "action creates identity." Route to a story structure, and then *do not state it*. It is carried by outcome. The reader may reject it and still be moved.
+- **Both present → nest.** Thesis goes in the nut graf or the governing thought, stated. Theme stays implicit in the scenes and in what the ending chooses to end on.
+
+Two mirror-image failures:
+- **Theme asserted as thesis** produces moralizing. "This shows that greed always wins" converts a resonant piece into an argument the reader will fight.
+- **Thesis left as theme** produces analytic mush. The reader finishes unable to say what was claimed. This one is far more common in model output, because withholding feels sophisticated.
+
+Theme statement form, when you use one: `[NOUN] [TRANSITIVE VERB] [NOUN]`. Reject intransitive verbs and any form of "to be." Reject proper nouns. Build the chronology table before the theme statement is allowed, or the theme will bend the material.
+
+## Opponent warrant tiers
+
+Require three independent kinds of evidence for any antagonist.
+
+| Evidence | What it looks like |
+|----------|-------------------|
+| Competition | Both parties sought the same scarce object at overlapping times, documented |
+| Awareness | Each party knew of the other: a memo, filing, earnings call, commit message, interview |
+| Directed action | At least one action by A that the record shows was taken *because of* B, sourced |
+
+- **3 of 3 = opponent.** Permitted verbs: target, counter, retaliate, undercut.
+- **2 of 3 = rival.** Permitted verbs: compete with, gain share against.
+- **1 or 0 = environmental pressure.** Permitted verbs: coincide with, constrain, be present during. No transitive verbs of intent.
+
+For a system subject, the opponent slot takes a named force with a documented mechanism: a binding constraint, a regulatory regime, a physical limit, a countervailing incentive. Ban "the market wanted," "the industry decided," "physics fought back" unless the sentence immediately cashes the phrase out into the mechanism.
+
+If nothing reaches 2 of 3, leave the slot empty and say so: "No adversary appears in the record; the binding constraint was X."
+
+## Empty Slot Protocol
+
+A slot with zero evidence and no candidate event. Choose in this order.
+
+**MOVE 1 (default) — declare the absence in the body.** "No source records what was decided in that room." "The record is silent on why the threshold was set at 40%." A named absence is a legitimate narrative beat. It creates tension rather than destroying it.
+
+**MOVE 2 — downgrade and substitute.** Use the best-documented adjacent event and reduce its structural weight in the same sentence: "the nearest thing to a turning point in the record is X, though nobody at the time treated it as one."
+
+**MOVE 3 — change the architecture.** Two or more major slots empty means the material does not have this shape. Re-run selection over structures that do not require the missing slots: chronicle, braided comparison, taxonomy, single-question investigation.
+
+**ILLEGAL — fill by inference, disclosed only in an endnote, appendix or methods block.** Readers experience the body, not the back matter.
+
+**ILLEGAL — fill by invention of any kind**, including invented but "representative" detail, and including detail flagged as illustrative.
+
+**BUDGET** — at most one inference-filled slot per piece, never at the climax. **LOG** — record every empty slot and the move chosen; the log ships with the deliverable.
+
+Disclosure placement is load-bearing and will degrade silently. Any later "tighten this up" pass strips disclosure sentences first. Mark them non-removable and keep them within two sentences of the claim, in the same typographic register as the surrounding prose.
+
+## The refusal catalogue
+
+Each of these is a complete, successful output.
+
+1. Refuse a story arc when the corpus contains no documented desire for the proposed protagonist. Report the absence. Do not infer motive.
+2. Refuse a story arc when the proposed opponent is a real named party whose intent is not documented. Substitute a constraint, an incentive or a status quo.
+3. Refuse to fill an empty template slot from outside the corpus.
+4. Refuse to state a theme. If it must be stated, it is a thesis and the structure must change.
+5. Refuse to withhold a thesis. Withholding a falsifiable claim for suspense in analytical material is a defect.
+6. Refuse to reduce multi-causal material to one mechanism without disclosing what was set aside.
+7. Refuse to open with an anecdote whose position in the distribution is unknown.
+8. Refuse to change spine mid-draft. Escalate for an explicit restart with a logged reason.
+9. Refuse to declare the plan finished when the read-through test fails, regardless of prose quality.
+10. Refuse to discard contradicting evidence silently. Evidence that merely fails to support may be pruned. Evidence that contradicts must be surfaced.
+
+**The counter-rule.** Refusing is also a bias. The red-team literature is stocked asymmetrically with attacks on agency-based explanation, so an agent steeped in it will over-attribute outcomes to luck, structure and path dependence. Every refusal output must name the strongest agency-based reading it considered and say why it was not adopted. "The lens disfavours agency" is not a reason.
+
+## Spine contract template
+
+```
+SPINE CONTRACT — [deliverable name] — [date] — FROZEN
+
+FORM:              [STORY NARRATIVE | EXPLANATORY NARRATIVE | MULTI-NODE GATHERING | DO NOT NARRATE]
+FAILING QUESTIONS: [numbers, or "none"]
+ABT:               "___ AND ___, BUT ___, THEREFORE ___"
+                   AND cite: [ref]  BUT cite: [ref]  THEREFORE cite: [ref]
+                   [or: NO BUT IN MATERIAL — spectrum band AAA]
+STRUCTURE:         [name]
+RUNNER-UP:         [name] — lost because [reason]
+THESIS OR THEME:   [thesis | theme] — "[the sentence]" — [stated early | never stated]
+BOREDOM BUDGET:    The reader is permitted to be bored in [zone] and nowhere else.
+NESTING:           [scenes nested inside explanatory spine at depth n | one nut graf, at para n | none]
+OPENING CASE:      [what] — distribution position: [median | tail | unique]
+EMPTY SLOTS:       [slot] → [MOVE 1 | MOVE 2 | MOVE 3]
+SET ASIDE:         [contradiction or evidence dropped] — because [reason] — [contradicting | not-supporting]
+AGENCY READING:    Strongest agency-based account considered: [___]. Not adopted because [___].
+ATTRIBUTION:       [named sources used, with the caveats from this file]
+```
+
+## Pre-ship gate
+
+Run before the contract leaves triage. Assume a specialist has already published a demolition; what did they find?
+
+- Would this explanation have made the outcome predictable in advance? If not, is the piece labelled description rather than explanation?
+- What selection rule produced this corpus? Is it survival? Is that said in the text?
+- Name two entities that took the same actions and did not get the same outcome. Are they in the plan?
+- Which corpus items appear nowhere in the plan, and why? An omission that would weaken the spine, with no justification, is a cherry-pick.
+- Which claim gets the most words relative to its evidence? Which best-evidenced driver gets the fewest? Was it suppressed by the arc?
+- Name the linchpin assumption whose failure collapses the spine. Is it stated in the body, with its implications if wrong?
+- Does every opponent have 3-of-3 or 2-of-3 warrant, and do the verbs match the tier?
+- Does any real person think, feel, believe, worry or intend anything without a sourced statement that they did?
+- Are all disclosures in the body, within two sentences of the claim, in the same register?
+- Count hedges, contingency notes and disclosure sentences per thousand words. Over budget is a signal to change architecture, not to spend more budget.
+- Read only the headlines in sequence. Do they alone tell a complete argument? Headings that are labels ("Background," "Analysis," "Findings") mean the grouping failed.

--- a/skills/narrative-form-triage/resources/structure-catalog.md
+++ b/skills/narrative-form-triage/resources/structure-catalog.md
@@ -1,0 +1,267 @@
+# Structure Catalog
+
+Thirteen spines, with slots, system remaps, boredom rules, failure signatures and cross-domain examples. Companion to the selection table in SKILL.md. Attribution caveats live in [form-triage-gate.md](form-triage-gate.md).
+
+## Contents
+- [How to read an entry](#how-to-read-an-entry)
+- [1. Truby / full story arc](#1-truby--full-story-arc)
+- [2. Explanatory narrative (layer cake)](#2-explanatory-narrative-layer-cake)
+- [3. Pyramid / SCQA](#3-pyramid--scqa)
+- [4. OCAR / LDR](#4-ocar--ldr)
+- [5. PR/FAQ working backwards](#5-prfaq-working-backwards)
+- [6. Duarte sparkline](#6-duarte-sparkline)
+- [7. Raskin five-slot](#7-raskin-five-slot)
+- [8. Martini glass](#8-martini-glass)
+- [9. Drill-down](#9-drill-down)
+- [10. Inverted pyramid](#10-inverted-pyramid)
+- [11. Braided / mosaic gathering](#11-braided--mosaic-gathering)
+- [12. Chronicle](#12-chronicle)
+- [13. Taxonomy](#13-taxonomy)
+- [The system remap, in one table](#the-system-remap-in-one-table)
+- [Writing backwards: the order to draft in](#writing-backwards-the-order-to-draft-in)
+- [Emplotment disclosure](#emplotment-disclosure)
+
+## How to read an entry
+
+Each entry carries six fields.
+
+- **Slots** — what the structure demands.
+- **Select when** — the keys that pick it.
+- **Boredom rule** — the one sentence you must be able to state.
+- **System variant** — what it becomes when the subject is a market, protocol, institution, codebase or supply chain.
+- **Failure signature** — how it goes wrong, and the detector.
+- **Example** — drawn from a named domain.
+
+## 1. Truby / full story arc
+
+**Slots.** Exposition; a rupture that pulls the subject out of the status quo; rising action where each development raises a question; a point of insight; a climax after the insight; a new stable state.
+
+**Select when.** All six triage questions pass. The subject is a person. The opponent has 3-of-3 warrant. The outcome is unknown to the audience.
+
+**Boredom rule.** Nowhere. Exposition is blended into motion, never stacked.
+
+**System variant.** There is not a good one, and that is the point. A market or protocol has no desire and no opponent. Forcing the arc means filling the desire and opponent slots by invention. If the material is a system with one contradiction, go to entry 2 or entry 7.
+
+**Failure signature.** The manufactured point of insight: the largest number or the most recent event gets promoted into a turning point and the draft says "and that changed everything." Detector: name the behavior that changed after it, with a source. No source means no insight and the form downgrades. Second signature: the climax precedes the point of insight, which means the arc is backwards.
+
+**Example (biography).** Dated grant applications state the researcher's goal. A rejection letter is the rupture. Her lab notebooks record the day she stopped trusting an assay, and the same notebooks then show a changed protocol. The published paper is the climax. The method in general use is the resolution. All six slots have paper behind them, which is rare.
+
+## 2. Explanatory narrative (layer cake)
+
+**Slots.** An action line of concrete events; digressions attached to specific moments in it; a return to a moving moment after each digression; a circle kicker returning to the opening element.
+
+**Select when.** One contradiction, a system subject, a voluntary audience, dense material, and a followable sequence exists.
+
+**Boredom rule.** Inside a digression that a preceding scene has paid for, and only for a length not exceeding that scene. Early in the piece hold that cap strictly. Extend once the reader is invested.
+
+**System variant.** This *is* the system variant, and the mechanism is the traveling unit. Choose the smallest concrete thing that physically moves through the whole system end to end. Verify three constraints: it touches at least four distinct nodes; at each node a named human's actions on it are documented; its journey covers the time span the piece needs. Movement between nodes supplies the transitions for free, which is the entire reason the technique works. At each node render the mechanism, not the label.
+
+**Failure signature.** Two. *The decorative scene*: a vivid passage that instantiates no adjacent claim. Detector: delete it; if no claim changes, it was decoration. *Gimmick drift*: the traveling unit becomes a frame the piece returns to for atmosphere while the real explanation happens elsewhere. Detector: cut every traveling-unit passage; if the explanation still stands complete, integrate the device or remove it.
+
+**Example (supply chain).** One purchase order followed from a component broker through a customs bond, a contract assembler and a distribution centre. Each node is a scene site with a named person. The digressions carry tariff mechanics, lead-time math and the inventory accounting. Each digression gets its own miniature ABT so it has shape rather than being a dump.
+
+## 3. Pyramid / SCQA
+
+**Slots.** Governing thought at the top; a key line of three to five supports readable alone; groups beneath, each internally ordered by exactly one method. Opener is SCQA: Situation, Complication, Question, Answer.
+
+**Select when.** An obligated audience must decide. Or the material is AAA. Or the outcome is already known.
+
+**Boredom rule.** Below the key line only. Never above it. The reader already has the answer and reads down only as far as scepticism requires.
+
+**System variant.** Unchanged. Minto's structure never assumed an agentic protagonist, which is why it survives translation without remapping.
+
+**Failure signature.** The false grouping. Three headings that look parallel but are not the same kind of idea: one cause, one symptom, one proposed action. Detector: name the group with a single plural noun out loud. "Three reasons," "four constraints," "five markets." A group that resists naming is fake. Second detector: the parent sentence is a category label. "Cost drivers" fails. "Three cost drivers explain 80% of the gap" passes. A "Background" heading is almost always evidence that grouping failed.
+
+**SCQA order selection.**
+
+| Order | Lead with | Use when |
+|-------|-----------|----------|
+| Direct | Answer | Reader trusts you and is time-poor. Default for senior audiences |
+| Standard | Situation | Audience is new; the problem needs shared context first |
+| Concerned | Complication | Audience does not yet feel the problem |
+| Aggressive | Question | Audience already agrees there is a problem and wants the frame |
+
+Deductive grouping is a chain: one broken link fails the group. Inductive is a bundle: one failed support leaves the others standing. Hostile audiences get inductive.
+
+**Example (policy memo).** Situation: the subsidy has run at a fixed rate since 2019, uncontested. Complication: three of the five eligibility criteria now select for firms the program was not designed for. Question: should the criteria change or the rate? Answer, stated first for a minister who trusts the department.
+
+## 4. OCAR / LDR
+
+**Slots.** Opening (the larger problem, not your topic); Challenge (the specific question); Action (what was done); Resolution (how understanding changed).
+
+**Select when.** Peer or technical audience, empirical claim, authority coming from method rather than from the writer.
+
+**Boredom rule.** Permitted and expected in Action. O, C and R must be interesting and must convey the key points when read alone.
+
+**System variant.** Unchanged. OCAR never assumed a protagonist.
+
+**Failure signature.** The paper with no Challenge: fine Opening, large Action, and a Resolution that merely restates the Action. It reads as competent and leaves no residue. Detector: delete the Action entirely. If O + C + R still communicates a finding, the structure holds. If deleting the Action makes the document meaningless, there was no Challenge, and the piece is a record of activity rather than an argument.
+
+**Variants.** LDR (Lead, Development, Resolution) for broad audiences who will bail if the conclusion is withheld. ABDCE (Action, Background, Development, Climax, Ending) for proposals, where the reader is choosing whether to read at all.
+
+**Example (ML research writeup).** Opening: retrieval quality degrades on long-tail queries across every production system in this class. Challenge: does the degradation come from the index or the reranker? Action: the ablations, where the reader may be bored. Resolution: the boundary moves, and here is what that changes.
+
+## 5. PR/FAQ working backwards
+
+**Slots.** Press release (heading; subheading naming who it is for; summary with date; problem from the customer's view with the addressable size; solution and how it differs; a spokesperson quote; a customer quote; how to get started). External FAQ. Internal FAQ.
+
+**Select when.** Obligated audience, the subject does not exist yet, and the decision is go/no-go.
+
+**Boredom rule.** None anywhere in the body. All density is exiled to appendices, which do not count against the page limit. Enforced by a silent-read ritual: 15 to 25 minutes of reading before any discussion.
+
+**System variant.** For a proposed system rather than a product, the "customer" is the system participant who bears the current cost, and the customer quote slot is the most dangerous slot in the document. It is routinely filled with fabrication. If no real participant said it, leave it out.
+
+**Failure signature.** Selling instead of truth-seeking: the author advocates rather than evaluates, discounts existing alternatives, and reasons from what the organisation is good at rather than what the problem needs. Detector: the internal FAQ must contain at least one answer that materially weakens the proposal. Second signature: weaponization, where the format becomes a mechanism for stalling disfavoured work through endless review. Cap the iteration count explicitly.
+
+**Internal FAQ mandatory slots.** Competitive landscape; market or population size and how it was computed; capabilities required that we do not have; regulatory and legal risk; unit economics; when it becomes viable; the assumptions success depends on. Every answer is a claim with a number or an explicit "unknown." Never a reassurance.
+
+## 6. Duarte sparkline
+
+**Slots.** What Is; What Could Be; sustained oscillation between the two; a climax naming one concrete action; a close on the transformed state.
+
+**Select when.** The audience must act and feel, and a change is already underway that they half-believe.
+
+**Boredom rule.** None. Any stretch without an oscillation is a leak.
+
+**System variant.** "What could be" is an equilibrium, not a product. Ground "what is" in the participants' own numbers and language, or nothing after it lands.
+
+**Failure signature.** Manufactured oscillation. Because the form rewards alternation, an analyst applying it will invent problems to alternate against, or restate one problem in five costumes. The audience registers the rhythm as manipulation and trust collapses faster than with a flat report. Detector: list each "what is" beat; each must be a distinct obstacle with its own evidence. Duplicates mean the material supported one oscillation and the structure is wrong.
+
+Two named failure shapes: a **report** (too much what-is, audience bored) and a **pitch** (too much what-could-be, no credible problem, audience sceptical).
+
+## 7. Raskin five-slot
+
+**Slots.** A big undeniable change in the world; winners and losers it created; the promised land; capabilities as tools against named obstacles; evidence that the promised land is reachable.
+
+**Select when.** The audience must be repositioned, and there is no human protagonist in the material. The protagonist here is the audience.
+
+**Boredom rule.** None before the evidence slot.
+
+**System variant.** The change is the exogenous shock. The winners and losers are the differential outcomes across participants. The promised land is the equilibrium the system is moving toward. The capabilities are the mechanisms that make the equilibrium reachable. The evidence is the sub-population that already reached it. This remap is what lets a story-shaped spine carry non-agentic material.
+
+**Failure signature.** The manufactured enemy. Older formulations say "name the enemy," and applied mechanically to analytical material this produces villains where the record supports only incentives: a named competitor, a named executive, a named institution assigned intent it never had. Detector: the enemy slot must hold a status quo, a constraint or an incentive structure. Never a party who could sue you. Never a party whose intent is undocumented.
+
+Hard prohibitions from the source: never open with your product, your organisation, your investors or your clients. Do not coin new terminology for the change; borrow the term already circulating. Name obstacles before capabilities, and cut any capability with no matching obstacle.
+
+## 8. Martini glass
+
+**Slots.** An author-driven stem; a defined handoff point; a reader-driven bowl.
+
+**Select when.** The reader must understand before exploring, and a dataset, model, scenario set or appendix is attached.
+
+**Boredom rule.** None in the stem. After the handoff, boredom is the reader's own choice and is fine.
+
+**System variant.** Unchanged.
+
+**Failure signature.** Premature handoff. An agent optimizing for "let the reader explore" hands off before the reader has the frame, and the reader constructs their own, usually wrong, story from raw material and attributes it to you. Detector: if the stem does not contain a stated thesis and stated limitations, it is not a stem. Second diagnostic: could a reader entering the bowl draw the opposite conclusion using what you handed them? If yes and that conclusion is wrong, the stem is too short. If yes and the conclusion is legitimate, say so in the stem.
+
+**Example (market analysis with a model attached).** Stem: the frame, the three observations the reader could not have found alone, the model's known biases, and the questions the reader will want to pursue. Handoff: named explicitly. Bowl: the scenario switches and per-segment tables.
+
+## 9. Drill-down
+
+**Slots.** An entry frame; a set of parallel cases the reader selects among; a consistent per-case template.
+
+**Select when.** The reader arrives with their own case in mind and wants to find themselves in the data.
+
+**Boredom rule.** Everywhere outside the entry frame. The reader chose the path.
+
+**System variant.** Unchanged.
+
+**Failure signature.** No shared frame, so every reader leaves with a different conclusion and none of them is yours. Detector: write the one sentence every reader should carry out regardless of which case they entered. If you cannot, the entry frame is missing.
+
+## 10. Inverted pyramid
+
+**Slots.** The answer; then supporting facts in descending order of consequence.
+
+**Select when.** The reader may exit at any point without penalty, or the outcome is already known.
+
+**Boredom rule.** Increasing from top to bottom, by design.
+
+**System variant.** Unchanged.
+
+**Failure signature.** Used on material whose value depends on accumulation, where the reader who stops early gets a true-but-useless fragment. Detector: does the third paragraph, read alone, mislead?
+
+## 11. Braided / mosaic gathering
+
+**Slots.** Three to five nodes, each with its own miniature arc; one connective tissue; a closing node carrying the fullest expression of the theme.
+
+**Select when.** No single entity spans the material, but all nodes instantiate the same causal verb.
+
+**Boredom rule.** At node boundaries only.
+
+**System variant.** A node is a person, place, firm, site or event. Pick exactly one connective tissue and hold it:
+
+- **Shared clock** — all nodes advance through the same timeline.
+- **Shared object** — the traveling unit visits each node.
+- **Shared pressure** — the same force acts on every node, from a different angle.
+
+**Failure signature.** Mosaic mush: nodes chosen for availability rather than theme, so the reader gets four interesting fragments and no accumulation. Detector: ask what node 4 proves that node 1 did not. If the answer is "it is another example," the structure is a list, and a list should be formatted and labelled as a list, not disguised as narrative.
+
+Other rules: sequence by escalation of stakes or widening of scope, never by convenience of the source material. Give each node an equal allocation within about 30%; wildly uneven nodes mean one is really the protagonist and the form should be reconsidered. Do not close on the weakest node just because it happened last.
+
+**Example (institutional history).** Four regional offices under the same funding change, sequenced from the least to the most exposed, connected by a shared clock.
+
+## 12. Chronicle
+
+**Slots.** Sequence, with no required resolution.
+
+**Select when.** Two or more major structural slots are empty and the record is genuinely thin.
+
+**Boredom rule.** Throughout, by design. Say so up front so the reader knows what they are getting.
+
+**System variant.** Unchanged.
+
+**Failure signature.** Used to avoid taking a position the evidence supports. Chronicles inform nobody, and shipping one when an argument was available is its own accuracy failure. Detector: name the claim you could have defended and say why you did not.
+
+## 13. Taxonomy
+
+**Slots.** Categories, a stated classification rule, and members.
+
+**Select when.** Independent findings with no causal chain, or DHY that will not collapse into one contradiction.
+
+**Boredom rule.** Within categories.
+
+**System variant.** Unchanged.
+
+**Failure signature.** Hiding a real contradiction behind categories, so the reader never encounters the tension the material actually contains. Detector: if one category's members contradict another's, that contradiction is the spine and the piece should have been an ABT.
+
+## The system remap, in one table
+
+Apply before adopting any agentic template on a market, protocol, institution, codebase or supply chain.
+
+| Agentic slot | System translation | Prohibited phrasing |
+|--------------|-------------------|---------------------|
+| Desire | Design objective, or the equilibrium the system moves toward | "the market wanted" |
+| Opponent | Binding constraint, regulatory regime, physical limit, countervailing incentive | "the industry decided to fight" |
+| Inciting incident | Exogenous shock, dated | "everything changed the day" |
+| Point of insight | The moment participants' shared model was falsified, evidenced by changed behavior | "the sector realized" |
+| Climax | The event of maximum consequence occurring after the falsification | "the crisis reached its climax" (in a piece with no climax) |
+| Resolution | The new equilibrium, or an explicit statement that none has been reached | "and so the system healed" |
+| Winners and losers | Differential outcomes across participants, measured | "the winners deserved it" |
+
+Systems have states, constraints and incentives. Only people have wants. Once a market "decides," a protocol "wants" or a model "believes," the prose is asserting intent, and therefore causation the analysis has not established.
+
+## Writing backwards: the order to draft in
+
+For any evidence-led structure, determine conclusions before chronology.
+
+1. List candidate take-home messages. Lay every figure, table and finding out at once.
+2. Cut to a maximum of three. Each must fit in one sentence. A message that will not fit is two messages, or is not yet understood.
+3. Order them simple to complex, not most-exciting-first. That ordering becomes the section order in every part of the document, so a reader tracking message two finds it in the same position each time.
+4. Draft results, then methods, then discussion, then introduction, then abstract, then title.
+5. Read the whole thing forward, cold, to test whether it survives normal reading order.
+
+**The mandatory countervailing guard.** Filtering evidence to what serves the spine is one keystroke from discarding what contradicts it, because contradicting evidence by definition does not serve the spine. Keep a discarded-evidence log with two categories. "Did not support" may be pruned. "Contradicted" is always surfaced to the reader. Second guard: if the take-home messages remain unclear after this process, the answer is more evidence, not better structure.
+
+## Emplotment disclosure
+
+Genre is chosen before the evidence is consulted, and it decides which facts become salient. Most agents perform this choice silently.
+
+1. Name the genre in the working notes using a fixed vocabulary: TRAGEDY (capable agent, internal flaw, fall), COMEDY (misalignment resolved), ROMANCE (quest, obstacle transcended), SATIRE (agents defeated by conditions they cannot see), CHRONICLE (sequence without resolution).
+2. Write a 200-word summary of the material in the chosen genre.
+3. Write a 200-word summary in a rival genre.
+4. Diff them. Every evidence item appearing in one and not the other is the suppression set of your chosen genre.
+5. **Any item in the suppression set carrying documented-mechanism evidence must be reinstated in the delivered text, even if it damages the arc.** Losing a colourful anecdote to genre choice is acceptable. Losing a documented mechanism is not.
+6. Disclose in one structurally visible sentence. Not "this is a tragedy," but "this account treats X as the decisive actor; a reading that treated market structure as decisive would emphasise Y."
+
+Step 5 is the part that does the work. Disclosure without reinstatement is a confession booth, and it is worse than no disclosure, because naming the genre buys credibility the piece then spends on distortion.

--- a/skills/narrative-handoff-contract/SKILL.md
+++ b/skills/narrative-handoff-contract/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: narrative-handoff-contract
+description: Defines and validates the machine-readable contract that passes a narrative architecture between a structural agent and a drafting agent — architecture.json with evidence-backed slots, capped scene tags, gap dispositions, a DEAD column, and an escalation object for sending defects back upward. Ships a validator script so the rules are enforced rather than requested. Use when two agents or two sessions must hand narrative work to each other, when an architecture needs checking before drafting begins, when a draft must report a defect it cannot fix at its own layer, or when the user mentions handoff, contract, schema, validator, architecture.json, escalation, or "the outline and the draft have drifted apart".
+---
+
+# Narrative Handoff Contract
+
+## Table of Contents
+
+- [Core Principles](#core-principles)
+- [Workflow](#workflow)
+- [The three fields that carry the weight](#the-three-fields-that-carry-the-weight)
+- [The escalation object](#the-escalation-object)
+- [Guardrails](#guardrails)
+- [Quick Reference](#quick-reference)
+
+**Related skills:** Use `narrative-evidence-ledger` to build the claim set this contract points at, `narrative-arc-mapping` to fill the slots, and `narrative-fidelity-audit` to check the prose that comes back.
+
+## Core Principles
+
+1. **A pipeline whose interface is prose has no interface.** Two agents that hand each other paragraphs cannot enforce anything. The handoff is a file.
+2. **The evidence array is the validated field, not the value.** A slot with a confident sentence and no claim ID fails here rather than reading well downstream.
+3. **ABSENT is a passing state.** An architecture with every slot filled is flagged, because real material always has holes.
+4. **Enforce with a cap, not a request.** "Never draft prose" decays as context fills. A length limit on scene lines does not.
+5. **The channel runs both ways.** Without an escalation object the drafting layer has no way to report a structural defect, so it papers over it with polish.
+6. **Pointers resolve outward.** A citation resolving into the pipeline's own earlier output is circular, invisible to reading, and a hard failure.
+
+## Workflow
+
+Copy this checklist and track your progress:
+
+```
+Handoff Contract Progress:
+- [ ] Step 1: Emit the architecture object
+- [ ] Step 2: Validate before handing off
+- [ ] Step 3: Write the demand manifest
+- [ ] Step 4: Receive and route escalations
+```
+
+**Step 1: Emit the architecture object**
+
+Step 1.1: Write `architecture.json` with the fields in [resources/schema.md](resources/schema.md). Start from the worked example there rather than from an empty file.
+
+Step 1.2: Stamp the run header — model, corpus reference, timestamp, and the list of claim IDs actually consulted. A run over a corpus too large to read linearly must record which claims it did **not** see. Silent partial coverage reported as full coverage defeats every audit downstream.
+
+Step 1.3: Write incrementally. Append each slot as you settle it, so a run that dies partway loses one slot rather than the whole pass.
+
+**Step 2: Validate before handing off**
+
+Step 2.1: Run the validator. It reports every problem, not just the first:
+
+```
+python3 resources/validate_architecture.py path/to/architecture.json \
+    --corpus-root path/to/corpus --output-root path/to/pipeline/output
+```
+
+Step 2.2: Fix errors. Read warnings as diagnosis rather than noise — "0 slots ABSENT" usually means slot-filling, not unusually complete material.
+
+Step 2.3: Use `--strict` in CI, where a warning should stop the build. Leave it off while drafting.
+
+**Step 3: Write the demand manifest**
+
+Step 3.1: Give the drafting agent absolute paths, an explicit scope in beat IDs, an explicit out-of-scope statement, the style contract, and the required return shape.
+
+Step 3.2: Read it back as a stranger. If it only makes sense to someone who saw the previous conversation, it will fail. The downstream agent inherits nothing else.
+
+**Step 4: Receive and route escalations**
+
+Step 4.1: An escalation naming layer `architecture` is a defect in the spine or the slot. An escalation naming layer `reporting` means the corpus lacks something — route it to research, not to redrafting.
+
+Step 4.2: A spine change is legal but never local. Bump `spine_version`, invalidate the draft, and re-pass from the scene weave down. Patching one section into a different structure while the rest keeps the old one is what readers register as untrustworthy without being able to say why.
+
+## The three fields that carry the weight
+
+| Field | Rule | What it prevents |
+|---|---|---|
+| `slots[].evidence[]` | Non-empty for any slot not marked ABSENT | A fluent sentence standing in for a finding |
+| `slots[].status` | `ABSENT` passes; all-filled warns | Twenty-two slots producing twenty-two inventions |
+| `scenes[].tagged_line` | Hard character cap | The structural agent quietly drafting, leaving the craft agent editing text instead of executing architecture |
+
+Two more matter almost as much. `dead_column[]` keeps every killed finding, distinguishing `did_not_support` from `CONTRADICTED` — the second always reaches the reader, and its absence is how cherry-picking becomes undetectable. And `scenes[].representativeness` is assigned upstream against the corpus, never by the drafting agent, because a vivid case in the opener is selected for energy and energy correlates with being atypical.
+
+## The escalation object
+
+```json
+{
+  "beat_id": "b14",
+  "layer": "architecture",
+  "defect": "No particular exists anywhere in the corpus for this beat; the ladder audit finds an R2 run with no R1 within two paragraphs.",
+  "what_would_resolve_it": "Either a dated artifact from the 1998 filings, or a redesign that does not require a scene here."
+}
+```
+
+`layer` is `architecture` when only the spine can resolve it, and `reporting` when the material itself is missing. Both are successful outputs. Neither is a request for permission to invent.
+
+## Guardrails
+
+**Requirements:**
+
+1. **Validate before every handoff.** An unvalidated contract is a suggestion.
+2. **Absolute paths only.** Relative paths across an agent boundary are a documented recurring failure.
+3. **Version the contract.** A run that cannot say which contract it was written against cannot be re-derived or diffed.
+4. **Every gap carries exactly one disposition** — RESEARCH, REDESIGN, DECLARE or CUT. There is no "draft and flag": flagged prose survives review at high rates because it reads well.
+5. **Zero gaps is a red flag, not a success.**
+
+**Common pitfalls:**
+
+- Treating the markdown companion as the artifact. Generate it from the JSON; never edit it by hand and expect the JSON to follow.
+- Letting the drafting agent widen its own scope because "the next section obviously follows."
+- Recording coverage as the whole corpus when the agent read the first N chunks.
+- Deleting killed findings to tidy the file.
+- Escalating by writing a note into the prose instead of emitting the object, where nothing will route it.
+
+## Quick Reference
+
+**Key resources:**
+- **[resources/schema.md](resources/schema.md)**: full field list, types, and a worked example for a system protagonist
+- **[resources/validate_architecture.py](resources/validate_architecture.py)**: the validator; exit 0 pass, 1 violated, 2 unreadable
+- **[resources/evaluators/rubric_narrative_handoff_contract.json](resources/evaluators/rubric_narrative_handoff_contract.json)**: quality scoring
+
+**Inputs required:**
+- A claim set or evidence ledger with stable claim IDs
+- A chosen structure and its slots
+- The output directory, for the circular-citation check
+
+**Outputs produced:**
+- `architecture.json`, validated
+- A demand manifest a stranger could execute
+- Escalation objects routed by layer

--- a/skills/narrative-handoff-contract/resources/evaluators/rubric_narrative_handoff_contract.json
+++ b/skills/narrative-handoff-contract/resources/evaluators/rubric_narrative_handoff_contract.json
@@ -1,0 +1,102 @@
+{
+  "name": "Narrative Handoff Contract Rubric",
+  "description": "Evaluation criteria for an architecture object passed between a structural agent and a drafting agent. Minimum standard: average score >= 3.5, with Evidence Binding and Absence Handling both >= 4.",
+  "criteria": [
+    {
+      "name": "Evidence Binding",
+      "description": "Whether every non-absent slot and every scene traces to claim IDs that resolve to external artifacts",
+      "weight": 1.5,
+      "scores": {
+        "1": "Slots carry assertions with no evidence array at all; the contract is decorative",
+        "2": "Some slots cite evidence; others carry a confident sentence and nothing else",
+        "3": "Every slot cites evidence, but pointers are informal and some do not resolve",
+        "4": "Every slot and scene cites resolvable claim IDs; no pointer resolves into the pipeline's own output",
+        "5": "As 4, plus source dates recorded per slot and source interest annotated, so a starting weakness can be checked against a pre-outcome source"
+      }
+    },
+    {
+      "name": "Absence Handling",
+      "description": "Whether unfillable slots are declared and dispositioned rather than invented",
+      "weight": 1.5,
+      "scores": {
+        "1": "Every slot is filled; nothing is marked ABSENT and no gaps are recorded",
+        "2": "Gaps are mentioned in prose but carry no status field and no disposition",
+        "3": "Slots are marked ABSENT but several lack an empty_slot_move",
+        "4": "Every ABSENT slot carries a move, every gap carries one of the four dispositions, and no gap is left as 'draft and flag'",
+        "5": "As 4, plus the inference budget is respected (at most one INFERRED slot, never the climax) and each inference is disclosed in the body"
+      }
+    },
+    {
+      "name": "Layer Discipline",
+      "description": "Whether the structural layer stopped at the scene weave instead of drafting",
+      "weight": 1.2,
+      "scores": {
+        "1": "The architecture contains drafted paragraphs; the drafting agent inherits text to edit",
+        "2": "Scene entries run to several sentences of near-prose",
+        "3": "Scene lines are mostly short but a few exceed the cap",
+        "4": "Every tagged_line is within the cap and construction fields carry the detail",
+        "5": "As 4, and the validator was run and passed before the handoff was made"
+      }
+    },
+    {
+      "name": "Provenance and Reproducibility",
+      "description": "Whether the run can be re-derived, diffed, and audited later",
+      "weight": 1.0,
+      "scores": {
+        "1": "No run header; nothing records what produced this",
+        "2": "A timestamp only",
+        "3": "Model and corpus reference present, but no record of which claims were consulted",
+        "4": "Full run header including the coverage receipt of claim IDs actually consulted",
+        "5": "As 4, plus claims skipped are named explicitly, so partial coverage is visible rather than silent"
+      }
+    },
+    {
+      "name": "Causal Typing",
+      "description": "Whether causal claims carry a tier and stay inside the verbs that tier licenses",
+      "weight": 1.2,
+      "scores": {
+        "1": "No causal tiers; warrants assert causation freely",
+        "2": "Tiers assigned inconsistently, and warrants ignore them",
+        "3": "Every slot carries a tier, but some warrants exceed it",
+        "4": "Every tier is assigned and every warrant stays inside its permitted verbs",
+        "5": "As 4, plus no later reference upgrades a claim's tier anywhere in the artifact"
+      }
+    },
+    {
+      "name": "The Dead Column",
+      "description": "Whether killed findings are retained and the contradicting ones distinguished",
+      "weight": 1.0,
+      "scores": {
+        "1": "No dead column; killed findings were deleted",
+        "2": "A list of discarded items with no reasons",
+        "3": "Reasons recorded but 'did not support' and 'contradicted' are not distinguished",
+        "4": "Every entry carries what killed it and which of the two categories it falls in",
+        "5": "As 4, and every CONTRADICTED entry is routed into the deliverable rather than pruned"
+      }
+    },
+    {
+      "name": "Return Channel",
+      "description": "Whether the drafting layer can send a defect back up, and whether escalations were routed",
+      "weight": 1.0,
+      "scores": {
+        "1": "No escalation mechanism; the pipeline runs one way only",
+        "2": "Escalations arrive as prose notes with nothing to route them",
+        "3": "Escalation objects exist but do not name a layer",
+        "4": "Escalations carry beat, layer, defect and what would resolve it, and are recorded in the artifact",
+        "5": "As 4, and architecture-layer escalations produced a spine version bump and a re-pass rather than a local patch"
+      }
+    },
+    {
+      "name": "Handoff Legibility",
+      "description": "Whether the manifest survives being read by an agent that inherits nothing",
+      "weight": 1.0,
+      "scores": {
+        "1": "Refers to 'the architecture we built' and 'the next section'; unusable without the prior conversation",
+        "2": "Relative paths and an implied scope",
+        "3": "Absolute paths, but scope is described rather than enumerated",
+        "4": "Absolute paths, explicit beat IDs, an out-of-scope statement, and the required return shape",
+        "5": "As 4, plus a precondition check the downstream agent runs first and a style contract with a stated precedence order"
+      }
+    }
+  ]
+}

--- a/skills/narrative-handoff-contract/resources/schema.md
+++ b/skills/narrative-handoff-contract/resources/schema.md
@@ -1,0 +1,232 @@
+# The architecture contract — field reference
+
+`architecture.json` is the artifact. Any markdown companion is generated from it.
+
+Contract version covered here: **1.0**.
+
+---
+
+## Top level
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `contract_version` | string | yes | `"1.0"`. A run that cannot name its contract cannot be diffed later. |
+| `run_header` | object | yes | Provenance. See below. |
+| `frame_lock` | object | yes | What is being counted, over what, for whom. |
+| `form` | object | yes | The triage verdict and which rung of the downgrade ladder shipped. |
+| `protagonist` | object | yes | Person, composite, or system. Systems carry extra obligations. |
+| `designing_principle` | object | yes | Statement plus the claims it excludes. |
+| `spine` | object | yes | The chosen structure and the one rejected. |
+| `slots` | array | yes | The architecture proper. |
+| `scenes` | array | no | Tagged scene weave. Present when the form admits scenes. |
+| `gaps` | array | yes | May be empty only if genuinely nothing is missing, which is rare. |
+| `dead_column` | array | yes | Killed findings, kept. |
+| `hypothesis_diff` | object | no | Strongly recommended. What changed between the starting guess and the derived spine. |
+| `escalations_received` | array | no | Defects sent back up from the drafting layer. |
+
+## `run_header`
+
+| Field | Type | Notes |
+|---|---|---|
+| `model` | string | Which model produced this. Tuning on one model silently breaks others. |
+| `corpus_ref` | string | A path, a commit, or a freeze tag. |
+| `timestamp` | string | ISO 8601. |
+| `claim_ids_consulted` | array of string | The **coverage receipt**. If the corpus exceeded the context budget, this is the only record of what was actually seen. |
+| `claim_ids_skipped` | array of string | Optional but honest. Silent partial coverage defeats every downstream audit. |
+
+## `frame_lock`
+
+`unit`, `denominator`, `window`, `population`, each a string, plus `rejected_alternatives` — an array of `{field, alternative, why_rejected}`.
+
+Denominator drift is the failure where every exhibit is defensible and the sequence is a lie. Locking the frame once, in writing, is what makes drift detectable.
+
+## `form`
+
+| Field | Type | Notes |
+|---|---|---|
+| `verdict` | string | `story-narrative`, `explanatory-narrative`, `gathering`, or `do-not-narrate`. |
+| `rung` | integer | 1–5 on the downgrade ladder. |
+| `failing_questions` | array | Which triage questions failed, by number. |
+| `downgrade_reason` | string | Required when `rung > 1`. |
+| `research_requests` | array | `{gap, artifact_that_would_fill_it, slot_unblocked}`. Required when `rung > 1`. |
+
+## `protagonist`
+
+`type` is `person`, `composite`, or `system`.
+
+When `type` is `system`, these become required:
+
+| Field | Why |
+|---|---|
+| `stated_purpose` | Quoted verbatim from a real document — a charter, prospectus, mission statement, launch post. |
+| `revealed_function` | What the system reliably converts into what, inferred from outcomes. |
+| `gap` | One sentence. The gap between stated and revealed is the dramatic engine; no gap means no narrative. |
+| `regimes_evidenced` | At least **two** distinct regimes (boom and bust, normal and incident). A function inferred from one episode is a description of that episode dressed as a character trait. |
+| `outcomes_unexplained` | At least one. Every inferred objective function fails to explain something, and that list reaches the reader. |
+
+## `slots[]`
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string | Unique. |
+| `name` | string | `inciting_event`, `climax`, `self_revelation`, or a spine-specific slot name. |
+| `status` | enum | `FILLED`, `ABSENT`, `INFERRED`. **ABSENT is a passing state.** |
+| `evidence` | array of claim ID | Required unless `ABSENT`. **This is the validated field, not `value`.** |
+| `warrant` | string | Why this evidence fills this slot. Checked against the tier's permitted verbs. |
+| `causal_tier` | enum | `L1` mechanism, `L2` correlation, `L3` sequence, `L4` adjacency, `L5` conjecture. Only L1 may assert causation. |
+| `empty_slot_move` | string | Required when `ABSENT`: `DECLARE`, `DOWNGRADE`, or `REDESIGN`. |
+| `source_dates` | array | Recommended. A starting weakness needs a source predating the outcome. |
+
+Budget: at most **one** `INFERRED` slot per piece, and never the climax.
+
+## `scenes[]`
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string | Unique. |
+| `slot_id` | string | Must match a slot. |
+| `tagged_line` | string | **Length-capped.** A tag, not a draft. This cap is what stops the structural layer drafting. |
+| `whose_desire`, `opposition`, `plan`, `endpoint`, `twist` | string | Construction fields. |
+| `carrier` | enum | `prose`, `exhibit`, or `both`. The non-carrier may not restate the claim at full strength. |
+| `position` | string | `opener`, `climax`, `closer`, or a section name. |
+| `representativeness` | enum | `median`, `tail`, `unique`. **Required in load-bearing positions.** Assigned upstream against the corpus, never by the drafting agent. |
+| `rung` | enum | `R1`–`R4` on the ladder of abstraction. |
+| `provenance` | array of claim ID | Required. |
+
+## `gaps[]`
+
+`{slot_id, gap_type, disposition}` where `gap_type` is one of missing scene, motive, quote, number, causal link, outcome; and `disposition` is `RESEARCH`, `REDESIGN`, `DECLARE`, or `CUT`.
+
+There is no `draft and flag`. Flagged drafted text survives review at high rates because it reads well.
+
+## `dead_column[]`
+
+`{claim_id, killed_by, reason}` where `reason` is `did_not_support` or `CONTRADICTED`.
+
+`did_not_support` may be pruned from the deliverable. `CONTRADICTED` always reaches the reader. This distinction is the difference between editing and cherry-picking.
+
+---
+
+## Worked example — a system protagonist
+
+```json
+{
+  "contract_version": "1.0",
+  "run_header": {
+    "model": "claude-opus-5",
+    "corpus_ref": "corpus/freeze-2026-03-11",
+    "timestamp": "2026-03-14T09:22:00Z",
+    "claim_ids_consulted": ["c-001", "c-002", "c-118", "c-204"],
+    "claim_ids_skipped": []
+  },
+  "frame_lock": {
+    "unit": "settled trades per venue",
+    "denominator": "all trades reaching settlement, not all submitted orders",
+    "window": "1994-01-01 to 2009-12-31",
+    "population": "the four venues with continuous public reporting",
+    "rejected_alternatives": [
+      {
+        "field": "denominator",
+        "alternative": "all submitted orders",
+        "why_rejected": "two venues stopped publishing rejected-order counts in 1998, so the series breaks"
+      }
+    ]
+  },
+  "form": {
+    "verdict": "explanatory-narrative",
+    "rung": 2,
+    "failing_questions": [5, 6],
+    "downgrade_reason": "No evidenced point of insight. Behaviour changes across the window, but no dated moment shows participants recognising why, and the record reaches no stable end state.",
+    "research_requests": [
+      {
+        "gap": "A contemporaneous document showing a participant recognising the settlement lag as structural rather than operational",
+        "artifact_that_would_fill_it": "Clearing-committee minutes 1999-2001, or an internal risk memo",
+        "slot_unblocked": "point_of_insight"
+      }
+    ]
+  },
+  "protagonist": {
+    "type": "system",
+    "stated_purpose": "\"to guarantee settlement of every matched trade\" (1994 rulebook, s.1.2)",
+    "revealed_function": "converts counterparty risk into timing risk, by deferring failures to the settlement window rather than preventing them",
+    "gap": "The rulebook promises elimination; the record shows relocation.",
+    "regimes_evidenced": ["1994-1997 low-volume normal", "1998 stress episode"],
+    "outcomes_unexplained": [
+      "The 2003 fee change reduced fails by a third with no rule change, which a pure timing-relocation account does not predict."
+    ]
+  },
+  "designing_principle": {
+    "statement": "Follow one trade from match to settlement in each of three regimes, and let the widening gap between the rulebook and the tape carry the argument.",
+    "claims_excluded": [
+      "c-044 the 2011 governance dispute, outside the window",
+      "c-077 comparative European venue structure, a different denominator",
+      "c-155 the founder's biography, no bearing on the mechanism"
+    ]
+  },
+  "spine": {
+    "abt": "The venue guaranteed settlement AND volumes grew twelvefold, BUT the guarantee moved failures into the settlement window rather than removing them, THEREFORE the 1998 stress was a timing failure that the rulebook had no language for.",
+    "structure": "layer-cake explanatory narrative on a traveling-object action line",
+    "runner_up": "braided mosaic across three venues",
+    "runner_up_reason": "Rejected: only one venue has continuous ground-level artifacts, so two strands would run at summary distance and the braid would be decorative.",
+    "boredom_permitted": "Inside a digression the preceding scene has paid for, and only for a length not exceeding that scene.",
+    "spine_version": 1
+  },
+  "slots": [
+    {
+      "id": "s1",
+      "name": "inciting_event",
+      "status": "FILLED",
+      "evidence": ["c-002", "c-118"],
+      "warrant": "The 1994 rulebook takes effect and the guarantee language appears; both venues' volumes diverge in the following quarter.",
+      "causal_tier": "L3",
+      "source_dates": ["1994-02-11", "1994-07-30"]
+    },
+    {
+      "id": "s2",
+      "name": "point_of_insight",
+      "status": "ABSENT",
+      "empty_slot_move": "DECLARE",
+      "warrant": "No source records anyone naming the lag as structural before 2004. The absence is stated in the body."
+    }
+  ],
+  "scenes": [
+    {
+      "id": "sc1",
+      "slot_id": "s1",
+      "tagged_line": "1994 rulebook takes effect; first matched trade under the guarantee clears in 90 minutes",
+      "whose_desire": "clearing members, for a guarantee that removes counterparty checks",
+      "opposition": "settlement capacity, fixed at the 1991 build",
+      "plan": "guarantee first, add capacity later",
+      "endpoint": "the clause is live and the first trade clears",
+      "twist": "the 90 minutes is already at the ceiling",
+      "carrier": "both",
+      "position": "opener",
+      "representativeness": "median",
+      "rung": "R1",
+      "provenance": ["c-002"]
+    }
+  ],
+  "gaps": [
+    { "slot_id": "s2", "gap_type": "missing causal link", "disposition": "DECLARE" }
+  ],
+  "dead_column": [
+    {
+      "claim_id": "c-091",
+      "killed_by": "instrument check",
+      "reason": "did_not_support"
+    },
+    {
+      "claim_id": "c-133",
+      "killed_by": "graveyard pass",
+      "reason": "CONTRADICTED"
+    }
+  ],
+  "hypothesis_diff": {
+    "before": "The 1998 stress was caused by the volume surge.",
+    "after": "The 1998 stress was a timing failure the guarantee created in 1994; volume made it visible rather than causing it.",
+    "what_changed": "The frozen inventory put two fails-to-deliver spikes before the volume surge, which the original hypothesis could not accommodate."
+  }
+}
+```
+
+Note what this example does **not** do. It does not fill `point_of_insight`. It ships at rung 2 with a research request naming exactly what would lift it to rung 1. Its one causal slot is tagged `L3` — sequence, not cause — and its warrant uses no causal verb. That is what a passing architecture looks like.

--- a/skills/narrative-handoff-contract/resources/validate_architecture.py
+++ b/skills/narrative-handoff-contract/resources/validate_architecture.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Validate a narrative architecture against the handoff contract.
+
+The contract exists because a two-agent pipeline whose interface is prose has no
+interface at all. This script is the mechanism behind three rules that are otherwise
+just good intentions:
+
+  1. The evidence array, not the value, is the validated field. A slot carrying a
+     confident sentence and no claim ID fails here rather than reading well downstream.
+  2. ABSENT is a passing state. An architecture with every slot filled is flagged,
+     because real material always has holes.
+  3. The macro layer must not draft. A length cap on scene lines enforces that
+     mechanically; a prose prohibition in a system prompt decays as context fills.
+
+Usage:
+    python3 validate_architecture.py ARCHITECTURE_JSON [--corpus-root DIR]
+                                     [--output-root DIR] [--strict]
+
+Exit codes:
+    0  contract satisfied (warnings may still be printed)
+    1  contract violated
+    2  file missing, unreadable, or not valid JSON
+
+--strict promotes warnings to errors. Use it in CI; leave it off while drafting.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+# --- Tunable limits -----------------------------------------------------------------
+# Each has a stated reason. None of these is a magic number.
+
+# A scene line is a tag, not a draft. 200 characters is roughly two sentences of
+# summary — enough to identify the beat and its construction, too short to be prose.
+MAX_TAGGED_LINE_CHARS = 200
+
+# Truby licenses fewer than 22 steps and treats only seven as mandatory. An
+# architecture in which nothing is ABSENT has almost certainly been slot-filled.
+MIN_ABSENT_SLOTS = 1
+
+# A designing principle that excludes nothing organises nothing. Three is the
+# smallest number that demonstrates the principle is actually cutting.
+MIN_CLAIMS_EXCLUDED = 3
+
+# At most one slot may be filled by inference, and never the climax. More than one
+# and the architecture is carrying the argument rather than the evidence.
+MAX_INFERRED_SLOTS = 1
+
+VALID_STATUS = {"FILLED", "ABSENT", "INFERRED"}
+VALID_TIERS = {"L1", "L2", "L3", "L4", "L5"}
+VALID_DISPOSITIONS = {"RESEARCH", "REDESIGN", "DECLARE", "CUT"}
+VALID_DEAD_REASONS = {"did_not_support", "CONTRADICTED"}
+VALID_REPRESENTATIVENESS = {"median", "tail", "unique"}
+VALID_PROTAGONIST_TYPES = {"person", "composite", "system"}
+LOAD_BEARING = {"opener", "climax", "closer"}
+
+# Verbs each causal tier licenses. L1 is the only tier permitted to assert causation.
+TIER_BANNED_VERBS = {
+    "L2": r"\b(because|drove|forced|caused|triggered|led to|resulted in)\b",
+    "L3": r"\b(because|drove|forced|caused|triggered|led to|resulted in|coincided with)\b",
+    "L4": r"\b(because|drove|forced|caused|triggered|led to|resulted in)\b",
+    "L5": r"\b(because|drove|forced|caused|triggered|led to|resulted in)\b",
+}
+
+SUPPORTED_CONTRACT_VERSIONS = {"1.0"}
+
+
+class Report:
+    """Collects findings so the caller sees every problem, not just the first."""
+
+    def __init__(self):
+        self.errors = []
+        self.warnings = []
+
+    def error(self, where, message):
+        self.errors.append((where, message))
+
+    def warn(self, where, message):
+        self.warnings.append((where, message))
+
+    def emit(self, strict):
+        for where, message in self.errors:
+            print(f"ERROR  {where}: {message}")
+        for where, message in self.warnings:
+            label = "ERROR " if strict else "WARN  "
+            print(f"{label} {where}: {message}")
+        failed = bool(self.errors) or (strict and bool(self.warnings))
+        counts = f"{len(self.errors)} error(s), {len(self.warnings)} warning(s)"
+        print(f"\n{'REFUSED' if failed else 'CONTRACT SATISFIED'} — {counts}")
+        return 1 if failed else 0
+
+
+def require(report, obj, key, where):
+    """Return obj[key], recording an error when it is missing or empty."""
+    value = obj.get(key)
+    if value is None or value == "" or value == []:
+        report.error(where, f"required field '{key}' is missing or empty")
+        return None
+    return value
+
+
+def check_header(doc, report):
+    version = doc.get("contract_version")
+    if version not in SUPPORTED_CONTRACT_VERSIONS:
+        report.error(
+            "contract_version",
+            f"got {version!r}, expected one of {sorted(SUPPORTED_CONTRACT_VERSIONS)}",
+        )
+
+    header = doc.get("run_header") or {}
+    if not header:
+        report.error("run_header", "missing — a run with no provenance cannot be reproduced")
+        return
+    for key in ("model", "corpus_ref", "timestamp", "claim_ids_consulted"):
+        require(report, header, key, "run_header")
+
+    consulted = header.get("claim_ids_consulted")
+    if isinstance(consulted, list) and not consulted:
+        report.error(
+            "run_header.claim_ids_consulted",
+            "empty — an architecture built from no claims is not an architecture",
+        )
+
+
+def check_frame_and_principle(doc, report):
+    frame = doc.get("frame_lock") or {}
+    for key in ("unit", "denominator", "window", "population"):
+        require(report, frame, key, "frame_lock")
+    rejected = frame.get("rejected_alternatives") or []
+    if not rejected:
+        report.warn(
+            "frame_lock.rejected_alternatives",
+            "empty — a frame chosen without a named alternative was not chosen, it was assumed",
+        )
+
+    principle = doc.get("designing_principle") or {}
+    require(report, principle, "statement", "designing_principle")
+    excluded = principle.get("claims_excluded") or []
+    if len(excluded) < MIN_CLAIMS_EXCLUDED:
+        report.error(
+            "designing_principle.claims_excluded",
+            f"{len(excluded)} claim(s) excluded, need at least {MIN_CLAIMS_EXCLUDED}. "
+            "A principle that excludes nothing organises nothing.",
+        )
+
+
+def check_protagonist(doc, report):
+    prot = doc.get("protagonist") or {}
+    ptype = prot.get("type")
+    if ptype not in VALID_PROTAGONIST_TYPES:
+        report.error("protagonist.type", f"got {ptype!r}, expected one of {sorted(VALID_PROTAGONIST_TYPES)}")
+    if ptype != "system":
+        return
+
+    # A system protagonist carries extra obligations, because the character is inferred
+    # from behaviour rather than stated by a person.
+    for key in ("stated_purpose", "revealed_function", "gap"):
+        require(report, prot, key, "protagonist")
+
+    regimes = prot.get("regimes_evidenced") or []
+    if len(regimes) < 2:
+        report.error(
+            "protagonist.regimes_evidenced",
+            f"{len(regimes)} regime(s). A revealed objective function derived from one "
+            "episode is a description of that episode dressed as a character trait.",
+        )
+
+    unexplained = prot.get("outcomes_unexplained") or []
+    if not unexplained:
+        report.error(
+            "protagonist.outcomes_unexplained",
+            "empty — every inferred objective function fails to explain something, and "
+            "that list must reach the reader",
+        )
+
+
+def check_slots(doc, report):
+    slots = doc.get("slots") or []
+    if not slots:
+        report.error("slots", "empty — there is no architecture here")
+        return
+
+    absent = inferred = 0
+    seen_ids = set()
+
+    for slot in slots:
+        sid = slot.get("id", "<no id>")
+        where = f"slot[{sid}]"
+
+        if sid in seen_ids:
+            report.error(where, "duplicate slot id")
+        seen_ids.add(sid)
+
+        status = slot.get("status")
+        if status not in VALID_STATUS:
+            report.error(where, f"status {status!r} not one of {sorted(VALID_STATUS)}")
+            continue
+
+        if status == "ABSENT":
+            absent += 1
+            if not slot.get("empty_slot_move"):
+                report.error(
+                    where,
+                    "ABSENT with no empty_slot_move. Choose DECLARE, DOWNGRADE or REDESIGN — "
+                    "an unhandled absence becomes an invention downstream.",
+                )
+            continue
+
+        if status == "INFERRED":
+            inferred += 1
+            if str(slot.get("name", "")).lower() == "climax":
+                report.error(where, "the climax may never be filled by inference")
+
+        # This is the rule the whole contract exists for.
+        evidence = slot.get("evidence") or []
+        if not evidence:
+            report.error(
+                where,
+                f"status {status} with no evidence[]. The evidence array is the validated "
+                "field, not the value. A confident sentence with no claim ID is not a slot.",
+            )
+
+        tier = slot.get("causal_tier")
+        if tier is not None and tier not in VALID_TIERS:
+            report.error(where, f"causal_tier {tier!r} not one of {sorted(VALID_TIERS)}")
+        elif tier in TIER_BANNED_VERBS:
+            warrant = str(slot.get("warrant") or "")
+            hit = re.search(TIER_BANNED_VERBS[tier], warrant, re.IGNORECASE)
+            if hit:
+                report.error(
+                    where,
+                    f"tier {tier} warrant uses causal verb '{hit.group(0)}'. Only L1 "
+                    "(documented mechanism) may assert causation.",
+                )
+
+    if absent < MIN_ABSENT_SLOTS:
+        report.warn(
+            "slots",
+            f"{absent} slot(s) ABSENT. Every slot filled is a defect, not a triumph — "
+            "real material always has holes.",
+        )
+    if inferred > MAX_INFERRED_SLOTS:
+        report.error(
+            "slots",
+            f"{inferred} slots filled by inference, budget is {MAX_INFERRED_SLOTS}",
+        )
+
+
+def check_scenes(doc, report):
+    slot_ids = {s.get("id") for s in (doc.get("slots") or [])}
+    for scene in doc.get("scenes") or []:
+        sid = scene.get("id", "<no id>")
+        where = f"scene[{sid}]"
+
+        if scene.get("slot_id") not in slot_ids:
+            report.error(where, f"slot_id {scene.get('slot_id')!r} does not match any slot")
+
+        line = str(scene.get("tagged_line") or "")
+        if not line:
+            report.error(where, "tagged_line is empty")
+        elif len(line) > MAX_TAGGED_LINE_CHARS:
+            report.error(
+                where,
+                f"tagged_line is {len(line)} chars, cap is {MAX_TAGGED_LINE_CHARS}. "
+                "The macro layer tags scenes; it does not draft them.",
+            )
+
+        if not (scene.get("provenance") or []):
+            report.error(where, "no provenance[] — every scene traces to claims or it is invented")
+
+        rep = scene.get("representativeness")
+        position = str(scene.get("position") or "").lower()
+        if rep is not None and rep not in VALID_REPRESENTATIVENESS:
+            report.error(where, f"representativeness {rep!r} not one of {sorted(VALID_REPRESENTATIVENESS)}")
+        if position in LOAD_BEARING and not rep:
+            report.error(
+                where,
+                f"in load-bearing position '{position}' with no representativeness label. "
+                "An unlabelled case in the opener, climax or closer is the anecdote-"
+                "distribution failure.",
+            )
+
+
+def check_gaps_and_dead(doc, report):
+    for gap in doc.get("gaps") or []:
+        disposition = gap.get("disposition")
+        if disposition not in VALID_DISPOSITIONS:
+            report.error(
+                f"gap[{gap.get('slot_id', '?')}]",
+                f"disposition {disposition!r} not one of {sorted(VALID_DISPOSITIONS)}. "
+                "'draft and flag' is not a disposition — flagged prose survives review.",
+            )
+
+    dead = doc.get("dead_column")
+    if dead is None:
+        report.error(
+            "dead_column",
+            "missing. Killed findings are kept, never deleted — this is the record of "
+            "what the story is not, and the only defence against a cherry-picking claim.",
+        )
+        return
+    for entry in dead:
+        reason = entry.get("reason")
+        if reason not in VALID_DEAD_REASONS:
+            report.error(
+                f"dead_column[{entry.get('claim_id', '?')}]",
+                f"reason {reason!r} not one of {sorted(VALID_DEAD_REASONS)}",
+            )
+
+
+def check_circular_citation(doc, report, corpus_root, output_root):
+    """A pointer resolving into the pipeline's own outputs is a hard failure.
+
+    Agent A summarises, agent B structures from the summary, agent C cites A's summary
+    as a source. Every claim has a pointer, nothing has a source, and no single agent
+    did anything wrong. This is invisible to reading, so it must be checked here.
+    """
+    if not output_root:
+        return
+    output_root = os.path.abspath(output_root)
+
+    def flag(where, pointer):
+        resolved = os.path.abspath(os.path.join(corpus_root or ".", str(pointer)))
+        if resolved.startswith(output_root + os.sep):
+            report.error(
+                where,
+                f"provenance pointer {pointer!r} resolves inside the pipeline's own output "
+                "directory. Pointers must resolve to external artifacts.",
+            )
+
+    for slot in doc.get("slots") or []:
+        for pointer in slot.get("evidence") or []:
+            flag(f"slot[{slot.get('id', '?')}].evidence", pointer)
+    for scene in doc.get("scenes") or []:
+        for pointer in scene.get("provenance") or []:
+            flag(f"scene[{scene.get('id', '?')}].provenance", pointer)
+
+
+def check_spine_and_diff(doc, report):
+    spine = doc.get("spine") or {}
+    for key in ("abt", "structure", "spine_version"):
+        require(report, spine, key, "spine")
+    if not spine.get("runner_up"):
+        report.warn(
+            "spine.runner_up",
+            "no runner-up structure named. A structure chosen without a rejected "
+            "alternative was not chosen.",
+        )
+    if not spine.get("boredom_permitted"):
+        report.warn(
+            "spine.boredom_permitted",
+            "unstated. If you cannot say where this structure lets the reader be bored, "
+            "you have not chosen a structure.",
+        )
+
+    if not doc.get("hypothesis_diff"):
+        report.warn(
+            "hypothesis_diff",
+            "missing. The diff between the starting hypothesis and the derived spine is "
+            "how you show the evidence did its job.",
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("architecture", help="path to architecture.json")
+    parser.add_argument("--corpus-root", default=None, help="root that provenance pointers resolve against")
+    parser.add_argument("--output-root", default=None, help="pipeline output dir, for the circular-citation check")
+    parser.add_argument("--strict", action="store_true", help="treat warnings as errors")
+    args = parser.parse_args()
+
+    try:
+        with open(args.architecture, "r", encoding="utf-8") as handle:
+            doc = json.load(handle)
+    except FileNotFoundError:
+        print(f"ERROR  {args.architecture}: file not found")
+        return 2
+    except json.JSONDecodeError as exc:
+        print(f"ERROR  {args.architecture}: not valid JSON — {exc}")
+        return 2
+    except OSError as exc:
+        print(f"ERROR  {args.architecture}: could not be read — {exc}")
+        return 2
+
+    if not isinstance(doc, dict):
+        print(f"ERROR  {args.architecture}: top level must be an object, got {type(doc).__name__}")
+        return 2
+
+    report = Report()
+    check_header(doc, report)
+    check_frame_and_principle(doc, report)
+    check_protagonist(doc, report)
+    check_spine_and_diff(doc, report)
+    check_slots(doc, report)
+    check_scenes(doc, report)
+    check_gaps_and_dead(doc, report)
+    check_circular_citation(doc, report, args.corpus_root, args.output_root)
+    return report.emit(args.strict)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/narrative-opposition-web/SKILL.md
+++ b/skills/narrative-opposition-web/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: narrative-opposition-web
+description: Builds a four-corner opposition web for narrative nonfiction and stops the writer from casting whoever lost as the villain. Runs Truby's four-corner worksheet (shared central moral problem, per-corner value clusters, distinct routes of attack, corner-to-corner conflict), the best-possible-opponent audit (same goal, necessity, relentlessness, value conflict, the double, power parity, justification in the opponent's own voice), the Opponent Warrant evidence test that demotes undocumented antagonists to rivals or constraints, and a drive-section collapse check that catches a web that was decorative. Use when planning a piece with competing parties, when an antagonist feels flat or cartoonish, when the protagonist is a system rather than a person, or when user mentions opposition web, four-corner opposition, antagonist, opponent, villain, steelman the other side, character web, who is the bad guy here.
+---
+
+# Narrative Opposition Web
+
+## Table of Contents
+- [Core Principles](#core-principles)
+- [Workflow](#workflow)
+- [Opponent Warrant Tiers](#opponent-warrant-tiers)
+- [When the Protagonist Is a System](#when-the-protagonist-is-a-system)
+- [Guardrails](#guardrails)
+- [Quick Reference](#quick-reference)
+
+**Related skills:** Use `dialectical-mapping-steelmanning` for deep steelmanning of one opposing position, `writing-structure-planner` for the sequence the web will be delivered in, `deliberation-debate-red-teaming` for attacking your own thesis, `causal-inference-root-cause` when the question is causation rather than opposition. Use `systemic-protagonist` for the full agency-repair table and the responsibility-laundering check that this skill's system section only summarises, `narrative-arc-mapping` for the mandatory-seven triage that consumes the warranted opponent.
+
+**Attribution caveat, carry it into any output:** four-corner opposition, the same-goal rule, and the opponent's justification requirement are John Truby's (*The Anatomy of Story*). Everything numeric in this skill — three appearances per corner, three-of-three warrant evidence, four-corner maximum — is a derived operational default set for auditability, not a published threshold from Truby or anyone else. State it as a default you chose, never as a rule someone established. The word "satellite" for a corner that only opposes the protagonist is this skill's label, not a term of art.
+
+## Core Principles
+
+1. **Corners are defined relationally, never individually**: a corner is not a party you find interesting. It is a distinct answer to one shared question. Build the question first.
+2. **Same goal or no opponent**: two parties who want different things can both win and there is no opposition. Name the single scarce thing both are fighting to control, or demote the party.
+3. **Losing is not a warrant**: the entity that lost is the default villain and the default villain is almost always wrong. Opposition must be evidenced, not inferred from the outcome.
+4. **A corner that only opposes the protagonist is a satellite**: real corners collide with each other too. If C and D never touch, you have a two-part opposition wearing four hats.
+5. **In a system narrative the opponent is usually a constraint**: physics, capital cost, regulation, latency, yield, a legal deadline. Filling the slot with a person because the slot exists is the failure, not the fix.
+6. **The empty slot is a finding**: "no adversary appears in the record; the binding constraint was X" is a successful output. Report it in the same voice as a filled slot.
+7. **Justification is the test of understanding**: if you cannot write the opponent's case so a smart person holding it recognises themselves, you do not yet know what the fight was about.
+
+## Workflow
+
+Copy this checklist and track your progress:
+
+```
+Opposition Web Progress:
+- [ ] Step 1: State the central moral problem as one question
+- [ ] Step 2: Warrant every candidate before it becomes a corner
+- [ ] Step 3: Fill the four-corner worksheet and push to corners
+- [ ] Step 4: Run the best-possible-opponent audit on corner B
+- [ ] Step 5: Run the delete test, the exposure check, and the drive collapse check
+```
+
+**Step 1: State the central moral problem as one question**
+
+Step 1.1: Write one question that every corner will answer differently. It must be answerable in more than one defensible way. Good: "How much of a scarce good do you let spoil in order to reach the people hardest to reach?" Bad: "Was the ministry negligent?" — that has one defensible answer and will produce a prosecution, not a web.
+
+Step 1.2: Sanity-check it against the material. If every party in the record gave the same answer, there is no web here. Say so and stop; a piece can be an explanation rather than a conflict.
+
+Step 1.3: If the material is value-neutral — a benchmark result, a pricing mechanism, a taxonomy — record "no moral problem available; this is explanatory material" and run only the constraint inventory in [resources/opponent-warrant.md](resources/opponent-warrant.md).
+
+**Step 2: Warrant every candidate before it becomes a corner**
+
+Step 2.1: List every candidate opponent. For each, gather three independent evidence types: COMPETITION (both sought the same scarce object at overlapping times), AWARENESS (each knew of the other), DIRECTED ACTION (at least one act by A the record shows was taken *because of* B).
+
+Step 2.2: Tier each candidate per [Opponent Warrant Tiers](#opponent-warrant-tiers). Three of three is an opponent, two is a rival, one or zero is environmental pressure. Record the tier and the citation for each evidence type.
+
+Step 2.3: Apply the verb constraints for the tier immediately, in your notes, before any prose exists. Verbs leak; fixing them later is harder than assigning them now.
+
+Step 2.4: If no candidate reaches two of three, do not proceed to a web. Go to the mystery substitute in [resources/opponent-warrant.md](resources/opponent-warrant.md).
+
+**Step 3: Fill the four-corner worksheet and push to corners**
+
+Step 3.1: Place the protagonist at A and the highest-warranted opponent at B. Choose C and D by a single rule: a different ROUTE of attack on the protagonist's weakness. Not a different opinion — a different mechanism.
+
+Step 3.2: Fill every field for all four corners using [resources/four-corner-worksheet.md](resources/four-corner-worksheet.md). Values are stated as goods, three to five per corner, and every value must be traceable to something that corner said or did with a citation. A value you inferred is an inference; label it one or cut it.
+
+Step 3.3: PUSH CHECK. Compare each pair of corners and name the sharpest difference. Any value shared between two corners means one of them changes or gets cut.
+
+Step 3.4: CONFLICT CHECK. For each pair, state what they fight over and cite it. A corner that conflicts only with A is a satellite. Promote it by finding its real quarrel with C or D, or cut it and run an honest three-corner web.
+
+**Step 4: Run the best-possible-opponent audit on corner B**
+
+Step 4.1: Work the seven gates in [resources/opponent-warrant.md](resources/opponent-warrant.md): same goal, necessity, relentlessness, value conflict, the double, power parity, justification. When corner B is a constraint rather than a party, use the **system variant** given under gates 5, 6 and 7. A constraint has no mirror, no status and no voice, and forcing one on it is the anthropomorphism this skill bans.
+
+Step 4.2: Write the justification paragraph in the opponent's own voice, first person, no hedging, no self-incrimination, no villain tell. Then apply the RECOGNITION TEST: would a competent person who holds this position read it and say "yes, that is why I did it"? If not, rewrite. This paragraph is a mandatory artifact and is delivered alongside the web, not discarded after the check.
+
+Step 4.3: FALSIFICATION PASS. If B's justification is more persuasive than A's, you have assigned the roles backwards. Swap them and re-derive rather than weakening B.
+
+**Step 5: Run the delete test, the exposure check, and the drive collapse check**
+
+Step 5.1: DELETE TEST. Remove corner D. Does any argument in the piece break? If nothing breaks, D was decoration. Give it a genuine competing value cluster or drop to three corners and say so.
+
+Step 5.2: EXPOSURE CHECK. Flag every corner occupied by a real named living person or an active institution. Do not adjudicate the framing yourself. Surface it: the party, the slot, the adverse inference being made, the evidence behind it, and the fact that a subject who gave an interview consented to an interview and not to a structural role. Hand the decision to a human.
+
+Step 5.3: COLLAPSE CHECK, run on the finished draft and not before. Audit for corners C and D in the DRIVE section specifically — the middle, after the plan and before the resolution. Count appearances per corner in the drive only. Default target: at least three, and at least one in the final third. Corners appearing only in setup mean the web was decorative and the prose collapsed to A-versus-B. See [resources/four-corner-worksheet.md](resources/four-corner-worksheet.md) for the audit procedure.
+
+Validate using [resources/evaluators/rubric_narrative_opposition_web.json](resources/evaluators/rubric_narrative_opposition_web.json). **Minimum standard:** average score >= 3.5.
+
+## Opponent Warrant Tiers
+
+No antagonist without documented opposition. Tier decides the verbs, and the verbs are the claim.
+
+| Evidence present | Tier | Permitted verbs | Forbidden |
+|---|---|---|---|
+| Competition + awareness + directed action (3/3) | **OPPONENT** | targeted, countered, retaliated against, undercut, moved to block | — |
+| Any two of three | **RIVAL** | competed with, gained share against, bid against, arrived at the same time | any verb implying the act was aimed at the other party |
+| One or none | **ENVIRONMENT / CONSTRAINT** | coincided with, constrained, bound, was present during, set the ceiling on | every transitive verb of intent |
+
+Worked contrast, drawn from a municipal transit case:
+
+- Bad: "The state highway department moved to strangle the streetcar line." Evidence: the department funded a parallel arterial the same year ridership fell. That is competition and coincidence. No awareness document, no "because."
+- Good: "The arterial opened in the same fiscal year ridership fell by a fifth. No document in the department's files mentions the streetcar line; the ceiling on the line's fare box was set by a road it was never told about." Same facts, honest tier, and the sentence is more interesting because the indifference is the point.
+
+Mirror failure to watch: refusing to name a real, documented rivalry because a thin archive is missing one of the three evidence types. Two of three plus an explicit note on what is missing is an honest rival, not a demotion to weather.
+
+## When the Protagonist Is a System
+
+A market, a protocol, an institution, a codebase, a supply chain, an ecosystem. The web still works because its primitives are functional, but three things change.
+
+**The B slot is usually a constraint, not a party.** Physics, capital cost, a regulatory regime, latency, yield, a legal deadline, a 2-to-8-degree cold-chain tolerance. Fill it with a named force plus a documented mechanism. Never with an anthropomorphised abstraction. "The market wanted consolidation" is a causal claim wearing a sentence. Cash it out or delete it. Cashed out: "clearing fees fell below the cost of running an independent desk, and eleven of fourteen desks closed within two years." Full repair table in `systemic-protagonist`.
+
+**Corners get value clusters by delegation.** A constraint has no values. Give the corner a named human or institutional carrier who demonstrably held the position, and let the carrier's documented statements be the value cluster. If no carrier exists, the corner is environment and belongs in the constraint inventory, not the web.
+
+**Systemic framing must be additive to individual accountability, never a substitute.** "The system failed" is often a sentence written to avoid naming a person. For every systemic attribution, ask whether a specific named actor had the authority and the information to do otherwise. If yes, name them. Run this in both directions: the frame that dissolves a decision-maker into a structure is the same error as the frame that dissolves a structure into a villain. Full responsibility-laundering check in `systemic-protagonist`.
+
+Do not translate archetypes (King, Trickster, Mentor) onto institutions. They are the most psychology-dependent part of the apparatus and produce nonsense here.
+
+Do not let the institutions-as-larger-forces frame become the finding. It is a stance, not a discovery. If every corner's attempt to change the system fails in your account, you have written inevitability with the sign flipped. Include at least one documented partial success, or state explicitly the conditions under which this system has changed before.
+
+## Guardrails
+
+**Requirements:**
+
+1. **Warrant before web**: every corner carries a tier and a citation per evidence type before it is written about. Untiered corners do not enter the draft.
+2. **Justification is a deliverable**: corner B's first-person justification paragraph ships with the web and passes the recognition test. No paragraph and no documented carrier, no opponent — route the corner to the constraint inventory instead.
+3. **Values are cited, not inferred**: each of the three-to-five values per corner points at something that party said or did. Inferred values are labelled as inferences in the worksheet.
+4. **Empty and absent are first-class outputs**: "no opponent in the record," "three corners, not four," "no moral problem available" are complete answers. Report them with the same confidence as a filled web.
+5. **Named living parties are escalated, not resolved**: adverse inference about a real person or an active institution is surfaced for human decision. The skill does not adjudicate defamation risk or consent.
+6. **The collapse check runs on the draft**: the web is not validated by the worksheet. It is validated by counting C and D in the drive section of finished prose.
+
+**Common pitfalls:**
+
+- Casting the loser as the opponent, then backfilling stupidity or malice as motive. This is bad craft and bad analysis at once.
+- Padding to four corners with generic placeholders — "regulators," "consumers," "the community" — that carry no independent value system. Three real corners beat four with a mannequin.
+- Writing the justification paragraph with a villain tell inside it ("we knew the risk and shipped anyway"). Opponents do not narrate their own guilt.
+- Manufacturing a same-goal rivalry between parties who were operating in different markets and never contested the same scarce thing.
+- Over-correcting into agentless passive prose ("share was observed to shift") to avoid intentional verbs. The goal is to relocate agency onto whoever has it, not to delete agency. If agentless passives went up after your verb pass, the pass failed.
+- Letting the double reversal degrade into "both sides had a point." A real synthesis produces a THIRD position neither corner held at the start, stateable in one sentence and defensible on the evidence.
+- Treating a constraint as a villain because a villain is easier to narrate. A yield ceiling has no motive and needs none.
+
+## Quick Reference
+
+**Key resources:**
+- **[resources/four-corner-worksheet.md](resources/four-corner-worksheet.md)**: the full worksheet fields, push and conflict and delete tests, the drive collapse audit procedure, three worked webs (open-source governance, public-health logistics, a scientific replication controversy)
+- **[resources/opponent-warrant.md](resources/opponent-warrant.md)**: warrant evidence test, verb tier table with worked repairs, the seven-gate best-possible-opponent audit, justification paragraph templates with strawman-versus-steelman contrasts, the mystery substitute, the system constraint inventory, the exposure escalation format
+- **[resources/evaluators/rubric_narrative_opposition_web.json](resources/evaluators/rubric_narrative_opposition_web.json)**: quality scoring
+
+**Inputs required:**
+- The research corpus, with sources that can be cited per claim
+- The protagonist and its weakness, already fixed (a route of attack has to attack something specific)
+- Whether the protagonist is a person or a system
+- The draft, if the collapse check is being run
+
+**Outputs produced:**
+- The central moral problem as one question, or a recorded finding that none exists
+- A warrant table: candidate, evidence type present, citation, tier, permitted verbs
+- The four-corner worksheet, filled, with push/conflict/delete test results
+- Corner B's justification paragraph in first person, recognition-tested
+- A constraint inventory when the protagonist is a system
+- An exposure list of named living parties in adversarial slots, escalated for human decision
+- A collapse-check report: appearances per corner in the drive section

--- a/skills/narrative-opposition-web/resources/evaluators/rubric_narrative_opposition_web.json
+++ b/skills/narrative-opposition-web/resources/evaluators/rubric_narrative_opposition_web.json
@@ -1,0 +1,104 @@
+{
+  "name": "Narrative Opposition Web Rubric",
+  "description": "Evaluation criteria for a four-corner opposition web built from researched material. Scores the evidentiary warrant behind each corner, the differentiation between corners, the quality of the opponent's justification, the handling of system protagonists and constraints, whether absence was reported honestly, and whether the web survived into the drive section of the finished draft.",
+  "criteria": [
+    {
+      "name": "Opponent Warrant and Verb Discipline",
+      "description": "Whether every adversarial corner was tiered on documented evidence (competition, awareness, directed action) and whether the prose verbs match the tier assigned",
+      "weight": 1.3,
+      "scores": {
+        "1": "The opponent is whoever lost. No warrant test run; motive inferred from outcome; transitive verbs of intent used with no dated source for the 'because'",
+        "2": "Some evidence cited but tiers not assigned, or tiers assigned and then ignored in the prose; rivals written with opponent verbs",
+        "3": "All corners tiered with citations, but at least one tier is generous relative to its evidence, or verb constraints slip in a few sentences",
+        "4": "Every corner tiered with citation per evidence type; verbs match tier throughout; missing evidence types named explicitly",
+        "5": "Full warrant table delivered as an auditable artifact; at least one candidate correctly demoted to rival or environment with the demotion explained; verbs traceable to tier in every adversarial sentence"
+      }
+    },
+    {
+      "name": "Central Moral Problem Quality",
+      "description": "Whether one shared question genuinely organizes the web and admits more than one defensible answer",
+      "weight": 1.0,
+      "scores": {
+        "1": "No central problem stated, or it is a verdict disguised as a question with one defensible answer",
+        "2": "A question is stated but the corners do not actually answer it differently; it is a topic rather than a problem",
+        "3": "A workable question; two corners answer it distinctly, the others restate one of those answers",
+        "4": "A genuine question with four distinct, defensible answers, each traceable to what that corner said or did",
+        "5": "The question is answerable only from this material, each corner's answer is cited, and the question would change the piece if replaced"
+      }
+    },
+    {
+      "name": "Corner Differentiation and Route Distinctness",
+      "description": "Whether each corner carries an independent value cluster and attacks the protagonist's weakness by a mechanism no other corner uses",
+      "weight": 1.2,
+      "scores": {
+        "1": "Corners padded with generic placeholders ('regulators', 'consumers') carrying no independent values; all oppose the protagonist the same way",
+        "2": "Corners have labels but overlapping value clusters; routes of attack differ in opinion rather than mechanism",
+        "3": "Three corners are distinct; the fourth duplicates another's route or shares a value with it",
+        "4": "All corners have cited, non-overlapping value clusters and mechanically distinct routes; push check run and recorded",
+        "5": "Push check and conflict check run on all six pairs with results recorded; every corner conflicts with corners other than the protagonist, each conflict cited"
+      }
+    },
+    {
+      "name": "Justification Strength and Recognition",
+      "description": "Whether the opponent's case is written in their own voice strongly enough that a smart person holding it would recognise themselves",
+      "weight": 1.3,
+      "scores": {
+        "1": "No justification written, or the opponent is given a villain speech that concedes guilt or narrates malice",
+        "2": "A justification exists but is easy to refute; it hedges on the opponent's own behalf or attributes to them motives they never stated",
+        "3": "A coherent justification, but it reads as the writer's summary of the position rather than the position itself",
+        "4": "First-person, non-conceding, factually grounded in what the opponent knew at the time; passes the recognition test",
+        "5": "Passes recognition, concedes the appearance while still concluding, and survives the falsification pass with the role assignment explicitly checked and defended"
+      }
+    },
+    {
+      "name": "System Protagonist and Constraint Handling",
+      "description": "Whether constraints were used where constraints belong, whether abstractions were kept out of intentional verbs, and whether systemic framing was checked against individual accountability",
+      "weight": 1.2,
+      "scores": {
+        "1": "An abstraction is written as an agent ('the market wanted', 'the protocol decided'); or a person is cast as villain where a documented binding constraint did the work",
+        "2": "Constraints mentioned but not inventoried; intentional verbs attached to abstractions in several places; no responsibility check run",
+        "3": "Constraint inventory present with mechanisms, but binding conditions or carriers are missing, or the responsibility check runs in only one direction",
+        "4": "Constraints typed with mechanism, units, and binding conditions; agency relocated onto named actors rather than deleted; responsibility check run both ways",
+        "5": "As 4, plus agentless passives checked and not increased after the verb pass, and at least one documented partial success or stated condition of past change prevents the frame becoming the finding"
+      }
+    },
+    {
+      "name": "Honest Absence Reporting",
+      "description": "Whether empty slots, three-corner webs, mystery substitutes, and 'no moral problem available' were reported as findings rather than filled",
+      "weight": 1.1,
+      "scores": {
+        "1": "All four corners filled regardless of material; no absence reported anywhere; a party invented or promoted to complete the shape",
+        "2": "Absence acknowledged vaguely but the web still presents four corners as if all were warranted",
+        "3": "One absence reported, but the delete test was not run or its result not recorded",
+        "4": "Delete test run on C and D with results recorded; corner count matches what the material supports; the reason for any drop stated",
+        "5": "Absence reported in the same voice and detail as presence, including, where applicable, a mystery substitute with its four properties or an explicit 'this material supports explanation, not opposition'"
+      }
+    },
+    {
+      "name": "Drive-Section Survival",
+      "description": "Whether corners C and D are live forces in the middle of the finished draft rather than a setup paragraph that lists the parties",
+      "weight": 1.2,
+      "scores": {
+        "1": "Collapse check not run; the draft is protagonist-versus-opponent after the opening and C and D never reappear",
+        "2": "Collapse check run but failing corners left in place with no disposition chosen",
+        "3": "Counts taken; C or D falls below target and a disposition is chosen for one but not the other",
+        "4": "Counts reported per corner in the drive section; every below-target corner promoted, cut, or demoted with the choice stated",
+        "5": "All corners meet the stated target including at least one appearance in the final third; the report names the target used and flags it as a chosen default rather than an established rule"
+      }
+    },
+    {
+      "name": "Exposure Escalation",
+      "description": "Whether real named living parties in adversarial slots were surfaced for human decision rather than adjudicated by the writer",
+      "weight": 1.0,
+      "scores": {
+        "1": "Named living parties cast as opponents with adverse inferences and no flag of any kind",
+        "2": "A generic disclaimer is offered in place of a specific flag, or the flag is treated as authorising the inference",
+        "3": "Exposed parties listed but the adverse inference or the unevidenced portion is not stated plainly",
+        "4": "Full exposure block per party: slot, tier, inference, evidence by type, what is not evidenced, decision routed to a human",
+        "5": "As 4, plus consent status recorded and source-availability bias addressed by naming who declined or is absent and whether their absence flatters anyone"
+      }
+    }
+  ],
+  "threshold": 3.5,
+  "passing_note": "Average score must be >= 3.5 for the opposition web to be considered complete. A score below 3 in 'Opponent Warrant and Verb Discipline' or 'Justification Strength and Recognition' requires rework regardless of average, because both indicate the losing party was cast as the villain."
+}

--- a/skills/narrative-opposition-web/resources/four-corner-worksheet.md
+++ b/skills/narrative-opposition-web/resources/four-corner-worksheet.md
@@ -1,0 +1,187 @@
+# The Four-Corner Worksheet
+
+Truby's four-corner opposition, rebuilt as an evidence-bearing worksheet. The four corners are his; the numeric defaults, the tests, and the audit procedures below are operational choices made for auditability, not published thresholds.
+
+## Table of Contents
+- [The shared field](#the-shared-field)
+- [Per-corner fields](#per-corner-fields)
+- [The four tests](#the-four-tests)
+- [The drive collapse audit](#the-drive-collapse-audit)
+- [Worked web 1: open-source project governance](#worked-web-1-open-source-project-governance)
+- [Worked web 2: public-health cold chain](#worked-web-2-public-health-cold-chain)
+- [Worked web 3: a replication controversy](#worked-web-3-a-replication-controversy)
+- [Three-corner and two-corner fallbacks](#three-corner-and-two-corner-fallbacks)
+
+## The shared field
+
+Fill this once. It belongs to the whole web, not to any corner.
+
+**CENTRAL MORAL PROBLEM (one question):** ____
+
+Requirements:
+
+- It is a question, not a verdict. "Who was responsible for the outage?" invites one answer and produces a prosecution. "How much reliability do you owe a customer who is not paying for it?" invites four.
+- Every corner must answer it differently, and each answer must be defensible by someone who is not a fool.
+- It must be answerable from the material. If you cannot point at a document per corner where that corner states or enacts its answer, you are writing your own debate and casting real people in it.
+
+Bad central problems and why:
+
+| Bad question | Failure | Repair |
+|---|---|---|
+| "Was the vendor negligent?" | Yes/no; one defensible answer | "When does a maintainer's right to stop become someone else's emergency?" |
+| "How did the market evolve?" | Not moral, not contested; a process question | "Who should bear the cost of a standard that only pays off after everyone adopts it?" |
+| "Why do institutions fail?" | Too abstract to be answered by these four parties from this material | "What does an agency owe the users of a service it has already decided to shut down?" |
+
+## Per-corner fields
+
+Fill for all four. Every field carries a citation or the marker `[INFERRED]`.
+
+```
+CORNER: A / B / C / D
+ROLE: protagonist / main opponent / secondary opponent 1 / secondary opponent 2
+WARRANT TIER: opponent (3/3) / rival (2/3) / environment (0-1/3)   [from resources/opponent-warrant.md]
+IDENTITY: who or what, precisely, with its boundary in time
+
+WEAKNESS: the structural fragility or personal deficiency, with a CONTEMPORANEOUS source
+          predating the outcome
+
+DESIRE: the visible goal. For opponent corners this must be the SAME scarce object as A's.
+        Name the moment at which success or failure becomes externally verifiable.
+
+VALUES (3-5, stated as goods this corner believes in, each with a citation):
+  1. ____
+  2. ____
+  3. ____
+
+POWER / STATUS / ABILITY: what this corner can actually do, in resources and authority
+
+ROUTE OF ATTACK on A's weakness: the exact mechanism. Must differ from every other
+        corner's route. "They compete with A" is not a route.
+
+ANSWER TO THE CENTRAL MORAL PROBLEM: one sentence, in this corner's terms
+
+JUSTIFICATION: how this corner defends what it does, in its own voice (mandatory in full
+        for corner B; one sentence is acceptable for C and D)
+
+CONFLICTS WITH WHICH OTHER CORNERS, AND OVER WHAT:
+  vs B: ____   vs C: ____   vs D: ____
+  (A corner that only conflicts with A is a satellite, not a corner.)
+
+APPEARANCES IN DRIVE SECTION (fill during the collapse check): ____
+```
+
+### The value-label rule
+
+Every value must be traceable to something the corner said or did. This is where webs quietly become fiction.
+
+- Weak: "The regulator valued institutional control." That is your inference about a motive.
+- Strong: "The agency's 2019 supervisory guidance states its first priority as preventing depositor loss, ahead of preserving the number of independent institutions." That is the corner's stated good, in its words, dated.
+- Acceptable with a label: "`[INFERRED]` The agency behaved as if consolidation were preferable to failure: it approved four of five acquisitions and blocked none."
+
+Values written as evils are always inference and always wrong. "They valued profit over safety" is your verdict. The corner's version is "a service nobody can afford to run is a service nobody gets." Write theirs.
+
+### The route-of-attack rule
+
+Corners C and D exist to attack the protagonist's weakness by a route B does not use. Route means mechanism, not opinion. If B and C both "pressure A publicly," they are one corner.
+
+Distinct routes, from a fictional-but-typical municipal utility case where A's weakness is a deferred-maintenance backlog nobody has costed:
+
+| Corner | Route |
+|---|---|
+| B, the state auditor | Publishes the backlog number, converting a private liability into a public one |
+| C, the bond insurer | Reprices the debt, converting the backlog into a cash-flow problem next quarter |
+| D, the union local | Refuses overtime on unmaintained equipment, converting the backlog into a service outage this week |
+
+Same weakness, three mechanisms, three timescales. That is a working web. Three corners that all "criticise the utility" is one corner with three names.
+
+## The four tests
+
+Run all four. Record the result of each; a web delivered without test results is unaudited.
+
+**1. PUSH CHECK.** For each of the six pairs (AB, AC, AD, BC, BD, CD), name the sharpest difference between their value clusters. Any value appearing in two corners forces a change: either sharpen one corner's value into something the other would reject, or cut the corner. Maximum differentiation is the entire point of the exercise.
+
+**2. CONFLICT CHECK.** For each of the six pairs, state what they fight over and cite it. Pairs that never touch are the tell. A web where BC, BD, and CD are all blank is a two-part opposition with extra labels.
+
+**3. DELETE TEST.** Remove corner D entirely. Re-read the argument of the piece. Does anything break?
+
+- Something breaks: D is load-bearing. Keep it.
+- Nothing breaks: D was decoration. Two options, both honest. Give D a genuine competing value cluster the material supports, or drop to three corners and say in your notes that the material supported three.
+
+Repeat for C. It is common and fine to end with three corners. It is not fine to keep four and pretend.
+
+**4. RECOGNITION TEST.** Read corner B's justification paragraph aloud. Would a competent person holding that position recognise themselves in it? See [resources/opponent-warrant.md](resources/opponent-warrant.md) for the full procedure and the strawman-versus-steelman contrasts.
+
+## The drive collapse audit
+
+Run this on the finished draft, not on the plan. Even after building a real four-corner web, writers collapse to protagonist-versus-opponent in the prose, because binary conflict is easier to narrate. The worksheet cannot detect this. Only the draft can.
+
+Procedure:
+
+1. Mark the DRIVE section of the draft: everything after the protagonist's plan is established and before the resolution begins. Roughly the middle. If your piece has no such section, that is a separate structural problem — go to `writing-structure-planner`.
+2. Inside the drive only, count appearances per corner. An appearance means the corner acts, speaks, or its position is represented as a live force. A mention in a subordinate clause is not an appearance.
+3. Apply the default target: at least three appearances per corner in the drive, and at least one appearance in the final third of the drive. This threshold is a derived default chosen so that a corner cannot survive on a single cameo; adjust it for very short pieces and say that you did.
+4. Any corner below target has one of three dispositions, and you must pick one explicitly:
+   - **PROMOTE**: find the corner's real drive-section action in the material and write it in.
+   - **CUT**: remove the corner from the web and from the setup. A corner introduced and abandoned leaves the reader holding an unresolved obligation.
+   - **DEMOTE**: reclassify it as environment or context and strip its intentional verbs.
+5. Report the counts. The collapse-check report is a deliverable, not a private step.
+
+Failure signature to look for in the prose itself: corners C and D appear in a single setup paragraph that lists all the parties, then never again. That paragraph is the tell. It reads like completeness and functions as an alibi.
+
+## Worked web 1: open-source project governance
+
+Protagonist is a system-with-carriers: a volunteer-maintained library that a large number of products depend on.
+
+**Central moral problem:** When software everyone depends on is maintained by volunteers, who owes what to whom?
+
+**A — the maintainer team (protagonist).** Weakness: no succession plan; two people hold all merge rights, documented in the project's own 2021 governance thread. Values: correctness over convenience; the right to say no; a small dependency surface. Answer to the problem: nothing is owed; the licence says so, and the licence is the contract.
+
+**B — the downstream commercial vendor (opponent, 3/3).** Same goal: control of the release cadence. Competition: both publish releases of the same library. Awareness: vendor's engineering blog names the project. Directed action: vendor funded a fork and hired one of the two maintainers, dated. Values: predictable support windows; customers should never see breakage; paying for outcomes is legitimate. Route: buys the succession the project never built, attacking the weakness directly. Answer: obligations follow from dependence, and dependence can be bought out.
+
+**C — the distribution packagers (rival, 2/3).** Same goal: control of the release cadence. Values: reproducibility; long-term stability; every patch must be backportable. Route: freezes an old version and backports security patches, draining relevance from upstream rather than buying it. Conflicts with B: B ships fast features, C freezes interfaces, and both cannot be satisfied by one release. Answer: obligations run to users of the whole system, not to any one project.
+
+**D — the coordinated-disclosure process (opponent, 3/3, and it is a process rather than a party).** Same goal: control of the release cadence, at the moment of a vulnerability. Values: disclosure deadlines are non-negotiable; users deserve to know; unmaintained code is a public hazard. Route: publishes with a fixed clock, forcing the maintainers to ship on someone else's schedule. Conflicts with C over backport-versus-upgrade advice, and with B over embargo handling. Answer: obligation is to the public, and it overrides both the licence and the contract.
+
+Why this passes the delete test: remove D and the piece loses the only force that binds all three others to a calendar. The argument about volunteer obligation loses its hard edge.
+
+## Worked web 2: public-health cold chain
+
+Protagonist is a person: a district immunisation officer.
+
+**Central moral problem:** How much of a scarce good do you let spoil in order to reach the people hardest to reach?
+
+**A — the district officer.** Weakness: has never reported a wastage figure above the tolerated ceiling, documented in three years of her own returns filed before the events. Values: presence in every village; a clinic that has never had vaccine is worse than one that spoils some; trust is built by showing up.
+
+**B — the ministry logistics directorate (rival, 2/3).** Same goal: control of the last forty cold boxes. Values: waste is theft from the next district; coverage must be measurable; centralised allocation is the only fair allocation. Route: reallocates boxes on a wastage metric, attacking A's weakness by making her honest reporting the reason she loses supply.
+
+**C — the donor's monitoring team (rival, 2/3).** Same goal: control of the same forty boxes. Values: dose-level traceability; conditionality is what makes aid work; unverifiable delivery is indistinguishable from no delivery. Route: withholds the next tranche pending an audit, attacking the same weakness by a slower mechanism with a longer reach. Conflicts with B: B wants the boxes moved this week, C wants them stationary until counted.
+
+**D — the local clinic committees (rival, 2/3).** Same goal: the same boxes. Values: the village that has waited longest goes first; local knowledge beats a spreadsheet; a promise made in person is binding. Route: publicly commits A to a delivery she has no supply for. Conflicts with B over who allocates and with C over whether counting is respect or suspicion.
+
+**Not a corner — the constraint.** The vaccine's two-to-eight-degree tolerance and the four-hour road. It has no values, no awareness, and no directed action. It sets the ceiling on every corner's plan and belongs in the constraint inventory. Writing "the cold chain fought back" would be the exact error this skill exists to prevent. Write instead: "no route from the depot reaches the three northern clinics inside the tolerance, and none of the four positions above changes that."
+
+## Worked web 3: a replication controversy
+
+Protagonist is a system: a research subfield.
+
+**Central moral problem:** What do you owe a body of work that has been useful and may not be true?
+
+**A — the subfield's established programme.** Weakness: an effect size that was never estimated from a pre-registered design, visible in the 2013 methods reviews written before the failed replications. Values: cumulative evidence over single studies; theory should guide measurement; a literature is not overturned by one null.
+
+**B — the replication team (opponent, 3/3).** Same goal: control of what the subfield's textbooks say the effect is. Competition, awareness, and directed action all documented in the exchange of published comments. Values: a claim you cannot reproduce is not a claim; methods sections are the real paper; publishing the null is the service. Route: reruns the canonical study at high power, attacking A's weakness at its origin.
+
+**C — the journal editors (rival, 2/3).** Same goal: control of the textbook claim, exercised through what gets printed. Values: novelty is what a journal is for; adjudication is the field's job and not the editor's; the record is corrected by publication, not by retraction. Route: slows both sides by controlling the venue, which attacks A's weakness by leaving the original claim standing and uncontested in print. Conflicts with B over whether nulls are publishable.
+
+**D — the funders (rival, 2/3).** Same goal: control of the claim, exercised through what gets studied next. Values: money should follow translatable results; replication is not new knowledge; a portfolio should be judged in aggregate. Route: keeps funding extensions of the original effect, attacking A's weakness by ensuring nobody re-estimates it. Conflicts with B over what counts as a contribution and with C over what counts as impact.
+
+Note the double: A and B share a value neither will state, that the published record ought to be the field's memory. That shared value is what makes them opponents rather than strangers. Record it in the DOUBLE field of the opponent audit.
+
+## Three-corner and two-corner fallbacks
+
+Not every body of material supports four corners. The failure is padding, not honesty.
+
+**Three corners.** Legitimate and common. Run all the same tests on the three pairs. State in your notes: "The material supported three corners; the fourth candidate (____) failed the delete test because ____."
+
+**Two corners.** A genuine two-part opposition is a simple argument, and simple arguments are sometimes true. But check first: two corners plus a strong constraint is usually a three-corner web where you have not yet given the constraint a carrier. And check second: a two-part opposition is where good-versus-evil lives. If you are down to two, the recognition test on B's justification becomes the whole quality gate.
+
+**Zero corners.** No party in the record opposed any other. Go to the mystery substitute in [resources/opponent-warrant.md](resources/opponent-warrant.md). Do not proceed with a web.

--- a/skills/narrative-opposition-web/resources/opponent-warrant.md
+++ b/skills/narrative-opposition-web/resources/opponent-warrant.md
@@ -1,0 +1,214 @@
+# Opponent Warrant, the Seven-Gate Audit, and the Empty Slot
+
+Everything here answers one question: has this entity earned the opponent slot, or is it just the party that lost?
+
+## Table of Contents
+- [The warrant evidence test](#the-warrant-evidence-test)
+- [Verb constraints by tier](#verb-constraints-by-tier)
+- [The seven-gate best-possible-opponent audit](#the-seven-gate-best-possible-opponent-audit)
+- [Writing the justification paragraph](#writing-the-justification-paragraph)
+- [The double reversal and the third position](#the-double-reversal-and-the-third-position)
+- [The system constraint inventory](#the-system-constraint-inventory)
+- [The mystery substitute](#the-mystery-substitute)
+- [Exposure escalation](#exposure-escalation)
+
+## The warrant evidence test
+
+Real evidence frequently contains competitors, constraints, and coincidences but no opponent. An agent that needs an opponent to complete a shape will find one, and the cheapest one available is an inferred intention.
+
+For each candidate, gather three independent evidence types.
+
+**COMPETITION.** Documentary evidence that both parties sought the same scarce object at overlapping times. Not "both were in the same business." The same object: a contract, a standard, a customer, a frequency allocation, a merge right, a budget line, a seat on a committee.
+
+**AWARENESS.** Evidence that each party knew of the other. A memo, a filing, an earnings call, a commit message, a court exhibit, an interview, a footnote.
+
+**DIRECTED ACTION.** At least one action by A that the record shows was taken *because of* B, with a dated source for the "because." This is the type most often missing and most often assumed.
+
+Scoring: 3/3 opponent, 2/3 rival, 0-1/3 environmental pressure.
+
+The tell of a fabricated warrant is a transitive verb with no dated source for the because. Grep your own draft for "in response to," "to counter," "aimed at," "in order to block." Each hit must resolve to a document.
+
+The mirror failure is over-application. A thin archive that lacks awareness evidence does not turn a documented rivalry into weather. Two of three plus an explicit note naming the missing type is honest and usable.
+
+Worked scoring, three domains:
+
+| Case | Competition | Awareness | Directed action | Tier |
+|---|---|---|---|---|
+| Two standards bodies balloting incompatible specs for the same interface | Yes: same ballot, same interface | Yes: each spec cites the other | Yes: chair's minutes record the schedule change "given the parallel effort" | OPPONENT |
+| A generic manufacturer and the originator whose patent expired | Yes: same molecule, same market | Yes: litigation record | Missing: no dated evidence the originator's pricing move was aimed at this entrant specifically | RIVAL |
+| A drought and a water utility's expansion plan | No shared object | Not applicable | Not applicable | ENVIRONMENT |
+| A new labour statute and a haulier's route network | No shared object; the statute predates the network | Haulier's filings cite the statute | Statute was not written about the haulier | ENVIRONMENT (binding constraint) |
+
+## Verb constraints by tier
+
+Assign verbs at warrant time, in the notes, before prose exists. Verbs are where the claim actually lives, and they leak.
+
+| Tier | May use | May never use |
+|---|---|---|
+| OPPONENT | targeted, countered, retaliated against, undercut, moved to block, matched, pre-empted | — |
+| RIVAL | competed with, gained share against, bid against, arrived at the same time, offered a cheaper equivalent | any verb implying the act was aimed at the other party |
+| ENVIRONMENT | coincided with, constrained, bound, set the ceiling on, was present during, narrowed | every transitive verb of intent: wanted, decided, chose, sought, punished, refused, fought back |
+
+Worked repairs:
+
+- Environment written as opponent: "The new emissions limit went after the older fleet." → "The limit bound at 2.4 grams. Every vehicle in the older fleet was certified above it, and none could be recertified without a new head design."
+- Rival written as opponent: "The upstart moved to strangle the incumbent's flagship line." → "The upstart priced its equivalent 30 percent below the flagship. Nothing in its board minutes mentions the flagship."
+- System written as agent: "The grid decided to shed the industrial load." → "The under-frequency relay is set to trip at 49.5 hertz. Frequency reached 49.4 at 03:12 and the relay tripped, dropping the industrial feeders."
+
+**Do not over-correct.** Stripping intentional verbs into agentless passives ("share was observed to shift," "the load was shed") is worse, because passive voice obscures causation rather than clarifying it. The goal is to relocate agency onto the entity that actually has it. Post-pass check: count agentless passives before and after. If they went up, the pass failed.
+
+One deliberate, flagged personification per major section is acceptable when you can state in one line what mechanism it stands in for. Purism buys nothing and costs readability.
+
+## The seven-gate best-possible-opponent audit
+
+Run in order on corner B. A gate that fails sends you back to candidate selection, not forward with a weaker opponent.
+
+**1. SAME GOAL.** State in one sentence the single thing both parties are fighting to control or possess. Push to the deepest level of the conflict. If the honest answer is that they wanted different things, this is a competitor, not an opponent. Go deeper or replace the candidate.
+
+- Fails: "The archive wanted to preserve the collection; the developer wanted to build on the site." Different goals; both could have won.
+- Passes: "Both were fighting for the same thing: who decides what the block is for. The archive's claim ran through the landmark listing, the developer's through the zoning variance, and only one instrument could govern."
+
+**2. NECESSITY.** Name the exact mechanism by which THIS opponent attacks THIS protagonist's specific weakness. Not "they compete." If the opponent would be equally dangerous to any protagonist, they are generic, and the piece will feel arbitrary.
+
+**3. RELENTLESSNESS.** Does the opponent attack that weakness repeatedly across the span of the piece, or once? Count the documented instances. One instance is an event, not an opposition.
+
+**4. VALUE CONFLICT.** Three to five values per side, stated as goods, each cited. Verify they conflict directly rather than merely differ. "One valued speed, the other valued documentation" is a difference. "One held that a released artifact is a promise, the other that a released artifact is a draft" is a conflict, because both cannot govern the same repository.
+
+**5. THE DOUBLE.** Name what the opponent shares with the protagonist. In what way is each the other's mirror? Two parties with nothing in common are strangers. The shared thing is usually a value neither will state aloud, or a weakness both have.
+
+> **System variant.** A constraint has no mirror. Name instead the constraint or incentive **both** A and B are subject to, with a citation. A yield ceiling that binds only one side is asymmetric pressure, not a double.
+
+**6. POWER PARITY.** Does the opponent have real power, status, and ability? An opponent weaker than the protagonist produces no story and, in analytical work, usually signals hagiography. If your opponent is outmatched, you are probably writing a defence of the protagonist and should say so.
+
+> **System variant.** A constraint has no status. Ask instead whether it actually **binds inside the window**, with the evidence that it did. A constraint that never binds is environment, not corner B — route it to the constraint inventory.
+
+**7. JUSTIFICATION.** See the next section. Mandatory artifact.
+
+> **System variant.** A constraint cannot speak. Write the justification in the voice of the documented human or institutional **carrier** — the person or body that acted to preserve the constraint, or acted under it and defended doing so. If no carrier is documented, this gate returns **N/A**, the corner is not an opponent, and it routes to the constraint inventory.
+
+## Writing the justification paragraph
+
+A paragraph in which the opponent makes a strong, coherent, defensible case for what they did, in their own voice, first person, present tense of their own moment. Not a confession. Not a concession. Not a villain speech.
+
+Rules:
+
+- No self-incrimination. Nobody narrates their own guilt. "We knew the risk and shipped anyway" is a writer's sentence, not an opponent's.
+- No hedging on their own behalf. They believe this.
+- Every factual assertion in it must be one the opponent actually made or could have made from what they knew at the time.
+- It must be a good argument. If yours is easy to refute, you have not found the real one.
+
+**RECOGNITION TEST.** Would a competent person holding this position read it and say "yes, that is why I did it"? If not, rewrite until they would. If you cannot, you do not yet understand the opposition and should return to the material.
+
+**FALSIFICATION PASS.** If B's justification is more persuasive than A's position, you have assigned the roles backwards. Swap and re-derive. Do not weaken B.
+
+### Strawman versus steelman, three domains
+
+**Public-health logistics, corner B is the ministry directorate.**
+
+- Strawman: "Head office cared about its numbers, not about children. Wastage looked bad on the dashboard, so the boxes went where they would be safest, not where they were needed."
+- Steelman: "Every dose that spoils in a district was taken from a district that would have used it. I am not allocating vaccine, I am allocating the consequences of a cold chain that cannot reach everywhere at once, and the only defensible rule is the one I can apply the same way in all fifty-one districts. Her villages are hard to reach. So are four hundred others, and every officer who reaches them by accepting spoilage is asking me to fund that spoilage from someone else's allocation. I would rather be accused of a spreadsheet than of choosing favourites."
+
+**Open-source governance, corner B is the commercial vendor.**
+
+- Strawman: "The vendor saw a free library it could take over and took it, because that is what companies do."
+- Steelman: "Ten thousand businesses depend on two volunteers who have never promised anyone anything, and everyone has agreed to call this a healthy ecosystem. We offered to fund it and were told no, which is their right. So we hired one of them and forked the rest. Our customers now have a support window with a number on it. I am aware this looks like capture. The alternative was continuing to ship a dependency whose maintenance plan is that two people stay interested."
+
+**Scientific controversy, corner C is the journal editors.**
+
+- Strawman: "The editors protected their prestige by refusing to print corrections."
+- Steelman: "A journal is not a court and I am not a judge. If I start deciding which of two competent teams is right, I have replaced peer review with editorial taste, and the next editor will use that power for something worse. My job is to publish work that meets the standard and let the field adjudicate. Yes, that leaves the original claim standing longer than the critics would like. It also leaves it standing when the critics are wrong, which has happened in this journal three times that I can name."
+
+Note what the steelman versions share: they concede the appearance, they name the cost, and they still conclude. That is what a real position sounds like.
+
+## The double reversal and the third position
+
+Advanced move, and the structural form of intellectual honesty in analytical work: grant a self-revelation to the opponent as well as the protagonist. The reader receives two insights rather than one verdict.
+
+Procedure:
+
+1. Both A and B must have a weakness and a need. An opponent with no need is a force, not a corner, and cannot reverse.
+2. Establish that B is capable of changing position. For an institution, show it revising its position at least once, with a document.
+3. Write B's revelation alongside A's, at or after the decisive contest.
+4. CONNECT them. A must learn something from B and B something from A. Two independent lessons are two arcs, not a reversal.
+5. State the synthesis in your working notes, never in the prose: "the best of what both learned is ____."
+
+**THIRD-POSITION TEST.** A genuine double reversal produces a position neither party held at the start, stateable in one sentence and defensible on the evidence. If your synthesis is the midpoint of the two starting positions, no reversal occurred and you have written false balance. "Both sides had a point" is a refusal to argue, not a richer argument.
+
+**SENTIMENTAL REDEMPTION CHECK.** B's revelation must be supported by something B actually said or did afterward. Check the record for a post-contest behavioural change. Absent that, B did not learn anything and you should say so.
+
+## The system constraint inventory
+
+When the protagonist is a market, a protocol, an institution, a codebase, a supply chain, or an ecosystem, the opponent slot is usually filled by a constraint. Resist filling it with a party merely because the slot exists.
+
+For each constraint, record:
+
+```
+CONSTRAINT: ____
+TYPE: physical / capital / regulatory / informational / latency / yield / contractual / headcount
+MECHANISM: the specific pathway by which it binds, with units where units exist
+WHEN IT BINDS: the conditions under which it starts setting the outcome
+                (a constraint that never binds is background, not opposition)
+CARRIER (optional): the named human or institution that speaks for it and can be quoted
+EVIDENCE: source
+```
+
+Common types by domain, as a prompt list rather than a taxonomy:
+
+- Physical: thermal limits, tolerance windows, half-life, road time, port draft, bandwidth-distance product
+- Capital: minimum efficient scale, the cost of the next unit of capacity, working-capital cycle
+- Regulatory: a certification clock, a disclosure deadline, a licence condition, an ownership cap
+- Informational: what the system does not measure and therefore cannot respond to
+- Latency: settlement time, review time, procurement time, the delay in a feedback loop
+- Yield: the fraction of attempts that survive to output, and how it scales
+
+A constraint acquires narrative force through **binding**, not through motive. The dramatic moment is the first time it sets the outcome, staged at a specific timestamp, in a specific place, with a specific number, witnessed by a specific named person.
+
+**Responsibility check, run in both directions.** For every systemic attribution, ask whether a specific named actor had the authority and the information to do otherwise. If yes, name them. "The system failed" is often a sentence written to avoid naming a person, and a constraint-based opponent slot makes that evasion easy to write and hard to see. Systemic explanation is additive to individual accountability, never a substitute for it. The reverse also holds: naming a person where a binding constraint did the work is the original error this skill exists to prevent.
+
+**Do not let the frame become the finding.** The stance that institutions are the larger forces is powerful because it is a stance. Adopted as a default, it concludes that every system is unreformable, which is inevitability with the sign flipped. Include at least one documented partial success, or state explicitly the conditions under which this system has changed before.
+
+## The mystery substitute
+
+Some material genuinely has no opponent. Scientific findings, supply-chain descriptions, benchmark results, and process explanations often contain no party who opposed any other. Do not proceed with neither an opponent nor a substitute; the reader needs something to replace the ongoing conflict.
+
+Introduce a MYSTERY at the same structural position the opponent would have occupied: early, before the drive, alongside the protagonist's plan.
+
+A usable mystery has four properties:
+
+1. **A specific unanswered question**, not a topic. "Why did the yields differ between the two lines when the recipes were identical?" not "the mystery of manufacturing variance."
+2. **A reason the answer was not available at the time.** The reader must believe the question was genuinely open.
+3. **A partial answer arriving in pieces**, at an accelerating pace, more of them near the end.
+4. **A resolution the material actually supports.** If the record never answered it, say so. An unresolved mystery honestly labelled beats a resolved one you supplied.
+
+Worked: an epidemiological cluster with no antagonist. The mystery is "why did the cases follow the bus route and not the water main?" Pieces arrive as the case map, the negative water samples, the driver's shift log, the ventilation schematic. Resolution: the shared enclosed air. No opponent anywhere, and the piece has a spine.
+
+Alternative substitutes when no mystery exists either:
+
+- **A deadline**: a fixed date after which the protagonist's options close, documented.
+- **A binding constraint approaching**: a buffer draining toward zero, with the number and the rate.
+- **A verification question**: will the claim hold when someone finally checks it?
+
+If none of these is available, the honest output is: "This material supports explanation, not opposition." That is a complete answer. Report it.
+
+## Exposure escalation
+
+Where a real named living person or an active institution occupies an adversarial slot, surface it for human decision. Do not adjudicate it yourself. Adverse inference about a living party creates legal exposure that is not the writer's to resolve, and a subject who consented to an interview consented to an interview, not to a structural role in someone's argument.
+
+Emit this block, one per exposed party, alongside the web:
+
+```
+EXPOSURE FLAG
+PARTY: name, and whether living person / active institution / both
+SLOT: which corner, and the warrant tier assigned
+ADVERSE INFERENCE BEING MADE: state it plainly, in the words a reader would take away
+EVIDENCE BEHIND IT: the citations, by type (competition / awareness / directed action)
+WHAT IS NOT EVIDENCED: the part of the inference the record does not reach
+CONSENT STATUS: did this party speak to the project, and if so, to what did they agree?
+WHO DECLINED OR IS ABSENT: and does their absence flatter anyone in the piece?
+DECISION REQUIRED FROM: human reviewer
+```
+
+Two rules that make this real rather than ceremonial:
+
+- **Disclosure is not a currency.** Flagging an inference does not authorise it. "We noted the uncertainty, so we can print it" is the reasoning to refuse. The flag routes a decision; it does not pre-approve one.
+- **Source-availability bias is part of the exposure.** A cast selected by who agreed to talk systematically flatters cooperative parties and indicts silent ones. List who is missing from the web and why, in the flag and in the piece.

--- a/skills/numbers-in-narrative/SKILL.md
+++ b/skills/numbers-in-narrative/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: numbers-in-narrative
+description: Writes quantities into prose so they land without overstating what the source supports. Applies a per-paragraph number-landing checklist (three numbers per paragraph, one per sentence, direction before magnitude, a comparison on the same screen), a unit-and-denominator lock that catches denominator drift, quantitative fidelity refusals (precision ceiling, rounding drift, percent vs percentage point, model output vs measurement), an uncertainty routing table, a declared likelihood-and-confidence ladder, and a chart-beat contract for exhibits that carry a claim. Use when drafting or editing prose that carries figures, statistics, benchmarks, forecasts or estimates, when a passage reads as a stat wall, when deciding how much precision or hedging a number can bear, or when the user mentions numbers in prose, rounding, denominator, per capita, percentage points, error bars, confidence, uncertainty, chart title, caption, or stat wall.
+---
+
+# Numbers In Narrative
+
+## Table of Contents
+- [Core Principles](#core-principles)
+- [Workflow](#workflow)
+- [Number-Landing Checklist](#number-landing-checklist)
+- [Fidelity Refusals](#fidelity-refusals)
+- [Uncertainty Routing Table](#uncertainty-routing-table)
+- [Likelihood and Confidence Ladder](#likelihood-and-confidence-ladder)
+- [Guardrails](#guardrails)
+- [Quick Reference](#quick-reference)
+
+**Related skills:** Use `narrative-evidence-ledger` for the Frame Lock this skill imports, `narrative-fallacy-guard` for the likelihood lexicon, `narrative-fidelity-audit` for the pre-ship gate. Use `visual-storytelling-design` for the narrative shape around the exhibits, `cognitive-fallacies-guard` for auditing a chart's encoding, `writing-revision` for the prose pass after the numbers are settled, `readability-check` for reading-level gates.
+
+## Core Principles
+
+1. **A bare number is not information**: every figure that survives into prose carries a comparison on the same screen — a prior period, a peer, a denominator, or a physical referent the reader already owns.
+2. **Direction before magnitude**: say which way it moved, then how far. A reader who does not know the sign cannot use the size.
+3. **The frame is the claim**: unit, denominator, window, and population boundary determine which stories are sayable. Change one mid-piece and every exhibit stays defensible while the sequence becomes a lie.
+4. **Precision is a property of the source, not a style choice**: round for prose, compute from the source value, never from the rounded prose figure.
+5. **Uncertainty is routed, never dumped**: it rides in the annotation layer of the claim it qualifies, unless it would change the conclusion — then it is its own beat. Never all of it in a trailing methods note; never a hedge in every sentence.
+6. **The exhibit travels alone**: readers recall the gist of the title, and follow it even when it disagrees with the marks (Kong et al., CHI 2018/2019). So the title must be a claim the chart's own marks can falsify.
+7. **Sourced, not verified**: you track provenance. You do not verify. Never write "verified", "confirmed", or "fact-checked" about your own numbers.
+
+## Workflow
+
+Copy this checklist and track your progress:
+
+```
+Numbers In Narrative Progress:
+- [ ] Step 1: Import the frame, or build one (unit, denominator, window, boundary)
+- [ ] Step 2: Bind every number to a source and a precision
+- [ ] Step 3: Land the numbers, paragraph by paragraph
+- [ ] Step 4: Route the uncertainty by type
+- [ ] Step 5: Contract each exhibit that carries a beat
+- [ ] Step 6: Run the drift and fidelity audit
+```
+
+**Step 1: Import the frame, or build one**
+
+Step 1.1: The Frame Lock belongs to `narrative-evidence-ledger`. If a ledger already exists for this material, import its Frame Lock verbatim: unit, denominator, window, boundary, plus the rejected alternative and reason for each. Do not restate it in your own words. A paraphrased frame drifts from the frozen one, and the drift is invisible on reading.
+
+Step 1.2: If no Frame Lock exists, build one using that skill's procedure before drafting any prose. See [../narrative-evidence-ledger/resources/frame-lock.md](../narrative-evidence-ledger/resources/frame-lock.md). Whichever route you took, the frame is now frozen. Any later change to unit, denominator, window, or boundary re-opens the ledger. It is not a chart adjustment.
+
+Step 1.3: Apply the rate-vs-count rule. If entities differ in size by more than roughly 2x, rates are mandatory for comparison and raw counts are supplementary, never the headline. If the denominator is itself moving, show both series — the ratio alone hides which term moved.
+
+See [resources/quantitative-fidelity.md](resources/quantitative-fidelity.md) for the denominator-drift worked example.
+
+**Step 2: Bind every number to a source and a precision**
+
+Step 2.1: For each figure, record five things. The pointer: document and page, table and cell, query, row range, retrieval date. "The 10-K" is not a pointer. Then the source's own precision, OBSERVED or DERIVED, MEASURED or MODELLED, and CONTESTED or not.
+
+Step 2.2: Hold the unrounded value. Every derived figure is computed from the held value and cites its pointer, never from a rounded sentence elsewhere in the draft.
+
+Step 2.3: Never treat your own earlier draft, summary, or notes as a source for a number. A pointer that resolves inside your own pipeline is a hard failure and is invisible on reading.
+
+**Step 3: Land the numbers, paragraph by paragraph**
+
+Step 3.1: Run the [Number-Landing Checklist](#number-landing-checklist) on every data-carrying paragraph. Surplus figures go to a table, an exhibit, or a footnote — not into another sentence.
+
+Step 3.2: Convert to human scale where a scale exists, and swap bureaucratic number-words for plain ones (see [resources/number-landing.md](resources/number-landing.md)).
+
+Step 3.3: Where the protagonist is a system, do not let a single quantified individual stand in for a distribution without repair. If you open on one patient, one shipment, one training run, the next sentence must restore the distribution and say what that case is and is not typical of.
+
+**Step 4: Route the uncertainty by type**
+
+Step 4.1: For each load-bearing claim, name the DOMINANT uncertainty type — sampling, measurement, model/specification, coverage-missingness, or contested source. One type per claim; do not blend.
+
+Step 4.2: Route it through the [Uncertainty Routing Table](#uncertainty-routing-table). Apply the momentum rule: uncertainty earns its own beat only when it would change the conclusion.
+
+Step 4.3: Band only load-bearing judgments with the [Likelihood and Confidence Ladder](#likelihood-and-confidence-ladder), and declare the ladder's bands once, in the piece.
+
+Step 4.4: Write the reference-model sentence: what a reader would have to assume for your signal to be absent. Omitting uncertainty does not avoid assumptions, it outsources them to a distribution in the reader's head that you cannot see.
+
+**Step 5: Contract each exhibit that carries a beat**
+
+Step 5.1: Write the beat sentence first, as one declarative claim, before drawing anything. Make the title that sentence, phrased so the chart's own marks can check it.
+
+Step 5.2: Per annotation, write the falsification line privately: which specific marks would make this annotation false? Cannot answer means the annotation asserts something the chart does not show — cut it.
+
+Step 5.3: Mark the leap-of-faith point on the exhibit wherever measurement ends and projection, model, or extrapolation begins.
+
+Step 5.4: Run the detachment test: crop the exhibit out of the prose. Does it still carry the beat AND the caveat that qualifies it? Exhibits circulate alone.
+
+See [resources/uncertainty-and-exhibits.md](resources/uncertainty-and-exhibits.md) for the annotation spec and density caps.
+
+**Step 6: Run the drift and fidelity audit**
+
+Step 6.1: DENOMINATOR SWEEP. List every number in the finished draft in order with its denominator. Any change of denominator across the sequence must either be reverted or narrated explicitly as a beat. This is the failure fact-checking cannot see: every exhibit defensible, the sequence a lie.
+
+Step 6.2: RECOMPUTE. Recompute every total, share, and ratio from the held source values. Confirm parts still sum to the whole after rounding.
+
+Step 6.3: Walk the [Fidelity Refusals](#fidelity-refusals). Each hit is a defect, not a preference.
+
+Step 6.4: OMITTED-NUMBER LOG. List every figure you cut, and read the list as a set. Individually defensible cuts routinely form a pattern — the disconfirming quarter, the failed arm, the region that went the other way.
+
+Step 6.5: HEDGE BUDGET. Count hedged sentences. Over roughly one in four in a passage means the passage is under-sourced, not over-cautious: go back to sources rather than deleting hedges. Never delete a hedge that reflects genuine evidential uncertainty.
+
+Validate using [resources/evaluators/rubric_numbers_in_narrative.json](resources/evaluators/rubric_numbers_in_narrative.json). **Minimum standard**: average score >= 3.5.
+
+## Number-Landing Checklist
+
+Run per data-carrying paragraph. Caps are working defaults for narrative prose, not published thresholds. Tune them for your register, and say that you did.
+
+| # | Check | Fix |
+|---|-------|-----|
+| 1 | More than three numbers in this paragraph? | Move the surplus to a table, exhibit, or footnote |
+| 2 | More than one number in any sentence? | Split the sentence or cut a number |
+| 3 | Can it be rounded without losing the claim? | 105% becomes doubled; 33% becomes one in three; 1.043bn becomes about a billion |
+| 4 | Does the rounding erase a distinction that mattered? | Restore the digits and say in the sentence why the precision is the point |
+| 5 | Does every surviving number have a comparison on the same screen? | Add a prior period, a peer, a denominator, or a physical referent |
+| 6 | Is it at human scale where a scale exists? | Per person, per day, per shipment, per thousand doses, as a multiple of something owned |
+| 7 | Direction before magnitude? | Say which way it moved, then how far |
+| 8 | Does the paragraph open on a number with no frame? | Build the frame first, then land the number |
+| 9 | Bureaucratic number-words? | expenditures to spending, utilization to use, headcount to staff, revenue to income |
+
+**Bad (supply chain):** "Dwell time at the terminal averaged 4.7 days in Q3 against 3.2 days in Q2, with 61.4% of containers exceeding the 72-hour free window versus 44.9% prior, across 18,412 boxes."
+
+**Good:** "Boxes started sitting longer. Containers that used to clear the terminal in three days took nearly five, and for the first time most of them — three in five, against fewer than half the quarter before — blew past the free-storage window and started billing."
+
+**Bad (public health):** "Vaccination coverage in the district reached 62.3%, up 11.8 percentage points."
+
+**Good:** "Coverage rose by a ninth of the district, from roughly half of children to roughly three in five. The threshold health officials use for measles herd immunity is closer to nine in ten."
+
+## Fidelity Refusals
+
+These are refusals, not preferences. Every hit is a defect.
+
+- **Precision ceiling.** No figure may exceed the precision of its source. Source says "roughly a third" — you may never write 33.4%.
+- **Rounding drift.** Never compute a derived figure from a rounded prose number. Compute from the held source value; recompute totals at the end.
+- **Percent vs percentage point.** Never conflate. A rise from 4% to 6% is two percentage points and a fifty percent increase, and only one of those belongs in a given sentence.
+- **Relative vs absolute.** Never present a relative change without the base when the base is small. "Cases doubled" from 3 to 6 is a different claim from 3,000 to 6,000.
+- **Contested figures.** Both values, both sources, in the same sentence. "The operator put downtime at 40 minutes; the regulator's log records 94." Never average, never silently choose.
+- **Model output in measurement grammar.** A projection, fit, simulation, or estimate may not wear the sentence shape of an observation. Not "throughput reaches 14,000 units in 2027" but "the capacity model puts throughput at about 14,000 units by 2027."
+- **Trend from two points.** Two observations are a difference, not a trend. Never write "rising", "accelerating", or "the trajectory" off two data points.
+- **Qualitative to numeral.** Never convert "many", "several", or "most" into a numeral the source does not contain.
+- **Ranges survive.** If the source gives a range or interval, the prose carries it or states explicitly that it is using the midpoint.
+- **Thin support.** Never lead on a figure resting on a handful of records or one reporting period. Extremes concentrated in the smallest denominators are sampling noise wearing a story's clothes.
+- **Verified.** Never claim you verified, confirmed, or fact-checked a number. You sourced it.
+
+## Uncertainty Routing Table
+
+| Type | Vehicle | Placement |
+|------|---------|-----------|
+| Sampling | Interval, or frequency framing in words ("about one year in twenty looks like this") | Annotation layer of the exhibit it qualifies |
+| Measurement | Stated range or instrument-precision note | Exhibit caption AND the sentence that first uses the number |
+| Model / specification | Two or more specifications shown side by side; their disagreement is the point | Its own beat — here the disagreement outranks any point estimate |
+| Coverage / missingness | Render the absence: shade the gap, count what is missing, name who is not in the denominator | In the exhibit — missingness rendered as blank space is invisible |
+| Contested source | Both sources as separate series with provenance; say which you believe and why | Own beat if they disagree on sign, otherwise annotation layer |
+
+**Momentum rule:** uncertainty earns its own beat only when it would change the conclusion. Otherwise it rides in the annotation layer. This is what preserves pace without hiding anything.
+
+**Never** route all uncertainty to a trailing methods note. **Never** hedge every sentence — readers then fall back on the headline, which is the one unhedged artifact in the piece.
+
+**Self-diagnostic.** Three thoughts mean you are rationalising an omission rather than editing (Hullman, IEEE TVCG 2020). "The exhibit should express a clear signal." "The analysis was rigorous, so the reader can trust it." "This would muddy the message." Catch any of the three and route the uncertainty.
+
+## Likelihood and Confidence Ladder
+
+Two different quantities. **Likelihood** is how probable the thing is. **Confidence** is how good your evidence is. Never combine them in one sentence: "we are highly confident this is very likely" is unparseable and hides which one is weak.
+
+| Likelihood term | Band |
+|-----------------|------|
+| almost no chance / remote | 01-05% |
+| very unlikely / highly improbable | 05-20% |
+| unlikely / improbable | 20-45% |
+| roughly even chance | 45-55% |
+| likely / probable | 55-80% |
+| very likely / highly probable | 80-95% |
+| almost certain / nearly certain | 95-99% |
+
+**Attribution:** these seven bands are ICD 203's published lexicon. `narrative-fallacy-guard` carries the same ladder, so a draft run through both skills gets one ladder rather than two. Declare it once in the piece, where a reader meets it before the first banded judgment, and never let a term drift off its band mid-draft. If you substitute another published standard, substitute it everywhere. A piece must never carry two ladders.
+
+Confidence is a separate three-rung scale, and it is this skill's own: LOW (single source, or sources disagree on sign), MODERATE (multiple sources agreeing, known gaps), HIGH (direct primary evidence, replicated). Confidence is not a probability, which is why it never shares a sentence with a likelihood band.
+
+**Banding applies only to load-bearing judgments** — the ones a reader would act on. Banding every sentence produces the hedge flooding described above and costs the same credibility as no banding at all.
+
+## Guardrails
+
+**Requirements:**
+
+1. **Frame Lock in writing**: unit, denominator, window, boundary — plus one rejected alternative each — before any prose. Holding it in working memory is how drift happens.
+2. **Pointer per number**: every figure resolves to an external artifact. Pointers into your own drafts are a hard failure.
+3. **Denominator sweep before shipping**: an unnarrated change of denominator across the piece is the defect fact-checking cannot detect.
+4. **Falsification line per annotation**: no annotation ships without the private sentence naming the marks that would falsify it.
+5. **Leap-of-faith mark**: every exhibit containing projected, modelled, or extrapolated values marks where measurement ends.
+6. **One uncertainty type per claim**, routed by table, placed inside the claim it qualifies.
+7. **Omitted-number log reviewed as a set**, not per cut.
+
+**Common pitfalls:**
+- The stat wall: five figures and three percentages in one paragraph, packed in to demonstrate rigour, exactly where the evidence was strongest and the reader stops reading.
+- Rounding away the distinction that was the whole point ("about a billion" when 1.04bn versus 1.4bn is the argument).
+- Defensive over-disclosure: answering an honesty audit by adding twelve caveat exhibits and four hedging paragraphs. Volume is not integrity. The operative test is whether a disagreeing reader can find your strongest counter-number within one exhibit.
+- Intentionality verbs on systems: "the market priced in", "the protocol decided", "the index knew". Each is an unsourced claim about collective intent smuggled through a verb. Rewrite as aggregated behaviour of named actors, or mark it once as shorthand.
+- Deleting hedges during a style pass and silently raising a claim's confidence past its evidence.
+- Letting one quantified individual — one patient, one customer, one run — stand for a distribution without the sentence that says what it is not typical of.
+
+## Quick Reference
+
+**Key resources:**
+- **[resources/number-landing.md](resources/number-landing.md)**: the landing checklist with bad/good pairs across market history, epidemiology, ML evaluation and supply chain; rounding table; human-scale conversions; bureaucratic word swaps; opening-frame patterns
+- **[resources/quantitative-fidelity.md](resources/quantitative-fidelity.md)**: Frame Lock template, denominator-drift worked example, precision and rounding rules, percent vs percentage point, contested-figure grammar, model-vs-measurement grammar, person and system variants
+- **[resources/uncertainty-and-exhibits.md](resources/uncertainty-and-exhibits.md)**: expanded routing table, likelihood and confidence ladder usage, hedge budget, chart-beat contract, annotation spec and density caps, detachment and falsification tests
+- **[resources/evaluators/rubric_numbers_in_narrative.json](resources/evaluators/rubric_numbers_in_narrative.json)**: quality scoring
+
+**Inputs required:**
+- The draft or passage carrying the figures
+- The source values at full precision, with pointers
+- Which claims are load-bearing (what a reader would act on)
+
+**Outputs produced:**
+- Frame Lock block (unit, denominator, window, boundary, plus rejected alternatives)
+- Revised prose passing the number-landing checklist
+- Uncertainty routing decisions, one type per load-bearing claim
+- Chart-beat contract per exhibit: beat sentence, title, falsification lines, leap-of-faith mark
+- Denominator sweep result, recomputation result, omitted-number log, refusal-list defects

--- a/skills/numbers-in-narrative/resources/evaluators/rubric_numbers_in_narrative.json
+++ b/skills/numbers-in-narrative/resources/evaluators/rubric_numbers_in_narrative.json
@@ -1,0 +1,104 @@
+{
+  "name": "Numbers In Narrative Rubric",
+  "description": "Evaluation criteria for prose that carries quantities: whether the numbers land for a reader and whether they stay inside what the sources support",
+  "criteria": [
+    {
+      "name": "Frame Lock and Denominator Discipline",
+      "description": "Whether unit, denominator, window and population boundary are fixed in writing, and whether the denominator holds across the whole piece",
+      "weight": 1.4,
+      "scores": {
+        "1": "No frame stated; denominators switch between counts, rates and shares across the piece with no acknowledgement",
+        "2": "Frame implied but never written; at least one unnarrated denominator switch survives into the final text",
+        "3": "Frame written for unit and denominator; window and boundary unjustified; denominator sweep not run",
+        "4": "All four locked with justification; denominator sweep run; any switch is narrated as a beat",
+        "5": "All four locked with one rejected alternative and a reason each; sweep table produced; rate-vs-count rule applied and any moving denominator shown as both series"
+      }
+    },
+    {
+      "name": "Number Landing",
+      "description": "Whether each surviving figure is legible: budget respected, rounded appropriately, compared, at human scale, direction before magnitude",
+      "weight": 1.2,
+      "scores": {
+        "1": "Stat walls throughout; bare figures with no comparison; paragraphs open cold on numbers the reader has no frame for",
+        "2": "Some comparisons present but budgets ignored; magnitude given before direction; precision carried unnecessarily",
+        "3": "Budgets mostly respected and most figures compared; human-scale conversion inconsistent",
+        "4": "Budgets respected; every figure compared on the same screen; direction precedes magnitude; frames built before figures land",
+        "5": "As 4, plus human-scale conversions that do not overclaim, rounding tested against the specific claim each sentence makes, and bureaucratic number-words replaced without breaking terms of art"
+      }
+    },
+    {
+      "name": "Source Fidelity and Precision",
+      "description": "Whether figures stay inside their sources: precision ceiling, rounding drift, percent vs percentage point, relative vs absolute, contested values, ranges",
+      "weight": 1.4,
+      "scores": {
+        "1": "Figures exceed source precision; derived numbers computed from rounded prose; percent and percentage point conflated; contested figures silently resolved",
+        "2": "Precision mostly respected but at least one derived figure traces to a prose number, or one contested figure was picked without disclosure",
+        "3": "Precision ceiling held and contested figures carry both values; totals not recomputed from held values at the end",
+        "4": "No precision violations; all derived figures computed from held source values; percent/point and relative/absolute correct throughout; ranges survive into prose",
+        "5": "As 4, plus end-of-draft recomputation of every total and share from held values, parts confirmed to sum, and every figure resolving to an external pointer with no circular sourcing"
+      }
+    },
+    {
+      "name": "Epistemic Grammar",
+      "description": "Whether the sentence shape matches the evidentiary status: measurement vs model, trend claims, qualitative quantifiers, sourced vs verified, intentionality verbs on systems",
+      "weight": 1.3,
+      "scores": {
+        "1": "Model output written as observation; trends asserted from two points; qualitative quantifiers converted to numerals; work described as verified",
+        "2": "Occasional model-as-measurement slips or an unmarked two-point trend; system intentionality verbs used freely",
+        "3": "Model output marked and two-point trends avoided; some intentionality verbs on systems remain unmarked",
+        "4": "Every projection, fit or estimate carries model grammar; no manufactured numerals; provenance language says sourced, not verified",
+        "5": "As 4, plus system intentionality either rewritten as aggregated behaviour of named actors or marked once as an explicit device, and no verb carrying a hidden causal claim survives"
+      }
+    },
+    {
+      "name": "Uncertainty Routing",
+      "description": "Whether uncertainty is typed and routed to a vehicle and a placement, rather than dumped in a methods note or smeared across every sentence",
+      "weight": 1.3,
+      "scores": {
+        "1": "Uncertainty absent, or entirely confined to a trailing methods note",
+        "2": "Uncertainty present but untyped and placed by habit; or hedges appear in nearly every sentence so nothing lands",
+        "3": "Dominant type named for most load-bearing claims and routed roughly by table; momentum rule not applied",
+        "4": "One type per claim, routed to the correct vehicle and placement; momentum rule applied so only conclusion-changing uncertainty takes its own beat",
+        "5": "As 4, plus reference-model sentences written for load-bearing claims, missingness rendered rather than left blank, and specification disagreement made the beat where two defensible specifications diverge"
+      }
+    },
+    {
+      "name": "Likelihood and Confidence Discipline",
+      "description": "Whether banded language is declared, consistent, separated from confidence, and reserved for load-bearing judgments",
+      "weight": 1.0,
+      "scores": {
+        "1": "Probability words used loosely and interchangeably; likelihood and confidence combined in single sentences",
+        "2": "Some banded terms used but no ladder declared, and terms drift between sections",
+        "3": "A ladder is declared but applied to too many non-load-bearing sentences, or the two ladders occasionally blend",
+        "4": "Ladder declared once in the piece; terms hold their bands; likelihood and confidence always separated",
+        "5": "As 4, plus banding restricted to judgments a reader would act on, no banded term paired with a contradicting bare number, and the ladder's status as a declared convention rather than a universal standard made explicit"
+      }
+    },
+    {
+      "name": "Exhibit Contract",
+      "description": "Whether each exhibit carrying a beat has a checkable title, falsification lines, a leap-of-faith mark and survives detachment",
+      "weight": 1.2,
+      "scores": {
+        "1": "Exhibits titled as labels; no annotation discipline; projected values indistinguishable from measured ones",
+        "2": "Titles carry claims but no falsification line was written; caveats live only in the surrounding prose",
+        "3": "Beat sentence written before drawing and title made a claim; density caps or the detachment test skipped",
+        "4": "Beat, checkable title, density caps, leap-of-faith mark, and a falsification line per annotation",
+        "5": "As 4, plus the exhibit passing the detachment test carrying both beat and caveat, provenance on the exhibit, and consistent encodings across the sequence"
+      }
+    },
+    {
+      "name": "Omission and Over-Disclosure Balance",
+      "description": "Whether cuts were reviewed as a set and whether counter-evidence is findable, without answering the audit by burying the reader in caveats",
+      "weight": 1.1,
+      "scores": {
+        "1": "No record of what was cut; disconfirming figures absent; or the draft is padded with caveat exhibits that obscure the argument",
+        "2": "Cuts made ad hoc with no log; strongest counter-evidence appears late or not at all",
+        "3": "Omitted-number log kept but reviewed per cut rather than as a set",
+        "4": "Log reviewed as a set for shared direction; counter-evidence present and reachable; hedge budget respected",
+        "5": "As 4, plus a disagreeing reader able to find the strongest counter-number within one exhibit of where they are, and no defensive volume added in place of a reversal"
+      }
+    }
+  ],
+  "threshold": 3.5,
+  "passing_note": "Average score must be >= 3.5. Scores below 3 in 'Frame Lock and Denominator Discipline' or 'Source Fidelity and Precision' require revision regardless of the average, because both failures survive fact-checking."
+}

--- a/skills/numbers-in-narrative/resources/number-landing.md
+++ b/skills/numbers-in-narrative/resources/number-landing.md
@@ -1,0 +1,116 @@
+# Number Landing: Making Quantities Land In Prose
+
+Reference matter for Step 3 of the workflow. The governing idea is old newsroom practice: a number alone has almost no meaning. Meaning comes from relative value.
+
+## The caps, and where they come from
+
+| Cap | Value | Status |
+|-----|-------|--------|
+| Numbers per narrative paragraph | 3 | Working default for narrative prose. Not a published figure. |
+| Numbers per sentence | 1 | Working default. |
+| Numerals per paragraph, reference matter | ~8 | Published newsroom guidance (KSJ Science Editing Handbook). A ceiling, not a target. |
+
+Treat the caps as a trigger for a decision, not a law. Over cap, you choose: move to a table, move to an exhibit, move to a footnote, or cut. You never choose "spread them across two sentences".
+
+## Rounding table
+
+| Source value | Prose | Why |
+|---|---|---|
+| 105% increase | doubled | The reader holds "doubled". They do not hold 105%. |
+| 33.2% | one in three | Ratio beats percentage at low precision. |
+| 49.6% | about half | "About" is a precision claim: plus or minus the rounding unit. |
+| $1.043bn | about a billion | Unless the difference from $1.4bn is the argument. |
+| 4.7 days vs 3.2 days | nearly five days, up from three | Direction and human units. |
+| 0.9994 AUC vs 0.9989 | five ten-thousandths apart, inside seed noise | Here the digits ARE the claim and must survive. |
+
+**Hedge words are precision claims, not softeners.**
+- "about" means plus or minus the rounding unit.
+- "nearly" and "more than" assert a direction. They must be true in that direction.
+- "roughly" signals genuine estimate uncertainty, not a rounded exact figure.
+
+Never use them decoratively. "Roughly 47.3%" is a contradiction on its face.
+
+## Human-scale conversions
+
+Pick the denominator the reader already owns.
+
+| Domain | Raw | Human scale |
+|---|---|---|
+| Public health | 44,000 deaths a year | a town the size of Wilkes-Barre, emptied, every year |
+| Supply chain | 18,412 containers dwelling over 72 hours | three in five boxes on the terminal |
+| ML evaluation | 3.2e22 training FLOPs | about eight times the compute of the previous release |
+| Market history | $47bn of new issuance | more paper in one quarter than the prior three years combined |
+| SRE | 99.92% availability | about seven hours down a year, or one bad afternoon a quarter |
+| Biography | 1,100 letters over 31 years | a letter every ten days for three decades |
+
+The conversion must not become a claim of its own. "A town emptied every year" is a scale device. It is not an assertion that the deaths were concentrated, simultaneous, or in one place. If a reader could take the device literally and be wrong, add the clause that stops them.
+
+## Direction before magnitude
+
+The sign is the information. The size is the qualifier.
+
+- Bad: "Median time to detect was 41 minutes in the second half, against 26 minutes in the first."
+- Good: "Detection got slower. It took about forty minutes to notice an incident by year end, up from under half an hour."
+
+Bad forces the reader to do the subtraction and then infer the sign. Good gives the sign in three words and spends the rest on scale.
+
+## Never open cold on a number
+
+A paragraph that opens on a figure the reader has no frame for is wasted. Build the frame in one clause, then land it.
+
+- Cold: "Yield at the new node ran at 61%."
+- Framed: "A new process node is considered economic somewhere above eighty percent yield. This one ran at sixty."
+
+The frame can be a threshold, a prior period, a peer, or a stated expectation. It cannot be a definition of the metric — that is a glossary, not a frame.
+
+## Bureaucratic number-words
+
+| Bureaucratic | Plain |
+|---|---|
+| expenditures | spending |
+| utilization | use |
+| headcount | staff, people |
+| revenue (in plain-audience prose) | income, sales |
+| remuneration | pay |
+| throughput degradation | slowdown |
+| attrition | people leaving |
+| capital expenditure | building and equipment |
+| adverse events | harms, side effects |
+| non-performing exposures | loans not being repaid |
+
+Keep the technical term when the audience uses it as a term of art, or when a defined accounting or clinical meaning is load-bearing. Swapping "revenue" for "income" inside a financial statement discussion introduces an error. Swapping it in a general-audience paragraph removes a barrier.
+
+## Worked pairs, four domains
+
+**Market history.**
+Bad: "Trading volume in the contract reached 412,000 lots in March 1998, a 187% increase over the 143,600 lots recorded in March 1997, while open interest grew 62.4% to 88,900."
+Good: "Volume in the contract nearly tripled in a year, to just over four hundred thousand lots a month. Open interest — the money actually left on the table overnight — grew far more slowly, which tells you most of the new activity went home flat."
+
+**ML evaluation.**
+Bad: "The model achieved 87.4% on the benchmark, up from 84.1%, with a variance across seeds of 1.2 points."
+Good: "The model gained about three points on the benchmark. Seeds move it more than a point on their own, so a third of the gain could be noise. Two of the three runs that ended above the old score also ended above it before fine-tuning."
+
+**Post-mortem.**
+Bad: "The incident lasted 4h12m, affecting 2.3% of requests, with p99 latency reaching 8,412ms against a baseline of 312ms."
+Good: "The outage ran most of an afternoon. One request in forty failed outright. For the slowest one percent of users the service went from a third of a second to more than eight seconds, which is past the point where people reload."
+
+**Biography.**
+Bad: "Between 1911 and 1918 she published 47 articles, 12 in journals with circulation above 10,000."
+Good: "She published something every other month for seven years. A quarter of it reached the large-circulation journals, which at the time was the only route to a paying readership."
+
+## The stat wall, and its mirror
+
+The stat wall packs figures in to demonstrate rigour. The eye slides off exactly where the evidence is strongest.
+
+The mirror failure is worse. Rounding away a distinction that materially mattered trades a stall for an error. "About a billion" is a defect when the difference between $1.04bn and $1.4bn is the argument. Test each rounding against the specific claim the sentence makes, not against a general readability preference.
+
+## Person and system variants
+
+| Move | Person protagonist | System protagonist |
+|---|---|---|
+| Human scale | per week of her life, per year of practice | per shipment, per wafer, per request, per enrolled patient |
+| Comparison | against her own earlier period, against a named peer | against the prior regime, a peer market, a design threshold |
+| Frame before the number | what she or her contemporaries expected | the stated threshold, the design spec, the regulatory limit |
+| Single case | her own figure IS the population — no repair needed | one case is a sample of one — the next sentence restores the distribution |
+
+The last row is the one that goes wrong. Framing a distributional finding through one quantified individual raises engagement precisely because it invites the reader to reason from a single case. When the real protagonist is a market, a protocol, or a cohort, the individualized opening is the most-remembered part of the piece and the least representative. If you use it, the next beat must restore the distribution and state what the case is and is not typical of.

--- a/skills/numbers-in-narrative/resources/quantitative-fidelity.md
+++ b/skills/numbers-in-narrative/resources/quantitative-fidelity.md
@@ -1,0 +1,143 @@
+# Quantitative Fidelity: The Frame Lock And The Refusals
+
+Reference matter for Steps 1, 2 and 6. The structural fact this file exists to answer: in quantitative narrative, every fact can be true and the story still false. Falsity lives in the choices — unit, denominator, window, boundary, aggregation level, which measure leads — not in the figures. Fact-checking cannot see it.
+
+## Frame Lock template
+
+The Frame Lock is owned by `narrative-evidence-ledger`. If a ledger exists, import its lock verbatim rather than filling this in; the template below is for material that has no ledger. The owner's procedure and worked examples live in [../../narrative-evidence-ledger/resources/frame-lock.md](../../narrative-evidence-ledger/resources/frame-lock.md).
+
+Fill this before any prose. Written down, not held in memory.
+
+```
+FRAME LOCK
+UNIT:         one row is ______
+  rejected:   ______ because ______
+DENOMINATOR:  per ______
+  rejected:   ______ because ______
+WINDOW:       ______ to ______
+  left edge justified by:  ______
+  right edge justified by: ______
+  rejected:   ______ because ______
+BOUNDARY:     population is ______
+  drawn by:   me / the source / a regulator / an industry body
+  rejected:   ______ because ______
+```
+
+Any later change to one of the four re-opens the whole piece. It does not just adjust one chart, because the change alters which claims are sayable about the material.
+
+**Worked lock, supply chain.**
+```
+UNIT:         one inbound container, at one terminal, on one calendar day
+  rejected:   one booking — bookings split across containers and double-count dwell
+DENOMINATOR: per container-day of dwell
+  rejected:   per TEU — mixes 20ft and 40ft boxes whose handling differs
+WINDOW:       Jan 2021 - Dec 2023
+  left edge:   first month the terminal's new gate system was live (prior data is a different instrument)
+  right edge:  last month with complete billing reconciliation
+  rejected:   starting 2019 — the pre-system data is not comparable and would manufacture a jump
+BOUNDARY:     the four terminals under the same operator agreement
+  drawn by:   the source, in its own reporting
+  rejected:   all terminals in the port — different operators report dwell differently
+```
+
+## Denominator drift: the failure fact-checking cannot detect
+
+The pattern: the piece opens on counts, pivots to per-capita for the one comparison where per-capita favours the thesis, then returns to counts for the conclusion. Every exhibit is individually defensible. The sequence is a lie.
+
+**Worked example, public health.**
+
+1. Opening: "The county recorded 412 cases, the most in the state." (count)
+2. Middle: "Adjusted for population, the neighbouring county is worse — 61 per hundred thousand against 44." (rate)
+3. Close: "With more than four hundred cases, the county remains the state's outbreak centre." (count again)
+
+Nothing here is false. The county is both the worst place and not the worst place, depending on which sentence you remember. The piece has already chosen for you: counts sit in the emphatic position at both ends.
+
+**The sweep.** List every number in the finished draft, in order, with its denominator:
+
+| # | Figure | Denominator | Position |
+|---|---|---|---|
+| 1 | 412 cases | none (count) | opening |
+| 2 | 61 vs 44 | per 100k residents | middle |
+| 3 | 400+ cases | none (count) | close |
+
+Two switches. Each switch must be reverted, or narrated as a beat: "Counted heads, this is the worst county in the state. Counted per resident, it is fourth — and which of those matters depends on whether you are allocating vaccine or allocating blame."
+
+**Rate vs count rule.** If entities differ in size by more than roughly 2x, rates are mandatory for comparison and raw counts are supplementary, never the headline. If the denominator is itself moving — a shrinking population, a growing user base, a changing test volume — show both series. The ratio alone hides which term moved.
+
+**Denominator language.** "Per capita" means per person. A figure of 2.3 per 1,000 residents is not a per-capita figure. This is the most checkable error in quantitative writing and the most common.
+
+## Precision and rounding
+
+**Precision ceiling.** No figure in prose may exceed the precision of its source.
+- Source: "roughly a third." Permitted: "about a third", "roughly one in three." Forbidden: "33.4%."
+- Source: 23.7%. Permitted: "about a quarter", "23.7%." Forbidden: "23.74%."
+
+**Rounding drift.** The compounding version is the dangerous one. The agent rounds for readability, then uses the rounded figure as the input to the next sentence's ratio or total. By the third derivation the number sits outside the source's range while still wearing the word "about".
+
+- Held value: 1,043,200 units. Prose: "about a million."
+- Next sentence derives a share: 1,000,000 / 4,180,000 = 24%. But the true share is 1,043,200 / 4,180,000 = 25%.
+- Shipped: "about a quarter" would have been right. "Just under a quarter" is now wrong.
+
+Rule: derived figures reference the held source value and its pointer, never a prose sentence. Recompute every total, share, and ratio at the end from the held values, and confirm the parts still sum to the whole after rounding.
+
+**Circular sourcing.** Your own earlier draft, summary, or notes are never a source for a number. In a multi-step pipeline this corruption is silent: every figure has a pointer, no figure has a source, and no single step did anything wrong. Check it mechanically. It is invisible on reading.
+
+## Percent, percentage point, relative, absolute
+
+| Move | Bad | Good |
+|---|---|---|
+| Percent vs point | "Coverage rose 50%" (from 4% to 6%) | "Coverage rose two percentage points, from 4% to 6%" |
+| Relative without base | "Adverse events doubled" | "Adverse events went from three to six, out of 4,000 enrolled" |
+| Absolute without base | "1,200 more failures" | "1,200 more failures, on a base of 90,000 — one in seventy-five" |
+| Both in one sentence | "a fifty percent rise, or two percentage points" | Pick the one the claim rests on. Put the other in the exhibit. |
+
+A rise from 4% to 6% is simultaneously two percentage points and a fifty percent increase. Both are true. Only one belongs in a given sentence, and which one you choose is a rhetorical act — pick it deliberately and disclosably.
+
+## Contested figures
+
+Both values, both sources, one sentence. Never average. Never silently pick the better-sounding one.
+
+- Bad: "Downtime ran to about an hour and a half."
+- Good: "The operator put downtime at 40 minutes; the regulator's incident log records 94."
+
+If the sources disagree on the SIGN of a change, the disagreement is its own beat and needs a paragraph, not a clause. If you believe one over the other, say which and why — that is a claim you own, and it belongs in the text rather than in a note.
+
+## Model output must not wear the grammar of a measurement
+
+A projection, a fit, a simulation, or an analyst estimate may not take the sentence shape of an observation.
+
+| Forbidden | Permitted |
+|---|---|
+| "Throughput reaches 14,000 units in 2027." | "The capacity model puts throughput at about 14,000 units by 2027." |
+| "The intervention prevents 3,100 infections." | "Under the transmission model as specified, the intervention averts roughly 3,000 infections; a second specification puts it near 1,200." |
+| "Latency will settle near 40ms." | "Extrapolating the last six weeks, latency settles near 40ms — the extrapolation is marked on the chart." |
+| "She earned the equivalent of $84,000." | "Converted at the 1911 exchange rate and adjusted by CPI, her salary is roughly $84,000 in today's money; other deflators give figures from $60,000 to $110,000." |
+
+The grammar carries the epistemic status. When it does not, the reader has no way to know they are reading a model.
+
+## The other hard refusals
+
+- **Trend from two points.** Two observations are a difference. "Rising", "accelerating", "the trajectory", "on track to" all require more than two.
+- **Qualitative quantifier to numeral.** Source says "several suppliers." You may not write "six". You may write "several", and you may go ask.
+- **Ranges survive.** If the source gives a range or interval, prose carries it, or states explicitly that it is using the midpoint. Silently collapsing an interval to its centre is manufacturing precision.
+- **Thin support.** Never lead on a figure resting on a handful of records or one reporting period. Rarity in real data is overwhelmingly produced by small denominators, coding errors, partial reporting periods, and newly created categories. Plot the measure's variance against denominator size. If your extremes all sit in the smallest denominators, your extremes are noise wearing a story's clothes.
+- **Instrument versus world.** A sharp break in a series is a change in the world only if it survives an instrument check. Enumerate definitional revisions, coverage changes, methodology restatements, reporting-lag artifacts, entity and boundary changes. If the break coincides with one of these, either re-baseline on a consistent definition or narrate the instrument change as the story. The artifact is usually sharper than the real transition, so the false version reads better.
+- **Verified.** You track provenance. You do not verify. The correct verb is "sourced".
+
+## The omitted-number log
+
+Refusal training makes a writer good at not adding. Nothing makes them good at not omitting. A fully sourced piece can be entirely false through subtraction alone: the disconfirming quarter, the failed arm, the region that went the other way, each cut individually defensible for length or flow.
+
+Keep a log of every figure cut from the draft. Review it as a SET, not per cut. The question is not "was this cut defensible?" but "do these cuts share a direction?" If the remaining text implies a different frequency, magnitude, or balance than the full record, the subtraction has become deception.
+
+## Person and system variants
+
+| Concern | Person protagonist | System protagonist |
+|---|---|---|
+| Unit | one year of a life, one work, one transaction she made | one shipment, one wafer, one request, one enrolled patient |
+| Denominator | per year of career, per work produced | per unit of exposure, per attempt, per dollar deployed |
+| Boundary | which of her activities count as the career | which entities count as the market, and who drew that line |
+| Intentionality | motive requires a stated source, at the time or recalled | "the market priced in", "the protocol decided" is an unsourced claim about collective intent — rewrite as aggregated behaviour of named actors |
+| Aggregates | not applicable | a representative firm or median user may never take a name, a date, a scene, or an intent |
+
+The intentionality row is the one that fails silently. Every "the market realized", "the industry decided", "the index knew" is either shorthand the reader will read as agency, or a hidden causal claim that never faces the sourcing discipline an explicit claim would face. Personify once, marked as a device. After that, attribute behaviour to named mechanisms and named actors.

--- a/skills/numbers-in-narrative/resources/uncertainty-and-exhibits.md
+++ b/skills/numbers-in-narrative/resources/uncertainty-and-exhibits.md
@@ -1,0 +1,121 @@
+# Uncertainty Routing And The Chart-Beat Contract
+
+Reference matter for Steps 4 and 5.
+
+## Why routing, and not disclosure
+
+Omitting uncertainty does not avoid assumptions. It outsources them. A reader looking at a figure with no uncertainty fills in an implicit reference distribution of their own, drawn from an effectively unlimited space of possible models (Hullman, IEEE TVCG 2020). The omission does not produce a cleaner inference. It produces an uncontrolled one that varies across readers and that you cannot see.
+
+Two failures sit on either side of the correct behaviour.
+
+**Uncertainty laundering.** Every caveat moves to a methods appendix so the narrative stays clean. This passes a disclosure audit and defeats its purpose. It is also the most comfortable failure, because it feels like good editing.
+
+**Hedge flooding.** Every sentence carries an interval, no claim lands, and readers fall back on the one unhedged artifact in the piece — the headline. Hedging everything is functionally the same as hedging nothing, with worse prose.
+
+There is a documented incentive trap here. One surveyed author reported that their work "would not be accepted by politicians because other analysts never describe uncertainty, so my more robust visualizations appear less valid if I am transparent." Honesty is locally costly. That is exactly why it has to be a rule rather than a preference.
+
+## The routing table, expanded
+
+| Type | What it is | Vehicle | Placement | Worked phrasing |
+|---|---|---|---|---|
+| Sampling | The figure would move if you drew the sample again | Interval, or frequency framing in words | Annotation layer of the exhibit it qualifies | "About one survey in twenty would put this below zero." |
+| Measurement | The instrument itself is imprecise or drifted | Stated range, or an instrument-precision note | Exhibit caption AND the sentence that first uses the number | "The gauge reads to the nearest half-day, so anything under a day of change is inside the instrument." |
+| Model / specification | A different reasonable specification gives a different answer | Two or more specifications, side by side | Its own beat | "Two ways of adjusting for mix are defensible. One says the effect is 12%; the other says 3%. Nothing in the data chooses between them." |
+| Coverage / missingness | Some of the population is not in the data at all | Render the absence: shade the gap, count what is missing, name who is not in the denominator | In the exhibit | "Four of the eleven sites never reported. The shaded band is where their volume would sit at the median of the rest." |
+| Contested source | Two sources give different numbers for the same thing | Both as separate series, with provenance | Own beat if they disagree on sign, else annotation layer | "The operator's log and the regulator's differ by more than a factor of two. Both are plotted." |
+
+**Momentum rule.** Uncertainty earns its own beat only when it would change the conclusion. Otherwise it rides in the annotation layer of the claim it qualifies. This is the rule that preserves pace without hiding anything, and it is what stops the routing table from turning into hedge flooding.
+
+**Never** route all uncertainty to a trailing methods note. **Never** hedge every sentence.
+
+**The reference-model sentence.** For each load-bearing claim, write the sentence stating what a reader would have to assume for your signal to be ABSENT. If you cannot write it, you do not know how strong your own claim is.
+- "For this to be noise, the four unreported sites would all have to run at less than a third of the median."
+- "For the gain to be real, seed variance would have to be smaller in this run than in any of the previous nine."
+
+## Likelihood and confidence: two ladders, never combined
+
+**Likelihood** is how probable the thing is. **Confidence** is how good the evidence behind that judgment is. They are independent. You can be highly confident that something is unlikely. You can have low confidence about a near-certainty.
+
+Never combine them in one sentence. "We are highly confident this is very likely" is unparseable and conceals which of the two is weak.
+
+**Likelihood ladder (ICD 203's published seven bands):**
+
+| Term | Band |
+|---|---|
+| almost no chance / remote | 01-05% |
+| very unlikely / highly improbable | 05-20% |
+| unlikely / improbable | 20-45% |
+| roughly even chance | 45-55% |
+| likely / probable | 55-80% |
+| very likely / highly probable | 80-95% |
+| almost certain / nearly certain | 95-99% |
+
+**Confidence ladder:**
+
+| Rung | Term | Meaning |
+|---|---|---|
+| LOW | low confidence | single source, or sources disagree on sign, or the specification drives the result |
+| MODERATE | moderate confidence | several independent sources agreeing, with known gaps |
+| HIGH | high confidence | direct primary evidence, replicated or reconciled |
+
+**Attribution.** The seven likelihood bands above are ICD 203's published lexicon, the same ladder `narrative-fallacy-guard` carries. The three confidence rungs are this skill's own. Other estimative-language standards exist and their bands differ from one another, so if you substitute one, substitute it everywhere. Whichever ladder you use:
+
+1. Declare it once, in the piece, where a reader will meet it before the first banded judgment.
+2. Never let a term drift off its band mid-draft. "Likely" cannot mean 55% in one section and 75% in another.
+3. Do not mix a banded term with a bare number for the same judgment ("likely, around 30%" contradicts itself).
+
+**Band only load-bearing judgments** — the ones a reader would act on. Banding every sentence is hedge flooding under a different name, and it trains the reader to skip the bands entirely.
+
+## The chart-beat contract
+
+One exhibit, one beat. The annotation layer carries the beat, not the marks.
+
+**1. Write the beat sentence first.** One declarative claim, before drawing anything. If you cannot write it, you do not know what the exhibit is for.
+
+**2. Identify the target inside that sentence.** Is the claim about a single data item or series? A threshold, span, or region? The chart's own framing — an axis range, a scale, a definition? A previous annotation?
+
+**3. Choose the form to match the target.**
+
+| Target | Form |
+|---|---|
+| Data item | Text label plus a dropline or leader |
+| Set or series | Highlight (alter stroke or fill), with the series label ON the line, never in a legend |
+| Coordinate span or threshold | Reference line or shaded band, labelled in words: "break-even", "herd immunity", "design limit" |
+| Chart framing | Peripheral annotation: caption, credit, footnote, scale note |
+| Prior annotation | Parenthetical reference label so later text can point back at earlier marks |
+
+**4. Make the title the beat sentence** — phrased as a claim the chart's own marks can be checked against. "Dwell time doubled after the gate change" is checkable. "A look at terminal dwell" is a label, not a beat.
+
+**5. Density cap per exhibit.** One highlighted series. One reference line or band. At most three text annotations. Everything else greys down. Contrast is the mechanism; without muting, highlighting encodes nothing.
+
+**6. Falsification line, per annotation, private.** Write the specific marks that would make this annotation false. Cannot answer means the annotation asserts something the chart does not show. Cut it or change it.
+
+**7. Leap-of-faith mark.** Wherever any part of the exhibit is projected, modelled, or extrapolated, mark on the exhibit where measurement ends. Established professional practice, and the single most portable device in this file.
+
+**8. Detachment test.** Crop the exhibit out of the prose. Does it still carry the beat AND the caveat that qualifies it? Exhibits circulate detached from their text; the annotation layer is the only thing that travels with them.
+
+**9. Provenance on the exhibit.** Source citation always. Methodology citation wherever a non-obvious transformation was applied.
+
+**10. Encoding consistency.** The same colour means the same thing in every exhibit in the sequence.
+
+## Why the title needs a falsification line
+
+Readers recall the gist of the TITLE rather than the data, and follow the title even when it is slanted relative to — or contradicts — the chart (Kong et al., CHI 2018 and CHI 2019). Worse: readers can identify a title as biased while continuing to rate the underlying information as impartial. Visible slant does not neutralise itself.
+
+So the practitioner advice to "make the title carry the finding" is genuinely effective AND genuinely dangerous. An annotation written to be a good narrative beat quietly becomes the claim readers carry away, whether or not the data licenses it, and it does so most effectively on readers who trust you. The falsification line is the working defence. Disclosure is not.
+
+## Volume is not integrity
+
+Obfuscation is a deception technique in its own right. Burying damaging information among many weakly supportive exhibits has a name — the visual Gish gallop — and it is an attack on the reader whether or not you meant it.
+
+So the response to an honesty audit is never "add twelve caveat charts and four paragraphs of hedging". That IS the third attack, performed on your own reader.
+
+**The operative test:** a reader who disagrees with your conclusion — can they find, inside your piece, the strongest evidence against you, within one exhibit of where they are? If not, you have obfuscated regardless of intent.
+
+## No exhibit is neutral, and that is not a licence
+
+Every encoding nudges. Some nudges are unavoidable. Every design choice makes some interpretation more probable than another.
+
+It does not follow that no framing can be criticised. That inference converts an analytical tool into an excuse. The obligation is to know which way your choices push, to pick the direction deliberately, and to be able to say so — not to reach a neutral artifact, which does not exist.
+
+For each exhibit, write one sentence: what interpretation does this choice make more probable? For each omission, write the sentence a reader would need in order to know the omission happened. Then decide: restore, or disclose. An audit that produces no reversal and no disclosure did not happen.

--- a/skills/prose-force-and-rhythm/SKILL.md
+++ b/skills/prose-force-and-rhythm/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: prose-force-and-rhythm
+description: Runs Jack Hart's Wordcraft line passes in strict order (Structure, Force, Brevity, Clarity, Rhythm, Humanity, Color, Voice, Mechanics) followed by a slop audit, one pass per edit class, with a claim-strength invariant that stops verb strengthening and hedge cutting from silently overclaiming. Enforces upward escalation instead of downward compensation, a protected-hedge list, a clarity split log the rhythm pass may not undo, and rhythm metrics reported as diagnostics rather than optimized. Use when line-editing a draft, tightening flabby prose, fixing weak verbs or monotonous sentence rhythm, de-slopping AI-sounding copy, or when user mentions line edit, force pass, punch it up, tighten this, passive voice, wordy, sentence variety, sounds like AI, burstiness, or Wordcraft.
+---
+
+# Prose Force and Rhythm
+
+## Table of Contents
+- [Core Principles](#core-principles)
+- [Workflow](#workflow)
+- [The Ten Passes](#the-ten-passes)
+- [The Claim-Strength Invariant](#the-claim-strength-invariant)
+- [List A and List B](#list-a-and-list-b)
+- [Diagnostics, Not Objectives](#diagnostics-not-objectives)
+- [Guardrails](#guardrails)
+- [Quick Reference](#quick-reference)
+
+**Related skills:** Use `writing-structure-planner` for the structural layer this skill escalates to, `readability-check` for scoring reader-facing prose, `writing-revision` for a lighter three-pass cleanup when the full pipeline is overkill, `slop-detector` for the machine-register signature scan Pass 10 delegates to.
+
+## Core Principles
+
+1. **One pass, one edit class**: Each pass may make only edits of its own kind. Running all passes in one prompt collapses them into "improve this writing" and implements none of them.
+2. **Escalate up, never compensate down**: A pass that cannot fix a defect inside its own class files an escalation record and moves on. It does not paper over a structural or reporting failure with prose polish.
+3. **Claim strength is invariant under editing**: Record each sentence's epistemic strength before rewriting and assert it survived. No pass may raise a claim's strength, because no pass has new evidence.
+4. **Two word lists, not one**: Cut List A on sight. Protect List B absolutely. Hart's parasite list was tuned for newspaper prose about events that happened; on technical, medical, legal, and financial material the qualifiers are the content.
+5. **Metrics diagnose, they do not command**: Report sentence-length mean, standard deviation, and cut percentage alongside the prose. An agent optimizing variance inserts one-word sentences.
+6. **Mechanics is last, always**: Never before Voice. Fixing commas in a paragraph that should not exist is the default LLM failure.
+7. **Thresholds are config, not canon**: Every number here is an operational default derived for mechanization, not a figure Hart publishes. Label it as such wherever it is reported.
+
+## Workflow
+
+Copy this checklist and track your progress:
+
+```
+Prose Force and Rhythm Progress:
+- [ ] Step 1: Configure the run and build the claim ledger
+- [ ] Step 2: Pass 1 STRUCTURE (gate: escalate or proceed)
+- [ ] Step 3: Passes 2-4 FORCE, BREVITY, CLARITY (separately)
+- [ ] Step 4: Passes 5-7 RHYTHM, HUMANITY, COLOR
+- [ ] Step 5: Passes 8-9 VOICE, then MECHANICS
+- [ ] Step 6: Pass 10 SLOP AUDIT, then the run report
+```
+
+**Step 1: Configure the run and build the claim ledger**
+
+Step 1.1: Declare the register (analytical, explanatory, narrative), the audience, and the domain risk class. Domain risk class HIGH (medical, legal, financial, safety, scientific) turns the claim-strength invariant and List B protection into hard blocks; class LOW (newsletters, essays, internal notes) keeps them as warnings.
+
+Step 1.2: Write the tunable config. Copy the defaults from [resources/rhythm-diagnostics.md](resources/rhythm-diagnostics.md) and adjust for the register. Record in the config header: "thresholds are derived operational defaults, not published Hart figures."
+
+Step 1.3: Build the claim ledger before any edit. One row per sentence that carries a claim: sentence id, S-level (S1-S5), the exact words carrying the strength, source cited. See [resources/claim-strength-ledger.md](resources/claim-strength-ledger.md).
+
+**Step 2: Pass 1 STRUCTURE (gate)**
+
+Step 2.1: Ask two questions only. Is each paragraph in the right place? Does each section advance the piece's central claim?
+
+Step 2.2: Defects here are not yours to fix. File an escalation record (defect, why it is structural, target layer) and hand it to the structural planner or the human. Do not proceed on a draft with unresolved structural escalations in HIGH risk class; in LOW class, proceed but carry the escalations into the run report.
+
+**Step 3: Passes 2-4 FORCE, BREVITY, CLARITY (separately)**
+
+Step 3.1: FORCE. Run the verb audit on every sentence: "to be" as main verb, light verbs, nominalized actions, expletive openers, suffix clusters, abstract nouns as subjects. Convert passive only where the actor is named in the material; otherwise leave the passive and log a reporting gap. Check S-level after every rewrite.
+
+Step 3.2: BREVITY. Cut List A. Protect List B. Attempt a 20-word version of every sentence over 30 words and accept only if no proposition is lost. Report the cut percentage.
+
+Step 3.3: CLARITY. One-reading test per sentence. Fix by splitting or by supplying the missing concrete referent, never by vaguer wording. Every split you make goes in the **clarity split log**, which the rhythm pass may not reverse.
+
+See [resources/pass-playbook.md](resources/pass-playbook.md) for each pass's full procedure, escalation targets, and worked before/after examples.
+
+**Step 4: Passes 5-7 RHYTHM, HUMANITY, COLOR**
+
+Step 4.1: RHYTHM. Compute the sentence-length series. Fix low variance by splitting one long sentence and merging two short ones inside the same paragraph, never by inserting fragments. Merges are forbidden on any pair in the clarity split log. Check terminal emphasis: is the last word of each paragraph the most consequential one?
+
+Step 4.2: HUMANITY. Named people, concrete nouns, agentless abstractions removed as sentence subjects. When the protagonist is a system, the fix is a named operator, a dated state, or a named constraint, never a personified system.
+
+Step 4.3: COLOR. Every sensory or specific detail must carry information and must be traceable to the material. A detail you cannot source is deleted, not softened.
+
+**Step 5: Passes 8-9 VOICE, then MECHANICS**
+
+Step 5.1: VOICE. Check consistency against the register declared in Step 1.1. Flag drift; do not "add personality."
+
+Step 5.2: MECHANICS. Grammar, usage, house style. This runs last of the nine and never before Voice.
+
+**Step 6: Pass 10 SLOP AUDIT, then the run report**
+
+Step 6.1: Invoke `slop-detector` for signature detection. It owns the signature list and the detection rules. Do not re-derive them here. That skill is still substacker-scoped: its flattened-uncertainty signature reads a `corpus/drafts/notes/` path, so skip that one signature when you run it as the general register pass.
+
+Step 6.2: Apply this skill's constraint to the hedge-reduction step, which `slop-detector` does not carry. That step may reduce only rhetorical hedge stacks. It may never remove a hedge reflecting genuine evidential uncertainty, and it may never touch a List B word. "It seems like it might possibly be the case that latency rose" is three rhetorical hedges on one claim; reduce it. "The estimate may understate exposure under these assumptions" is two epistemic hedges, both load-bearing; leave both.
+
+Step 6.3: Re-run MECHANICS on every line the slop pass changed, then produce the run report: claim ledger diff, escalation records, reporting gaps, cut percentage, rhythm diagnostics, and the config used.
+
+Validate using [resources/evaluators/rubric_prose_force_and_rhythm.json](resources/evaluators/rubric_prose_force_and_rhythm.json). **Minimum standard**: Average score >= 3.5.
+
+## The Ten Passes
+
+| # | Pass | May edit | May NOT touch | Escalates to |
+|---|------|----------|---------------|--------------|
+| 1 | Structure | Paragraph order, section boundaries | Wording | Structural planner / human |
+| 2 | Force | Verbs, subjects, voice | Claim strength, hedges | Reporting (missing actor) |
+| 3 | Brevity | List A words, redundancy, sentence length | List B, propositions | Reporting (claim stated twice, evidence once) |
+| 4 | Clarity | Sentence splits, missing referents | Terminology precision | Ladder of abstraction / reporting |
+| 5 | Rhythm | Length variance, terminal emphasis, openers | Clarity split log pairs | Pass 4 |
+| 6 | Humanity | Abstract subjects, named agents | Attribution of intent to systems | Reporting (who acted?) |
+| 7 | Color | Sourced detail, decoration | Unsourced sensory detail (delete it) | Reporting |
+| 8 | Voice | Register drift | Content | Step 1 config |
+| 9 | Mechanics | Grammar, usage, style | Everything above | None |
+| 10 | Slop audit | Machine-register signatures | Epistemic hedges, load-bearing claims | Reporting (specificity sweep) |
+
+An **escalation record** has four fields: the defect, the class it actually belongs to, why this pass cannot fix it, and the target layer. Escalations are successful outputs, not failures. A run that produces zero escalations on a thin-material draft is a run that papered over the thinness.
+
+## The Claim-Strength Invariant
+
+The most important rule in this skill. Hart's force rules were tuned for reporting on events that happened. Applied to analytical claims they turn "was associated with" into "drove" and "suggests" into "shows."
+
+**The ladder:** S5 asserted fact (dated, sourced) / S4 quantified finding with stated conditions / S3 association or co-occurrence / S2 inference or suggestion / S1 possibility or disputed.
+
+**The rule:** record S-level before the rewrite, assert it after. Any rewrite that raises S-level is reverted, even when the stronger version is probably true. Only new evidence raises a claim, and an editing pass has none.
+
+| Rewrite | Delta | Verdict |
+|---|---|---|
+| "The rollout was associated with a 12% drop in errors" to "The rollout drove errors down 12%" | S3 to S5 | REVERT |
+| "The rollout was associated with a 12% drop in errors" to "Errors fell 12% after the rollout" | S3 to S3 | ACCEPT (expletive killed, strength held) |
+| "The assay suggests the compound binds" to "The assay shows the compound binds" | S2 to S5 | REVERT |
+| "Output declined 4% in Q3" to "Output collapsed in Q3" | S4 magnitude inflation | REVERT |
+| "According to the 2019 filing, reserves fell" to "Reserves fell" | attribution deleted | REVERT |
+
+Strength also moves silently through deletions: dropped attribution, dropped scope ("in this cohort"), dropped date ("as of Q2 2023"), and dropped units. Treat every deletion of those as a strength change.
+
+**Anti-overcorrection:** the invariant is symmetric. Do not add hedges to sourced facts. "The plant appears to have possibly closed" when the closure is in the filing is also a violation.
+
+**System variant:** when the actor is a market, a protocol, or a pipeline, the force pass must reach for a state-change verb, not an intention verb. "The auction cleared at $4.10" is force. "The auction chose $4.10" is an unfalsifiable causal claim distributed across the sentence. Systems have states, constraints, and incentives; only people have wants.
+
+See [resources/claim-strength-ledger.md](resources/claim-strength-ledger.md) for the full ledger format, the verb-swap danger table, and worked examples from clinical, supply-chain, and market-history drafts.
+
+## List A and List B
+
+| List A: cut on sight | List B: protected, never auto-cut |
+|---|---|
+| rather, somewhat, generally, virtually, pretty, slightly, a bit, a little, quite, very, really, actually, basically, essentially, in order to, the fact that, it should be noted, it is important to note, needless to say | approximately, estimated, roughly, may, might, appears, suggests, is consistent with, in this sample, in this cohort, under these assumptions, as of [date], reported, alleged, preliminary |
+
+**The scope exception.** A List A word doing scope work is not a parasite. "Retail sales generally recover within two quarters" is a base-rate claim; deleting "generally" produces a universal law. The fix is neither to keep the vague word nor to cut it, but to replace it with the scope from the material: "In seven of the nine postwar recessions, retail sales recovered within two quarters." If the material does not supply the scope, keep the word and log a reporting gap.
+
+## Diagnostics, Not Objectives
+
+Report these alongside the prose. Never optimize them directly.
+
+| Metric | Default | If it fails | Forbidden fix |
+|---|---|---|---|
+| Sentence-length mean | 15-20 words, general readership | Investigate, do not chop | Splitting sentences to hit the number |
+| Sentence-length SD | >= 7, or 60-70% of mean | Split one long, merge two short in the same paragraph | Inserting fragments or one-word sentences |
+| Short-sentence presence | one under 8 words per 150 | Find a claim worth landing short | "It didn't." "Nobody knew." |
+| Consecutive similar lengths | no 3 within +/-2 words | Vary clause structure | Padding a sentence |
+| Brevity cut | 10-20% | Under 5% means the pass did not run; over 30% means diff the propositions | Cutting hedges to hit the target |
+| Readability score | set per audience in config | Route to a concrete example at the bottom of the abstraction ladder | Swapping a precise term for a vaguer one |
+
+All numeric thresholds above are operational defaults derived for mechanization. Hart publishes no such figures, and both Wordcraft and Storycraft are lending-restricted, so they could not be verified against the primary text. Ship them as tunable config with that provenance stated.
+
+## Guardrails
+
+**Requirements:**
+
+1. **Separate invocations**: Each pass runs as its own step with its own output. If you find yourself editing verbs and commas in the same reading, you are not running this skill.
+2. **Ledger before edits**: No FORCE pass begins before the claim ledger exists. In HIGH risk class this is a hard block.
+3. **Passive stays when the actor is unknown**: "The alert was silenced at 02:14" stays passive and produces a reporting gap. Writing "An on-call engineer silenced the alert" invents an actor.
+4. **Clarity split log is binding**: The rhythm pass may not merge any pair the clarity pass split.
+5. **Attribution honesty**: Cite Hart, Wordcraft, or Storycraft. Do not cite "the Oregon Method" as a codified canon; it is a retrospective label for the Oregonian coaching practice Hart ran, not a system he branded. Do not attribute the SCAM acronym to Hart; it comes from journalism pedagogy at Dynamics of Writing.
+6. **Report, do not silently apply**: Every claim-strength revert, escalation, and reporting gap appears in the run report.
+
+**Common pitfalls:**
+- Running all nine passes in one prompt, producing generic polish and no escalation signal.
+- Strengthening a verb past the evidence because the stronger verb reads better.
+- Deleting "approximately," "in this sample," or "as of Q3" during the brevity pass.
+- Maximizing sentence-length variance with fragments, which reads as LinkedIn copy in an engineering or clinical register and destroys credibility faster than monotony did.
+- Merging short sentences to raise the mean, reintroducing the subordination the clarity pass removed.
+- Over-correcting the slop audit into a new uniformity: banned em dashes, sprinkled fragments, performed casualness. The cure for machine register is specificity and asymmetry, not affected roughness.
+- Letting the humanity pass personify a market, model, or institution to satisfy "concrete agent."
+- Fixing a middle-rung abstraction trap by swapping jargon for plainer jargon instead of supplying one particular from the material.
+
+## Quick Reference
+
+**Key resources:**
+- **[resources/pass-playbook.md](resources/pass-playbook.md)**: Per-pass procedures for Passes 1-9, escalation targets, worked before/after examples across clinical, supply-chain, ML, incident, and market-history drafts. Its Pass 10 section predates the split; `slop-detector` now owns signature detection
+- **[resources/claim-strength-ledger.md](resources/claim-strength-ledger.md)**: S1-S5 ladder, ledger format, verb-swap danger table, silent strength moves, List A/B rationale
+- **[resources/rhythm-diagnostics.md](resources/rhythm-diagnostics.md)**: Burstiness, 2-3-1 end-stress, right-branching, terminal emphasis, pace modulation at complexity, number landing, transitions, tunable config block
+- **[resources/evaluators/rubric_prose_force_and_rhythm.json](resources/evaluators/rubric_prose_force_and_rhythm.json)**: quality scoring
+
+**Inputs required:**
+- The draft, as text or a file
+- Register, audience, and domain risk class
+- The source material or citation set behind the draft (required to distinguish a reporting gap from a wording problem)
+
+**Outputs produced:**
+- The edited draft
+- Claim ledger with before/after S-levels and every revert
+- Escalation records (defect, class, target layer)
+- Reporting-gap register
+- Rhythm and brevity diagnostics, plus the config used and its provenance note

--- a/skills/prose-force-and-rhythm/resources/claim-strength-ledger.md
+++ b/skills/prose-force-and-rhythm/resources/claim-strength-ledger.md
@@ -1,0 +1,124 @@
+# The Claim-Strength Ledger
+
+The guard that keeps the force and brevity passes from becoming an overclaiming machine.
+
+Hart's force rules were written for newspaper prose about events that happened, where a stronger verb is almost always a truer verb because the reporter watched the thing happen. Analytical prose is different. Its verbs carry epistemic weight, and "energy" and "calibration" pull in opposite directions. An unsupervised force pass trades the second for the first every time.
+
+---
+
+## The strength ladder
+
+| Level | Name | Markers | Example |
+|---|---|---|---|
+| S5 | Asserted fact | dated, sourced, no modal | "Fab 14 shut on 4 March 2021." |
+| S4 | Quantified finding, conditions stated | a number plus a scope | "In this cohort, 30-day mortality fell 8 points." |
+| S3 | Association or co-occurrence | associated with, coincided with, followed, correlates with | "The tariff coincided with a 15% fall in imports." |
+| S2 | Inference or suggestion | suggests, is consistent with, indicates, appears | "The ablation suggests the tokenizer caused the regression." |
+| S1 | Possibility or dispute | may, might, could, some argue, alleged, preliminary | "Reserves may be understated." |
+
+S-level is a property of the **evidence**, not of the sentence. The sentence's job is to report it. Editing changes sentences; it never changes evidence; therefore editing may never change S-level.
+
+---
+
+## Ledger format
+
+Build it before Pass 2. One row per claim-carrying sentence.
+
+| id | sentence (before) | S | strength markers | source | pass | S after | verdict |
+|---|---|---|---|---|---|---|---|
+| 12 | The rollout was associated with a 12% drop in checkout errors. | S3 | "was associated with" | dashboard export 2024-05 | Force | S3 | PRESERVED |
+| 19 | The assay suggests the compound binds ACE2. | S2 | "suggests" | Fig 3, internal report | Force | S5 | **VIOLATION, reverted** |
+| 27 | In this sample, churn rose roughly 4 points. | S4 | "in this sample", "roughly" | cohort file | Brevity | S5 | **VIOLATION, reverted** |
+
+The ledger diff goes in the run report. Reverts are reported, not hidden. In HIGH risk class (medical, legal, financial, safety, scientific), an unresolved violation blocks delivery.
+
+---
+
+## Verb-swap danger table
+
+The left column is what a force pass reaches for. The right column is what it costs.
+
+| From | To | Delta | Allowed? |
+|---|---|---|---|
+| was associated with | drove, caused, produced | S3 to S5 | No |
+| coincided with | triggered, set off | S3 to S5 | No |
+| suggests, indicates | shows, proves, demonstrates, confirms | S2 to S5 | No |
+| may, might | will, does | S1 to S5 | No |
+| contributed to | caused | S3 to S5 | No |
+| correlates with | predicts | S3 to S4 causal | No |
+| declined 4% | collapsed, cratered, plunged | magnitude inflation inside S4 | No |
+| rose 3 points | surged, exploded | magnitude inflation | No |
+| one model estimates | the data show | S2 to S5 | No |
+| reported that X | X | attribution deleted | No |
+| was silenced (actor unknown) | an engineer silenced | actor invented | No |
+| was reduced by the team | the team reduced | passive to active, actor named in material | **Yes** |
+| there was a decline of 12% in errors | errors fell 12% | expletive killed, strength held | **Yes** |
+| conducted an analysis of the logs | analyzed the logs | nominalization killed | **Yes** |
+| the implementation resulted in a reduction | after the clinic adopted it, median time fell from 19 days to 11 | abstract subject replaced with sourced particular | **Yes** |
+
+---
+
+## Silent strength moves
+
+Strength changes without any verb changing. Treat each of these deletions as a strength edit requiring a ledger check.
+
+1. **Attribution dropped.** "According to the 2019 filing, reserves fell" to "Reserves fell."
+2. **Scope dropped.** "In this cohort", "in this sample", "among firms with revenue over $50m", "in the 2018-2022 window."
+3. **Date dropped.** "As of Q2 2023" removed from a claim about a moving quantity.
+4. **Estimate marker dropped.** "approximately", "roughly", "estimated" removed from a number that was modeled, not measured.
+5. **Units or basis dropped.** "12% year over year" to "12%."
+6. **Plural evidence collapsed to a singular claim.** "Three of the five studies found" to "Studies found."
+7. **Hedge moved from clause to nothing during a slop-audit hedge-stack reduction.**
+8. **A range narrowed to its midpoint.** "$1.0bn to $1.4bn" to "about $1.2bn."
+
+---
+
+## Anti-overcorrection
+
+The invariant is symmetric. Adding hedges to sourced facts is also a violation, and it is the failure mode of an agent that has been burned once.
+
+- Bad: "The plant appears to have possibly closed in March" when the closure notice is in the filing.
+- Good: "The plant closed in March."
+- Bad: "Sources suggest she may have resigned on 12 June" when the resignation letter is dated 12 June.
+- Good: "She resigned on 12 June."
+
+Hedging sourced material reads as evasive and, in narrative passages, destroys close third-person rendering.
+
+---
+
+## Why List A and List B are different lists
+
+Hart's parasite list is correct for literary journalism, where "somewhat" and "virtually" genuinely dilute. It is catastrophic on technical, medical, legal, and financial writing, where "approximately", "in this cohort", "under these assumptions", and "as of [date]" are the difference between a defensible and an indefensible claim. Applying one list to both kinds of prose is the single most common way this method damages analytical work.
+
+**List A: cut on sight**
+rather, somewhat, generally, virtually, pretty, slightly, a bit, a little, quite, very, really, actually, basically, essentially, in order to, the fact that, it should be noted, it is important to note, needless to say
+
+**List B: protected, never auto-cut**
+approximately, estimated, roughly, may, might, appears, suggests, is consistent with, in this sample, in this cohort, under these assumptions, as of [date], reported, alleged, preliminary
+
+**The scope exception in detail.** Some List A words do real work in analytical prose by naming a base rate or a coverage fraction. Three moves are available, in order of preference:
+
+1. Replace with the scope from the material. "Retail sales generally recover within two quarters" to "In seven of the nine postwar recessions, retail sales recovered within two quarters."
+2. If the material does not supply the scope, keep the word and log a reporting gap.
+3. Never simply delete, which converts a base-rate claim into a universal law.
+
+The same applies to "typically", "in most cases", "tends to", and "on average" when they are the only thing standing between the sentence and a false universal.
+
+---
+
+## Worked ledger examples
+
+**Clinical.** Before: "It was found in the trial that the intervention was associated with a reduction in 30-day readmissions of approximately 18%." S3, markers "was associated with", "approximately."
+Force rewrite: "In the trial, 30-day readmissions fell about 18% in the intervention arm." Expletive gone, nominalization gone, "was found" gone. Association preserved by keeping the arm-scoped framing rather than making the intervention the grammatical subject of a transitive verb. S3, PRESERVED.
+Rejected rewrite: "The intervention cut 30-day readmissions 18%." S5, causal, and the estimate marker is gone. Two violations in eight words.
+
+**Supply chain.** Before: "There has been a significant deterioration in on-time delivery performance across the tier-two supplier base since the port closure." S3, marker "since."
+Force rewrite: "On-time delivery from tier-two suppliers has fallen since the port closed, from 91% to 74%." S3 preserved, expletive killed, two nominalizations killed, and the number came from the material, not from the rewrite.
+Rejected rewrite: "The port closure gutted tier-two delivery performance." Causal claim, unstated magnitude, and a verb that asserts an agent.
+
+**Market history.** Before: "The 1907 panic is generally understood to have been arrested by Morgan's intervention." S2, markers "generally understood", "is ... to have been."
+Force rewrite: "Historians credit Morgan's intervention with arresting the 1907 panic." S2 preserved, actor named, passive gone, and the belief-holder is now visible instead of implied.
+Rejected rewrite: "Morgan's intervention arrested the 1907 panic." A live historiographical dispute rendered as settled fact.
+
+**ML writeup, system protagonist.** Before: "The scheduler wants to keep queue depth low, so it decided to evict the long-running jobs." Personification asserting intent.
+Rewrite: "The scheduler evicts jobs once queue depth passes 400. On 14 April it evicted the four longest-running jobs." State and rule, dated instance, no intent claimed.

--- a/skills/prose-force-and-rhythm/resources/evaluators/rubric_prose_force_and_rhythm.json
+++ b/skills/prose-force-and-rhythm/resources/evaluators/rubric_prose_force_and_rhythm.json
@@ -1,0 +1,102 @@
+{
+  "name": "Prose Force and Rhythm Rubric",
+  "description": "Evaluation criteria for a line-editing run using Hart's Wordcraft pass order with the claim-strength invariant, protected-hedge list, escalation discipline, and diagnostics-not-objectives rule. Minimum acceptable standard is an average score of 3.5.",
+  "criteria": [
+    {
+      "name": "Pass Order and Separation",
+      "description": "Whether the ten passes ran in the mandated order, each as its own step with its own output, with Mechanics last and never before Voice",
+      "weight": 1.2,
+      "scores": {
+        "1": "All passes collapsed into one 'improve this writing' edit; order not observable in the output",
+        "2": "Some passes named but edits from different classes appear in the same step; Mechanics ran early",
+        "3": "Passes run in order but two or three are merged; Mechanics is last",
+        "4": "All ten passes run separately in the correct order with per-pass output; Mechanics after Voice",
+        "5": "All ten run separately and in order, each output states which edit class it made and which it declined as out of class"
+      }
+    },
+    {
+      "name": "Claim-Strength Invariant",
+      "description": "Whether epistemic strength was recorded before rewriting and preserved after, in both directions",
+      "weight": 1.5,
+      "scores": {
+        "1": "No ledger; verbs strengthened freely ('associated with' became 'drove', 'suggests' became 'shows')",
+        "2": "Ledger exists in name but strength changes went unnoticed; at least one claim silently promoted",
+        "3": "Ledger built for most claim-bearing sentences; strength preserved but silent moves (dropped attribution, scope, date) not tracked",
+        "4": "Ledger complete with before/after S-levels; all raises reverted and reported; silent moves tracked",
+        "5": "Complete ledger, reverts reported with rationale, silent strength moves tracked including rounding, and anti-overcorrection checked so sourced facts were not needlessly hedged"
+      }
+    },
+    {
+      "name": "Hedge Protection",
+      "description": "Whether List A was cut, List B protected, and the scope exception applied instead of blunt deletion",
+      "weight": 1.3,
+      "scores": {
+        "1": "Parasite list applied uniformly; 'approximately', 'in this sample', 'as of [date]' deleted from analytical claims",
+        "2": "List B mostly survived by luck; at least one load-bearing qualifier lost",
+        "3": "List A cut, List B protected, but scope-carrying List A words deleted outright, converting base rates into universals",
+        "4": "Both lists applied correctly and the scope exception used where the material supplied the scope",
+        "5": "Both lists applied, scope exception used, and cases where the material did not supply the scope kept the word and produced a reporting gap entry"
+      }
+    },
+    {
+      "name": "Escalation Discipline",
+      "description": "Whether defects outside a pass's class were escalated upward rather than compensated for with prose polish",
+      "weight": 1.2,
+      "scores": {
+        "1": "No escalations; structural and reporting failures smoothed over with wording changes",
+        "2": "Escalation mentioned as a concept but every defect was fixed in place",
+        "3": "Some escalations filed but without the class, reason, or target layer",
+        "4": "Escalation records complete (defect, real class, why not fixable here, target layer) and passed downstream",
+        "5": "Complete escalation records plus a reporting-gap register, with a passive construction correctly left intact where the actor was unnamed rather than an actor invented"
+      }
+    },
+    {
+      "name": "Metrics as Diagnostics",
+      "description": "Whether rhythm and brevity numbers were reported alongside the prose rather than optimized into it",
+      "weight": 1.2,
+      "scores": {
+        "1": "Variance maximized with fragments and one-word sentences; targets hit, register wrecked",
+        "2": "Metrics driven directly; sentences chopped or padded to reach numbers",
+        "3": "Metrics reported and used to guide edits, but no record of what was declined",
+        "4": "Metrics reported with the reading and the action taken; fixes made at clause level, not by fragments",
+        "5": "Metrics reported with reading, action, and an explicit 'declined' line; clarity split log respected so rhythm did not undo clarity"
+      }
+    },
+    {
+      "name": "Provenance and Attribution Honesty",
+      "description": "Whether numeric thresholds were labelled as derived defaults and attributions were made correctly",
+      "weight": 1.0,
+      "scores": {
+        "1": "Thresholds presented as 'Hart says'; 'the Oregon Method' or the SCAM acronym cited as Hart's",
+        "2": "Thresholds unlabelled; attributions vague",
+        "3": "Thresholds labelled as defaults somewhere; attributions correct but unstated",
+        "4": "Thresholds labelled as derived operational defaults in the config and the report; attributions correct",
+        "5": "Thresholds shipped as tunable config with the full provenance note, and attribution caveats carried explicitly where relevant"
+      }
+    },
+    {
+      "name": "System-Protagonist Handling",
+      "description": "Whether force and humanity passes avoided personifying markets, protocols, institutions, and pipelines",
+      "weight": 1.1,
+      "scores": {
+        "1": "Systems decide, want, believe, and fear throughout; intent asserted across every verb",
+        "2": "Personification used repeatedly with no sweep run",
+        "3": "Anthropomorphism sweep run but some intention verbs survive on non-human subjects",
+        "4": "Sweep run and clean; systems given state-change verbs, named operators, or named constraints",
+        "5": "Sweep clean, re-run after the humanity pass, and any single deliberate personification is declared as a framing device rather than distributed through the piece"
+      }
+    },
+    {
+      "name": "Slop Audit Execution",
+      "description": "Whether the final audit ran in its internal order, respected the hedge carve-out, and avoided the anti-slop tic",
+      "weight": 1.0,
+      "scores": {
+        "1": "Audit skipped, or hedge removal stripped genuine evidential uncertainty",
+        "2": "Audit run out of order; specificity sweep invented specifics it lacked",
+        "3": "Audit run in order; hedge carve-out respected but no meaning re-check at step 13",
+        "4": "Full 13 steps in order, carve-out respected, step 13 re-check performed, Mechanics re-run on changed lines",
+        "5": "All of the above, plus no overcorrection into a second uniformity (no categorical em-dash ban, no sprinkled fragments, no performed casualness), and unfillable specificity gaps stated openly"
+      }
+    }
+  ]
+}

--- a/skills/prose-force-and-rhythm/resources/pass-playbook.md
+++ b/skills/prose-force-and-rhythm/resources/pass-playbook.md
@@ -1,0 +1,189 @@
+# Pass Playbook
+
+Full procedure for each of the ten passes, with escalation targets and worked examples. Examples are drawn from clinical research, semiconductor and supply-chain reporting, ML writeups, incident post-mortems, market history, and biography, so that no single domain is assumed.
+
+Hart's diagnostic principle is what makes the order load-bearing: problems at any writing stage typically stem from the immediately preceding stage. That is why a pass that cannot fix a defect inside its own class reports upward instead of compensating downward.
+
+---
+
+## Pass 1: STRUCTURE
+
+**Class of edit:** paragraph placement, section boundaries, order of argument. Nothing smaller.
+
+**Procedure:**
+1. Number every paragraph. For each, write the one claim it advances.
+2. Mark any paragraph whose claim duplicates an earlier one, or whose claim does not serve the piece's central assertion.
+3. Mark any section whose paragraphs could be shuffled without loss. That section has no internal logic.
+4. Move or cut. Do not rewrite sentences to make a misplaced paragraph fit.
+
+**Escalates to:** the structural planner or the human. A draft whose problem is that it has three findings and one strained thesis cannot be fixed here.
+
+**Worked example (post-mortem):** a draft opens with three paragraphs of system background, then the outage timeline, then the root cause. The structure pass moves the timeline first and cuts background to the two facts the timeline needs. It does not touch a single verb. If the timeline turns out to have a four-hour hole, that is an escalation, not an edit.
+
+---
+
+## Pass 2: FORCE (the verb audit)
+
+**Class of edit:** the main verb and the grammatical subject.
+
+**Procedure, per sentence:**
+1. Identify the main verb. Flag it if it is a form of "to be"; "has/have" as main verb; a light verb ("make a decision", "conduct an analysis", "give consideration to"); or a verb whose real action sits in a nominalization beside it.
+2. Flag passive constructions. **Do not auto-convert.** Ask: is the actor named in the material? If yes, convert with the real actor as subject. If no, the passive is correct, keep it, and log a reporting gap.
+3. Flag expletive openers: "There is/are/was/were", "It is/was ... that". Promote the real subject.
+4. Flag suffix clusters: two or more words per sentence ending in -tion, -ment, -ance, -ity, -ness. Convert one to a verb.
+5. Flag abstract-noun subjects. If the grammatical subject cannot physically act ("the increase", "the situation", "the framework", "the deterioration"), find the entity that can.
+6. **Claim-strength lock.** Record the S-level before the rewrite. Verify it after. Revert on any raise.
+
+**Escalates to:** reporting, whenever step 2 or step 5 cannot find a named actor.
+
+**Worked examples:**
+
+| Defect | Bad fix | Good fix | Why |
+|---|---|---|---|
+| "There was a sharp increase in wafer scrap at the Hsinchu fab in March." | "Wafer scrap at Hsinchu exploded in March." | "Wafer scrap at Hsinchu rose 40% in March." | Expletive killed either way; the bad fix invents a magnitude the material does not state. |
+| "The alert was silenced at 02:14." (actor not in the incident log) | "An on-call engineer silenced the alert at 02:14." | Leave as written. Gap entry: "who silenced the 02:14 alert? Not in the log or the pager history." | Passive-voice elimination that invents an actor is the second failure mode of this pass. |
+| "The implementation of the new screening protocol resulted in a reduction in referral times." | "The new protocol slashed referral times." | "After the clinic adopted the screening protocol, median referral time fell from 19 days to 11." | Bad fix strengthens S3 to S5 and adds unstated magnitude. Good fix names the actor, kills two nominalizations, and holds the temporal claim. |
+| "The order book was characterized by significant fragmentation across venues." | "The order book fractured across venues." | "Between 2007 and 2012, trading in the name spread across nine venues from two." | Abstract subject replaced with a dated, countable fact. |
+| "It is believed by the team that the regression stems from the tokenizer change." | "The regression stems from the tokenizer change." | "The team believes the tokenizer change caused the regression; the ablation is not yet run." | Bad fix deletes the belief-holder and promotes S2 to S5. |
+
+**System variant.** When the actor is a market, protocol, institution, or pipeline, use a state-change verb, never an intention verb.
+
+- Bad: "The market decided the risk was overpriced." / "The scheduler wants to keep queues short." / "The protocol believes the block is final."
+- Good: "Spreads narrowed by 30 basis points over the week." / "The scheduler evicts jobs once queue depth passes 400." / "The protocol treats a block as final after six confirmations."
+
+Once a market decides or a model believes, the prose asserts intent, and therefore causation the analysis has not established. Sweep for: decided, wanted, chose, believed, feared, intended, tried to, aimed to, sought.
+
+---
+
+## Pass 3: BREVITY
+
+**Class of edit:** deletion and compression. No reordering, no verb changes.
+
+**Procedure:**
+1. Cut List A globally (see SKILL.md and claim-strength-ledger.md).
+2. For every List B instance, verify it is doing epistemic work, then leave it.
+3. Apply the scope exception: a List A word carrying scope gets replaced with the scope from the material, or kept plus a gap entry.
+4. For each sentence over 30 words, attempt a version at 20 or fewer that loses no proposition. Accept only if nothing is lost. List the propositions before and after when the sentence carries a claim.
+5. Redundancy sweep. Any claim stated twice keeps the instance closer to its evidence.
+6. Measure and report the cut. Under 5% means the pass did not run. Over 30% means something substantive probably went with it; diff the propositions.
+
+**Escalates to:** reporting, when a claim appears three times and the evidence appears once.
+
+**Worked examples:**
+
+- Bad: "The model generally outperformed the baseline, with approximately a 3-point gain in F1." to "The model outperformed the baseline with a 3-point gain in F1." Two violations: "generally" was scope (it did not win every run) and "approximately" was List B.
+- Good: "The model beat the baseline in 8 of 10 seeds, by about 3 F1 points."
+- Bad: "Deaths in the treatment arm fell by roughly a third in this cohort." to "Deaths fell a third." Scope and estimate both deleted; the sentence now claims a general result.
+- Good: "In this cohort, deaths in the treatment arm fell by roughly a third."
+
+---
+
+## Pass 4: CLARITY
+
+**Class of edit:** splitting sentences, supplying missing concrete referents.
+
+**Procedure:**
+1. One-reading test on every sentence. Flag anything that needed a second pass.
+2. Classify each flag: (a) long sentence, simple content, safe to split; (b) short sentence, dense abstract nouns, a middle-rung abstraction trap; (c) necessary technical term.
+3. Fix (a) by splitting. Fix (b) by supplying one particular instance from the material. Fix (c) by defining once, concretely, at first use.
+4. **Forbidden fixes:** replacing a precise term with a vaguer one; deleting a qualifier to shorten a sentence; splitting in a way that severs a causal link.
+5. **Maintain the clarity split log.** Record every split as a pair of sentence ids. Pass 5 may not merge any logged pair.
+6. If a (b) flag has no particular available in the material, that is a reporting gap, not a wording problem. Escalate.
+
+**Worked example (type b):** "Instructional unit throughput remained below the district's projected utilization envelope." No amount of rewording fixes this, because there is no particular in it. The fix requires material: "Sixteen of the district's 22 middle schools ran classes below 20 students; the budget had assumed 28."
+
+A run dominated by type (a) fixes is healthy. A run dominated by type (b) fixes that were made without new material is a warning sign, and the report must say so.
+
+---
+
+## Pass 5: RHYTHM
+
+**Class of edit:** sentence length distribution, terminal position, paragraph openers. See [rhythm-diagnostics.md](rhythm-diagnostics.md) for the full treatment.
+
+**Procedure:**
+1. Compute the sentence-length series per paragraph and for the piece. Report mean and SD.
+2. Fix low variance by splitting one long sentence **and** merging two short ones inside the same paragraph. Never by shortening everything, which produces a staccato tic.
+3. Merges are forbidden on any pair in the clarity split log. Rhythm must not undo clarity.
+4. Terminal emphasis: for each paragraph's last sentence, check that the last word is the most consequential one. Move prepositional tails, attributions, and dates off the end unless the date is the point.
+5. Paragraph openers: if more than a third open with the same construction, diversify one.
+6. Flag any sentence with four or more stacked prepositional phrases.
+
+**Worked example:** "Deaths in the treatment arm fell by a third, according to the 2019 trial report." to "According to the 2019 trial report, deaths in the treatment arm fell by a third." Same words, attribution moved off the terminal slot, and the claim lands last.
+
+**Anti-pattern:** "The fab went dark. Fast. Nobody knew." Variance achieved through typographic drama. In an engineering, clinical, or financial register this reads as unserious and costs more credibility than the monotony it replaced. Variance must come from clause structure and information density.
+
+---
+
+## Pass 6: HUMANITY
+
+**Class of edit:** sentence subjects and the presence of named agents.
+
+**Procedure:**
+1. List every sentence whose subject is an agentless abstraction. Replace with the entity that acted, where the material names one.
+2. Where the protagonist is a system, the replacement is a named operator, a dated state, or a named constraint. It is never a personified system.
+3. Use named people where the material names them. "A senior planner at the Tualatin plant" beats "stakeholders."
+4. Re-run the anthropomorphism sweep from Pass 2 on anything you rewrote here, because this pass creates the pressure that causes it.
+
+---
+
+## Pass 7: COLOR
+
+**Class of edit:** concrete and sensory detail.
+
+**Procedure:**
+1. Every detail must carry information, not decorate.
+2. Every detail must be traceable to the material. A detail you cannot source is deleted, not softened.
+3. Sensory instruction is gated on whether sensory observation exists in the source. A writeup built from filings, logs, and papers has no observed senses to report. Do not supply them.
+4. Test: could this passage have been written without the source material? If yes, it was generated rather than reported. Cut it.
+
+**Worked example:** "The trading floor fell quiet as the print crossed the tape" is fabrication unless someone on that floor said so, on the record, about that moment. The honest version is either the sourced quote or the state change: "Volume in the front contract dropped by two thirds in the four minutes after the print."
+
+---
+
+## Pass 8: VOICE
+
+Consistency against the register declared at run setup. Flag drift between sections. Do not add personality; do not level a deliberate register shift that the piece uses on purpose. Constant temperature across a long piece is itself a machine signature, so a single deliberate shift is a feature to preserve, not a defect to smooth.
+
+---
+
+## Pass 9: MECHANICS
+
+Grammar, usage, house style, numerals, citation format. Last of the nine. Never before Voice. If you catch yourself here early, you are polishing a paragraph that may not survive Pass 1.
+
+---
+
+## Pass 10: SLOP AUDIT
+
+Run in this internal order. Steps interact, and order matters.
+
+1. **Lexical sweep.** Remove: delve, underscore, showcase, pivotal, intricate, meticulous, realm, tapestry, landscape (as metaphor), mosaic, ecosystem (as metaphor), beacon, cornerstone, bedrock, testament to, robust, seamless, vibrant, holistic, multifaceted, nuanced, transformative, groundbreaking, leverage, harness, streamline, facilitate, foster, navigate, illuminate, unlock, embrace. Domain exception: keep "robust" in a statistics paper where it is a technical term, keep "ecosystem" in ecology.
+2. **Signpost filler.** Delete: "It's important to note", "It's worth noting", "That said", "At its core", "Let's break this down", "In conclusion", "Ultimately", "In today's fast-paced world".
+3. **Negated contrast.** Find every "not just X, it's Y" / "isn't X, it's Y". Allow one per piece maximum. Rewrite the rest as direct affirmations.
+4. **Tricolon.** Find three parallel phrases of near-equal length. Break at least one; introduce asymmetry in length or structure.
+5. **Participial tail.** Find clauses ending "...marking a", "...underscoring the", "...highlighting the", "...reflecting a". They restate the main clause. Delete them.
+6. **Hedge stack.** Find sentences with two or more hedges. Reduce to one, or convert the uncertainty to a quantity. **Carve-out: this step may remove only rhetorical hedges. It may never remove a hedge reflecting genuine evidential uncertainty.** "It seems like it might possibly be the case that latency rose" has three rhetorical hedges and one claim; reduce it. "The estimate may understate exposure under these assumptions" has two epistemic hedges, both load-bearing; leave both.
+7. **List shape.** Bulleted lists whose items are full parallel-stem sentences: if the idea is not list-shaped, convert to paragraphs.
+8. **Specificity sweep.** Replace every general noun with a named one: a date, an organization, a figure, a person, a version number. If you cannot, you lack the reporting. Say so explicitly rather than gesturing. This step must not invent the specific it wants.
+9. **Burstiness.** Run the sentence-length variance check as a diagnostic. Fix by clause structure, never by inserting fragments.
+10. **Affect.** Does the register shift anywhere across the piece? Constant temperature is a tell.
+11. **Closure ritual.** Does any paragraph end on a pull-quote-shaped generalization? Cut it.
+12. **Formatting.** Gratuitous bold on list stems, emoji in headings, heading density disproportionate to length, unnecessary title case.
+13. **Re-check.** Did steps 1-8 change any load-bearing claim's meaning or confidence level? Revert that edit. Then re-run Pass 9 on every line the audit touched.
+
+**The anti-slop tic.** Do not overcorrect into a second uniformity: categorically banning em dashes, sprinkling fragments, mandating register shifts, or performing casualness to prove humanity. That produces a recognizable second-order artificiality. The cure for machine register is specificity and structural asymmetry.
+
+---
+
+## Escalation record format
+
+```
+ESCALATION
+  defect:      the 02:14 alert has no named actor
+  found in:    Pass 2 (Force), sentence 41
+  real class:  reporting
+  why not me:  converting to active requires an actor the material does not name
+  target:      source corpus / the incident owner
+  status:      open
+```
+
+Escalations and reporting gaps are successful outputs. A run over thin material that produces none did not run the passes; it smoothed the prose over the holes.

--- a/skills/prose-force-and-rhythm/resources/rhythm-diagnostics.md
+++ b/skills/prose-force-and-rhythm/resources/rhythm-diagnostics.md
@@ -1,0 +1,159 @@
+# Rhythm Diagnostics
+
+Sentence-length variance, end-stress, pace, and number handling. Everything in this file is a **diagnostic**: something you measure and report next to the prose. None of it is an objective to optimize. An agent that maximizes sentence-length variance inserts one-word sentences; an agent that applies 2-3-1 to every sentence produces prose made entirely of landings.
+
+---
+
+## Provenance of the numbers
+
+**Every numeric threshold in this file is an operational default derived for mechanization. Hart publishes no such figures.** Both *Wordcraft* and *Storycraft* are lending-restricted, so the thresholds could not be verified against the primary text. Treat them as tunable config, state that provenance wherever the numbers are reported, and never write "Hart says the standard deviation should be at least 7."
+
+The two things that are genuinely attributable: Hart's rhythm attribute is about cadence and sound pattern, and Gary Provost's five-word demonstration is the canonical illustration of why uniform sentence length deadens prose. The measurement scheme built on top of them is ours.
+
+---
+
+## Config block
+
+Copy into the run header and adjust for register.
+
+```yaml
+# derived operational defaults, not published Hart figures
+register: analytical            # analytical | explanatory | narrative
+risk_class: HIGH                # HIGH blocks on claim-strength violations
+sentence_length_mean: [15, 20]  # words; raise for academic, lower for general
+sentence_length_sd_min: 7       # or 0.6 * mean, whichever is lower
+short_sentence_per_words: 150   # at least one sentence under 8 words per N words
+long_sentence_ceiling: 45       # words, without a structural reason
+consecutive_similar_max: 2      # sentences within +/-2 words of each other
+brevity_cut_target: [0.10, 0.20]
+brevity_cut_alarm_low: 0.05     # below this, the pass did not run
+brevity_cut_alarm_high: 0.30    # above this, diff the propositions
+numbers_per_sentence_max: 1     # narrative passages
+numbers_per_paragraph_max: 3
+readability_target: null        # set explicitly per audience; no silent default
+```
+
+---
+
+## Burstiness
+
+**What it is.** Human prose alternates between short and long. Machine prose flatlines near a 14 to 22 word median with low variance, and that flatness is one of the most reliable machine signatures after vocabulary.
+
+**Measure:** word count per sentence across the passage. Report mean and standard deviation, per paragraph and for the piece.
+
+**Read the diagnostic, then act at the clause level:**
+- Low SD with a high mean: the draft is all subordination. Split the longest sentence in each affected paragraph at its main clause boundary.
+- Low SD with a low mean: the draft is all simple declaratives. Merge two adjacent short sentences that share a subject, unless the pair is in the clarity split log.
+- Uniform paragraph lengths (every paragraph three sentences, 30 to 50 words) are a tell in their own right. Vary paragraph size as well.
+- Three consecutive sentences beginning with the same construction (participle, prepositional phrase, "The X of Y", a name) is a defect regardless of length variance. Rewrite one.
+
+**Failure mode: fragment cosplay.** Chasing variance produces "Everything changed." "Fast." "Nobody knew." In analytical, technical, clinical, and financial registers this reads as LinkedIn copy and costs more credibility than the monotony it replaced. Variance must come from clause structure and information density, not typographic drama.
+
+**Second failure mode:** hitting the variance target while leaving every sentence the same *shape* (subject, verb, object, trailing prepositional phrase). The ear detects shape even when the metric is satisfied. Check shapes, not just lengths.
+
+---
+
+## End-stress: the 2-3-1 order
+
+Roy Peter Clark's emphasis architecture. The most emphatic element goes at the end, the second most emphatic at the beginning, the least emphatic in the middle.
+
+**Procedure, for claim-bearing sentences only:**
+1. List the sentence's components. Rank them 1 (most emphatic), 2, 3.
+2. Rebuild in the order 2, 3, 1.
+3. Never end on a hedge, an attribution, or a date, unless the date is the point.
+4. Apply at paragraph and section scale too. The last line of a section is the loudest position in the piece after the opening.
+
+**Example (incident report).** Before: "Latency rose to 4.2 seconds at the p99 during the migration window, based on the Grafana export." After: "Based on the Grafana export, p99 latency during the migration window rose to 4.2 seconds." The attribution moves off the terminal slot; the number lands last.
+
+**Example (biography).** Before: "She resigned on 12 June, according to the letter in the college archive." After: "The letter in the college archive is dated 12 June. She resigned that day."
+
+**Failure mode: emphasis everywhere.** Applied to every sentence, 2-3-1 turns the prose into a sequence of punchlines and the reader stops registering any of them. Landings exist only against flat ground. Reserve the move for claim-bearing sentences and let connective sentences be deliberately unemphatic. Secondary failure: contorting syntax to force a word into the terminal slot, which produces the periodic sentence as mannerism.
+
+---
+
+## Right-branching default
+
+Begin sentences with subject and verb. Make meaning early. Let qualification branch to the right.
+
+- Left-branching (harder): "Because the 2019 revision changed how the deductible was indexed, and because indexation lagged inflation by two quarters, out-of-pocket costs rose."
+- Right-branching (default): "Out-of-pocket costs rose, because the 2019 revision indexed the deductible to a lag that trailed inflation by two quarters."
+
+Exception: use left-branching deliberately when the condition genuinely governs whether the claim holds at all, and the reader must not encounter the claim unconditioned. In HIGH risk class this exception is common and legitimate.
+
+---
+
+## Terminal emphasis check, per paragraph
+
+For each paragraph's final sentence, ask whether the final word is the most consequential one available. Move prepositional tails, attributions, dates, and citation parentheticals off the end. Then ask the harder question: does this paragraph end on a fact or an image, or on a pull-quote-shaped generalization? The second is a closure ritual and gets cut.
+
+---
+
+## Pace modulation at the point of complexity
+
+Clark's counterintuitive rule, and the one an LLM most reliably inverts.
+
+1. Mark the two or three hardest passages: where a new mechanism, a counterintuitive result, or a chain of inference is introduced.
+2. At each, cut average sentence length by roughly half. Break paragraphs more often. Replace every technical term you can with a plain one, and define the ones you cannot, once, at first use.
+3. One new idea per sentence in these passages. If a sentence carries two, split it.
+4. Immediately after the hard passage, place a concrete instance of the thing just explained, so the reader can check their own comprehension.
+5. Over familiar ground, lengthen and compress. Speed is the reward for a reader who already knows.
+6. Do not place a reward, a striking fact, or a set-piece image inside the hardest passage. Competition for attention destroys both.
+
+**Failure mode: the elaboration reflex.** Sensing reader difficulty, the agent adds more, longer, and more qualified sentences, which compounds the load. Recognizable by paragraphs that grow longest exactly where the argument is hardest. Secondary failure: over-simplifying into falsity. Pace modulation licenses shorter sentences, never weaker claims.
+
+---
+
+## Making numbers land
+
+Run per data-carrying paragraph.
+
+1. **Budget:** one number per sentence, at most three per paragraph, in prose passages. Everything else goes to a table, a chart, or a footnote.
+2. **Round hard in prose:** 105% becomes "doubled"; 33% becomes "one in three"; $1.043bn becomes "about a billion." Keep exact figures only where the precision is the claim.
+3. **Check each rounding against the claim.** "About a billion" is an error when the difference between $1.04bn and $1.4bn is the whole argument. Rounding away a material distinction trades a stall for a falsehood.
+4. **Comparison on the same screen:** an earlier year, another place, a competitor, or a physical referent the reader already owns.
+5. **Human scale where possible:** per person, per day, per household, as a multiple of something familiar.
+6. **Direction before magnitude:** say it doubled, then say from what.
+7. **Never open a paragraph on a number the reader has no frame for.** Build the frame, then land the number.
+8. **Strip bureaucratic number-words:** revenue to income, expenditures to spending, utilization to use, headcount to staff, where the plain word is accurate.
+
+**Failure mode: the stat wall.** In data-rich domains the agent packs five figures and three percentages into one paragraph to demonstrate rigor. The eye slides off, and the argument is lost exactly where the evidence was strongest.
+
+**Interaction with the claim-strength invariant:** rounding is a strength edit. "Roughly 40%" surviving as "40%" is a violation. Log every rounding in the ledger.
+
+---
+
+## Transitions: chain or cut, do not signpost
+
+Two legitimate mechanisms.
+
+1. **Hard cut.** End a unit on its strongest element; begin the next in a new place or time with a concrete anchor. No bridge sentence.
+2. **Chaining.** Repeat a key word, image, or number from the end of the previous unit near the start of the next, in a *changed* sense. The repetition is the bridge; the change of sense is the argument. Repeating without changing sense produces echo, not movement.
+
+**Banned mush layer:** "Meanwhile", "It is also worth considering", "Turning now to", "With that in mind", "Building on this", "First... Second... Finally..." as a roadmap.
+
+**Allowed and useful:** time and place markers that carry information. "Three months later." "By the following spring." "Back at the Tualatin plant."
+
+**Deletion test:** strip every transition sentence, re-read, restore only those whose absence caused real disorientation. Typically fewer than a third survive. Do not summarize the previous section after a break.
+
+**Failure mode: the roadmap.** Telegraphing the outline ("First we examine supply, then demand, then pricing") makes the structure fully visible, and once readers can see the skeleton they navigate instead of reading.
+
+---
+
+## Reporting the diagnostics
+
+The run report carries the numbers, the config, and the provenance note. Format:
+
+```
+RHYTHM DIAGNOSTICS (derived defaults, not published Hart figures)
+  sentences: 214
+  mean length: 21.4 words   (config target 15-20)
+  sd: 6.1                   (config min 7)
+  sentences < 8 words: 3    (config: >= 1 per 150 words, i.e. >= 12 expected)
+  sentences > 45 words: 4   (2 have a stated structural reason)
+  paragraph-opener repetition: 41% open with a subordinate clause
+  READ AS: the draft subordinates heavily and lands rarely.
+  ACTION TAKEN: split 9 long sentences at main-clause boundaries; merged 2 pairs
+                (neither in the clarity split log). No fragments added.
+```
+
+Report the reading, the action, and what you declined to do. A diagnostics block with no "declined" line usually means the metric drove the prose.

--- a/skills/readability-check/SKILL.md
+++ b/skills/readability-check/SKILL.md
@@ -16,7 +16,7 @@ description: Scores prose with Flesch Reading Ease, Flesch-Kincaid Grade, SMOG, 
 - [Guardrails](#guardrails)
 - [Reference files](#reference-files)
 
-**Related skills:** `slop-detector` catches AI-explainer patterns, `hedge-detector` catches weak hedging, `voice-check` and `strategist-voice` catch voice violations. This skill catches *structural* unreadability — sentence length and word difficulty — which the others do not measure. Run this last, after voice and slop passes.
+**Related skills:** `slop-detector` catches AI-explainer patterns, `hedge-detector` catches weak hedging, `voice-check` and `strategist-voice` catch voice violations. This skill catches *structural* unreadability — sentence length and word difficulty — which the others do not measure. Run this last, after voice and slop passes. When a score fails and splitting sentences does not fix it, use `ladder-of-abstraction`: it diagnoses what a failing score means and routes the fix to supplying a concrete particular rather than to swapping in vaguer words.
 
 ## Quick start
 

--- a/skills/scene-construction-scam/SKILL.md
+++ b/skills/scene-construction-scam/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: scene-construction-scam
+description: Builds scenes that are reported rather than generated, by running a four-slot SCAM qualification gate (Setting, Character, Action, Meaning) with a source required per slot, a scene floor and ceiling, the 1-of-20 telling-detail cut with a provenance veto, the RUE pass, and a scene/summary narrative-distance audit against per-form ratio targets. Every technique has a person variant and a system variant (market, protocol, institution, codebase, supply chain). Use when turning research notes into a scene, opening a section with a moment, deciding whether a passage is a scene or summary, or auditing whether a vivid paragraph is actually sourced, or when user mentions scene, SCAM, show don't tell, telling detail, scene vs summary, summary in costume, establishing shot, make this vivid, or in medias res.
+---
+
+# Scene Construction (SCAM)
+
+## Table of Contents
+- [Core Principles](#core-principles)
+- [Workflow](#workflow)
+- [The SCAM Gate](#the-scam-gate)
+- [Scene Floor and Ceiling](#scene-floor-and-ceiling)
+- [Scene or Summary: Distance Targets](#scene-or-summary-distance-targets)
+- [The Scene Provenance Ledger](#the-scene-provenance-ledger)
+- [Guardrails](#guardrails)
+- [Quick Reference](#quick-reference)
+
+**Related skills:** Use `narrative-fidelity-audit` for the interiority ladder and the bright lines, `narrative-arc-mapping` for where scenes sit in the whole piece, `narrative-opposition-web` for who the scene's actors oppose, `writing-structure-planner` for sequencing, `slop-detector` for the register pass that runs last. The fidelity audit owns the ladder and runs on a finished draft; this skill runs on a candidate scene before drafting.
+
+## Core Principles
+
+1. **Gate 4 decides everything**: Could this passage have been written without the source material? If yes, it is generated, not reported. Kill it. No other test in this skill outranks that one.
+2. **An empty slot is a result, not a problem**: any unfilled SCAM slot means the passage is not a scene. Demote it to summary. Never fill a slot by inference, and never fill it because the piece needs a scene there.
+3. **Sourced, never verified**: this skill tracks provenance. It cannot check whether a source is true. Write "sourced to X"; never write "verified" or "fact-checked".
+4. **CHARACTER has a system variant**: the protagonist may be a market, a protocol, an institution, or a codebase. Then CHARACTER is the system's observable state at that moment, plus one distinguishing behavior. State means a clearing price, a queue depth, a p99 latency, an inventory, a wafer yield. It is never a want, a belief, or a decision.
+5. **Stop at the ceiling**: two to four concrete elements. A fifth sourced detail that changes no inference is padding, and padding in a scene reads as texture manufactured to look reported.
+6. **RUE, then swap**: delete every sentence explaining what the scene means. If the meaning disappears with it, the scene was the wrong scene. Swap the scene; do not restore the annotation.
+7. **Thin record means honest summary or a gap note**: never a plausible specific. Reporting back "this material supports summary, not scene" is a successful outcome of this skill, not a failure.
+
+## Workflow
+
+Copy this checklist and track your progress:
+
+```
+Scene Construction Progress:
+- [ ] Step 1: Build the scene provenance ledger (blocks everything after it)
+- [ ] Step 2: Run the SCAM gate per candidate scene
+- [ ] Step 3: Build to the floor, stop at the ceiling
+- [ ] Step 4: Cut twenty details to one
+- [ ] Step 5: RUE pass, then the scene/summary distance audit
+- [ ] Step 6: Block or ship
+```
+
+Run these steps in order and do not batch them. Step 4's provenance veto collides with Step 3's concreteness push, and Step 5 can invalidate Step 3. When a later step changes load-bearing text, re-run the earlier step on that text only.
+
+**Step 1: Build the scene provenance ledger**
+
+Step 1.1: List candidate scenes. For each, open a ledger row and fill every required field in [The Scene Provenance Ledger](#the-scene-provenance-ledger). Any missing field BLOCKS the build of that scene. Do not draft prose for a blocked row.
+
+Step 1.2: Fill the drift-and-proportion field: is this moment typical of the period it stands for, or atypical and vivid? Atypical scenes may still be used, but the text must say so on the page ("the sharpest of the eleven outages that quarter"), not in a footnote.
+
+Step 1.3: Every pointer must resolve to an external artifact: page, section, timestamp, line number, table cell, commit hash, URL with retrieval date. Your own earlier notes, summaries, or drafts are never a source.
+
+See [resources/scene-ledger.md](resources/scene-ledger.md) for the full field list, worked ledger rows, and the composite/aggregate rules.
+
+**Step 2: Run the SCAM gate per candidate scene**
+
+Step 2.1: Fill the four slots and their source column using [The SCAM Gate](#the-scam-gate). Use the system row for CHARACTER when the protagonist is not a person.
+
+Step 2.2: Apply Gates 1 through 4 in order. Gate 4 is the last and the strictest: strip the citations mentally and ask whether a competent writer with no access to your sources could have produced this paragraph. If yes, delete it.
+
+Step 2.3: Record the disposition of every failed candidate: demoted to summary, sent back as a research request, declared as an absence in the text, or cut. There is no fifth disposition. "Draft it and flag it" is not a disposition.
+
+See [resources/scam-gate.md](resources/scam-gate.md) for the gate applied to five domains, including two candidates that correctly fail.
+
+**Step 3: Build to the floor, stop at the ceiling**
+
+Step 3.1: Meet the floor: one located place, one time marker, one observable action. Below the floor the reader is standing nowhere and the passage is summary.
+
+Step 3.2: Stop at the ceiling: two to four concrete elements. Test each addition by asking whether it changes what the reader can infer. If not, it does not go in.
+
+Step 3.3: Enter in medias res. After a section break, do not recap. No weather, light, or mood unless a source recorded weather, light, or mood.
+
+Step 3.4: Dialogue in quotation marks must be verbatim from a transcript, recording, or contemporaneous written record, and must occur between people inside the scene. Testimony given to a researcher is quotation, not scene; label it as such.
+
+**Step 4: Cut twenty details to one**
+
+Step 4.1: List 15 to 20 candidate details before writing anything. Score each against the seven tests in [resources/detail-selection.md](resources/detail-selection.md).
+
+Step 4.2: PROVENANCE is an absolute veto. A detail that is not in the record, sourced, and datable is cut regardless of how well it scores on every other test. There is no override.
+
+Step 4.3: Keep one, occasionally two. Do not demote survivors into a list. Attach no adjective explaining what the detail means.
+
+Step 4.4: Record which detail was kept and which were cut, so the selection can be audited as a set. Cuts that all point the same way are a proportion defect, not nineteen independent decisions.
+
+**Step 5: RUE pass, then the scene/summary distance audit**
+
+Step 5.1: Delete every sentence that explains the scene's meaning. Re-read. If the meaning is no longer available, swap the scene for one that carries it; do not restore the sentence.
+
+Step 5.2: Label every paragraph S (summary) or C (scenic). Ambiguous gets X. X is a defect, not a third mode.
+
+Step 5.3: Resolve every X. A general practice described with sensory adjectives is summary in costume: either demote it to clean summary or promote it with a date, a place, and named actors. Compare against the ratio targets in [Scene or Summary: Distance Targets](#scene-or-summary-distance-targets).
+
+See [resources/distance-and-rue.md](resources/distance-and-rue.md) for the audit procedure, costume-summary examples, and the alternation rule.
+
+**Step 6: Block or ship**
+
+Step 6.1: Run the blocking checklist in [resources/scene-ledger.md](resources/scene-ledger.md#blocking-checklist). Any red line fires means do not ship the scene.
+
+Step 6.2: Generate the note on sources from the ledger. Never write a boilerplate disclaimer in advance; a disclosure written before the deviation pre-authorizes it.
+
+Validate using [resources/evaluators/rubric_scene_construction_scam.json](resources/evaluators/rubric_scene_construction_scam.json). **Minimum standard**: average score >= 3.5.
+
+## The SCAM Gate
+
+Fill this table per candidate scene. Every filled cell needs a source pointer.
+
+| Slot | Person protagonist | System protagonist | Empty means |
+|------|--------------------|--------------------|-------------|
+| **S — Setting** | Place, time, and at least two physical specifics that a source records | Place, time, and at least two recorded conditions of the venue: the exchange session, the deploy window, the dock, the fab bay | No located moment. Not a scene. |
+| **C — Character** | At least one physical detail and one behavioral detail, sourced | Observable state at that moment (price, queue depth, latency, inventory, yield, error rate) plus one distinguishing behavior of the system | No subject. Not a scene. |
+| **A — Action** | At least three ordered observable events, each sourced | Three ordered observable events: an order posted, a fill printed, a limit hit; a commit, a rollout, a rollback | A state of affairs is not an action sequence. Not a scene. |
+| **M — Meaning** | One sentence naming what the scene demonstrates | Same, and it must map to the piece's governing claim | No reason to include it. Cut. |
+
+**Gate 1**: any empty slot means this is not a scene. Demote to summary. Do not fill by inference.
+**Gate 2**: the MEANING sentence may introduce no information absent from S, C, and A. If it does, you are interpreting; move that sentence into the following summary block, where interpretation is licensed.
+**Gate 3**: overinterpretation check. Sometimes a cigar is just a cigar. Would a skeptical reader accept this meaning from these details alone?
+**Gate 4**: could this passage have been written WITHOUT the source material? If yes, it is generated, not reported. Kill it.
+
+Attribution note: SCAM is journalism-pedagogy shorthand from Dynamics of Writing. It is **not** Jack Hart's acronym, and must not be attributed to him or to Storycraft.
+
+## Scene Floor and Ceiling
+
+**Floor** (all three required): one located place, one time marker, one observable action.
+
+**Ceiling**: stop at 2 to 4 concrete elements. Not a room inventory.
+
+A "scene" that covers a period of months is summary wearing a scene's grammar, and it quietly relicenses invented specificity. One dated decision, one filing, one price print, one shipped release, one failed test, one shift, one meeting.
+
+## Scene or Summary: Distance Targets
+
+| Form | Scenic share | Run-length rule |
+|------|--------------|-----------------|
+| Story narrative (one protagonist, one arc) | 40-60% | No summary run over 3 paragraphs |
+| Explanatory narrative (action line explores a subject) | 15-30% | A scenic beat at least every 6-8 paragraphs |
+| Analytical report or memo | 5-15% | Scenes only at openings, section heads, and the close |
+
+These ratios are **operational defaults derived for mechanization**, not published figures from any craft text. Tune them per project and say so.
+
+**Summary in costume** is the defect these targets exist to catch. It is the paragraph that sounds scenic and cites nothing:
+
+- Bad: "Across the Gulf ports that spring, dispatchers watched the backlog swell, phones ringing off the hook as one delayed vessel became six."
+- Good, as summary: "Dwell time at the four Gulf container terminals rose from 3.1 to 8.7 days between March and May 2021 (PMSA monthly, table 2)."
+- Good, as scene: "At Barbours Cut on 14 May, the *Ever Lissome* was logged in at 06:12 and did not begin discharge until 19:40 (terminal berth log, entry 2214)."
+
+## The Scene Provenance Ledger
+
+Required per scene. **Any missing field blocks the build.**
+
+| Field | Content |
+|-------|---------|
+| Scene ID | Stable handle used by the draft |
+| Date and place | Exact as the source carries it. Never imply finer precision than the source |
+| Actors | Named real people or named systems. No composites, no unnamed thesis-voicing extras |
+| Action sequence | The three-plus ordered events, each with its own pointer |
+| Source pointers | External artifacts only. Not your own summaries or drafts |
+| Interior-state class | Per interiority claim, tag [A] said-so, [B] document, [C] inference, [D] unsourced. Ladder defined in `narrative-fidelity-audit`, which owns it; any [D] refuses |
+| Drift and proportion | Typical of the period, or atypical? If atypical, the flag text that will appear on the page |
+| Subtraction log | What was cut from this moment, and whether the remainder implies a different frequency or magnitude than the record |
+| Disposition | Built, demoted to summary, research request, declared absence, or cut |
+
+Composites are prohibited regardless of framing: never merge two people, firms, incidents, shifts, or datasets into one entity presented as singular, not for privacy, not for concision, not for narrative economy. Aggregates ("the median advertiser", "a representative 200mm fab") are permitted only if labeled at first use, and they may never take a proper name, a date, a location, dialogue, intent, or sensory detail. The moment an aggregate gets a Tuesday and a phone call, it is a fabricated character. Never label an aggregate a "composite". That word is reserved for the prohibited operation, and reusing it re-licenses what this line forbids.
+
+## Guardrails
+
+**Requirements:**
+
+1. **Ledger before prose**: no scene is drafted before its ledger row is complete. A slot that cannot be filled produces a gap entry, never prose.
+2. **Provenance veto is absolute**: a detail with no pointer is cut at any score. The scan keys on missing pointers, never on vividness. A vivid detail that has a pointer survives no matter how good it sounds.
+3. **No invented sensory material**: literary-journalism sensory technique does not transfer to unreported domains. A writer working from filings, logs, or archives was in no room. If no source observed the setting, there is no setting, and the honest output is summary.
+4. **Systems get states, not wants**: no "the market realized", "the protocol decided", "the model believed". Personify at most once, explicitly, as a framing device. After that, attribute behavior to named mechanisms and named actors. An imputed institutional intent requires a filing, minute, transcript, or quoted executive.
+5. **Refusal is an output**: "this material supports exposition, not narrative" is a valid, complete result. Return it rather than manufacturing the missing elements.
+6. **Name the rationalization**: "this is clearly what happened", "the reader will understand", "it is emotionally true", "it is a reasonable inference" is the higher-truth argument. It is the named failure of this entire genre, and it will arrive sounding like good judgment. Refuse it in all its forms.
+
+**Common pitfalls:**
+- Establishing-shot bloat: weather, architecture, and mood written because that is what literary journalism looks like, in a domain where none of it was observed.
+- Detail confetti: six details each passed the tests, so all six were kept, producing an inventory paragraph that reads as texture and carries no inference.
+- The plausible bridge: a connective sentence asserting a state change ("by then the pressure was impossible to ignore") that carries no proper noun, trips no fact-check, and is pure invention. Transitions need pointers too.
+- Subtraction drift: every sentence sourced, the piece false, because the failed pilot and the dissenting engineer were each cut for length. Review the subtraction log as a set.
+- The scene promoted because it was vivid rather than because it was representative.
+- Claiming a fact was "verified" when it was only sourced.
+- Attribution errors that destroy credibility on first inspection. Do not credit SCAM to Hart. Do not cite "the Oregon Method" as a codified canon; it is a retrospective label for the Oregonian coaching practice, not a defined system. Do not present the ratio and count thresholds here as published figures.
+
+## Quick Reference
+
+**Key resources:**
+- **[resources/scam-gate.md](resources/scam-gate.md)**: the four slots worked through five domains, including two candidates that fail, plus the demotion procedure
+- **[resources/detail-selection.md](resources/detail-selection.md)**: the 1-of-20 cut, the seven tests, worked cuts, the representativeness flag
+- **[resources/distance-and-rue.md](resources/distance-and-rue.md)**: the S/C/X audit, costume summary, RUE, the alternation rule, gap-note formats
+- **[resources/scene-ledger.md](resources/scene-ledger.md)**: ledger schema, composite and aggregate rules, blocking checklist, note-on-sources generation
+- **[resources/evaluators/rubric_scene_construction_scam.json](resources/evaluators/rubric_scene_construction_scam.json)**: quality scoring
+
+**Inputs required:**
+- A researched corpus with resolvable pointers (documents, logs, filings, transcripts, datasets)
+- The form of the piece (story narrative, explanatory narrative, analytical report)
+- The governing claim the scene's MEANING slot must map to
+- Representativeness judgments: which cases are typical of the period, which are extreme
+
+**Outputs produced:**
+- A completed scene provenance ledger, one row per candidate
+- SCAM gate results with the disposition of every failed candidate
+- Built scenes at floor and ceiling, with one telling detail each
+- An S/C/X paragraph map with the measured scenic share against the form's target
+- A gap register: research requests, declared absences, and cuts
+- A note on sources generated from the ledger

--- a/skills/scene-construction-scam/resources/detail-selection.md
+++ b/skills/scene-construction-scam/resources/detail-selection.md
@@ -1,0 +1,71 @@
+# The 1-of-20 Telling-Detail Cut
+
+The discipline is subtraction, not collection. List 15 to 20 candidate details for the passage before writing a word. Score them. Keep one, occasionally two. Delete the rest, and do not demote the survivors into a list.
+
+## The seven tests
+
+Run all seven per candidate. PROVENANCE is a veto: it overrides every other score, and there is no override on it.
+
+| # | Test | Question | Fail action |
+|---|------|----------|-------------|
+| 1 | **PROVENANCE** | Is it in the record, sourced, and datable to this moment? | **Cut. Absolute veto, regardless of every other score.** |
+| 2 | **LOAD** | Does it carry an inference the reader would otherwise need a full sentence of assertion to reach? | Cut. A detail that carries nothing is texture. |
+| 3 | **OWNERSHIP** | Could this detail belong to any other subject in the same category? | Cut. "A busy trading floor" belongs to every trading floor. |
+| 4 | **REDUNDANCY** | Does a nearby surviving detail already carry this inference? | Keep the stronger one only. |
+| 5 | **EXPLANATION** | Have I attached an adjective or clause explaining what it means? | Delete the explanation. If the detail then fails, the explanation was doing the work. |
+| 6 | **REPRESENTATIVENESS** | Is this typical of the pattern I am claiming, or the most extreme instance I found? | If extreme, flag it as extreme in the text, or do not use it in a load-bearing position. |
+| 7 | **COUNT** | Am I keeping more than two? | You are building an inventory, not making a point. Cut to one. |
+
+## The two failure modes
+
+**DETAIL CONFETTI.** Six details each passed the tests, so all six were kept. The result is an inventory paragraph that reads as texture and carries no inference, and the reader skims exactly where the evidence is densest.
+
+- Bad: "The line ran three shifts, the yard held 40,000 TEU, the gate opened at 06:00, the reefer plugs were at 92% occupancy, the crane fleet numbered eleven, and dwell time had reached 8.7 days."
+- Good: "Dwell time had reached 8.7 days. The reefer plugs were at 92%, which is the number that decides whether a box can wait at all."
+
+**INVENTED SPECIFICITY.** Under instruction to be concrete, the writer supplies a plausible-sounding detail that is not in the source. In technical, historical, and financial domains this is fabrication wearing the costume of craft. It is the single most dangerous thing this skill can produce, because it scores well on every test except the one that matters.
+
+The scan must key on **missing pointers, never on vividness**. A vivid detail with a pointer survives no matter how good it sounds. A flat detail with no pointer is still cut. If the scan is applied by confidence rather than by provenance, it strips the genuinely reported detail that made the piece worth reading, and the writer learns to turn the scan off.
+
+## Worked cut — engineering post-mortem
+
+Candidates (abbreviated from 18):
+
+| Detail | 1 Prov | 2 Load | 3 Own | Verdict |
+|--------|--------|--------|-------|---------|
+| The room was quiet at 03:12 | none | — | — | **Cut on veto.** Nobody logged the room. |
+| The page went to the retired rotation | pagerduty audit log, evt 91d4 | high — carries the whole "nobody owned this" claim | high | **KEEP** |
+| The runbook's last edit was 19 months earlier | git blame, runbooks/api.md | medium | high | Cut on redundancy: same inference, weaker |
+| The on-call engineer had joined six weeks earlier | HR start date | medium | medium | Cut on count |
+| Error rate hit 31% | Grafana export | belongs in the CHARACTER slot, not here | — | Belongs to SCAM C, not to the detail cut |
+
+Kept: one. "The page went to a rotation that had been retired in March." No adjective attached. No sentence explaining that this means ownership had lapsed.
+
+## Worked cut — biography
+
+Candidates: the office, the light, the stacked papers, the brand of typewriter, the marginal note.
+
+Only the marginal note has a pointer (the annotated carbon copy in the archive, box 14). Everything else is cut on the veto, no matter how much better the paragraph would read with them. The output is one detail and one sentence: "In the margin of the carbon copy she wrote *ask again in June*."
+
+## Worked cut — market history
+
+Candidates: the auction tail, the dealer share, the trader's mood, the screen colors, the after-hours repricing.
+
+Mood and screen colors are cut on the veto. Dealer share and the tail both point at the same inference, so REDUNDANCY keeps the stronger one. The kept detail is the dealer share at 34.1% against a 12-month average of 17.8%, because the comparison is what carries the load. A number with no comparison on the same screen is not yet a telling detail.
+
+## Representativeness, and why this test exists
+
+Every technique in this skill creates pressure to promote unrepresentative material, because the most vivid case is rarely the most typical one. Applied mechanically, scene craft systematically over-weights the anecdote and under-weights the base rate.
+
+The fix is not to ban the extreme case. It is to make the text carry the flag:
+
+- Bad: "One shipment sat 22 days at the dock."
+- Good: "One shipment sat 22 days, the longest in the sample; median dwell that month was 8.7."
+
+The same rule applies to the whole scene. If the scene is atypical of the period it represents, the text says so on the page, not in a footnote.
+
+## Auditing the cut as a set
+
+Record the detail kept and the ones cut, per passage. Then review the cuts together, not one at a time.
+
+Individual cuts are almost always defensible on length or flow. A pattern in the cuts is a different object. If the nineteen discarded details all pointed the other way from the one kept, the passage is sourced and false. This is the failure that refusal training does not catch, because subtraction never trips a refusal.

--- a/skills/scene-construction-scam/resources/distance-and-rue.md
+++ b/skills/scene-construction-scam/resources/distance-and-rue.md
@@ -1,0 +1,102 @@
+# Narrative Distance Audit and the RUE Pass
+
+Two passes that run after the scene is built. Order matters: RUE first, then the distance audit, because RUE can delete or swap a scene and change the audit's inputs.
+
+## The RUE pass (Resist the Urge to Explain)
+
+1. Mark every sentence in and around the scene that explains what the scene means.
+2. Delete all of them.
+3. Re-read the scene cold.
+4. If the meaning is still available to a reader who has not seen your notes, keep the deletions permanently.
+5. If the meaning is gone, **the scene is the wrong scene**. Swap it for one that carries the meaning. Do not restore the explanation.
+
+Step 5 is the whole point and the step that gets skipped. Restoring the sentence produces a scene that is decorative plus an assertion that is unsupported. Two defects, not one.
+
+**Worked example, supply chain.**
+
+- Before: "The *Ever Lissome* logged in at 06:12 and did not begin discharge until 19:40. This thirteen-hour delay shows how badly the terminal's labor constraints had begun to bind, and illustrates the broader crisis in West Gulf capacity that spring."
+- After RUE: "The *Ever Lissome* logged in at 06:12 and did not begin discharge until 19:40."
+- Test: does a reader get "the ship waited on people, not cranes"? Only if the surrounding text has established that the cranes were idle. If it has not, the fix is a different scene or an added sourced fact, not the restored sentence.
+
+**Worked example, post-mortem.**
+
+- Before: "The page went to a rotation retired in March, revealing a deeper truth about how ownership erodes in fast-moving organizations."
+- After RUE: "The page went to a rotation retired in March."
+- The generalization was not just unnecessary. It was a claim about organizations in general, made with evidence about one rotation.
+
+## The S / C / X audit
+
+1. Label every paragraph **S** (summary) or **C** (scenic).
+2. Anything you cannot label confidently is **X**. X is a defect, not a third mode.
+3. Compute the scenic share and the longest run of each mode.
+4. Compare against the form's targets.
+5. Resolve every X before shipping.
+
+| Form | Scenic share | Run-length rule |
+|------|--------------|-----------------|
+| Story narrative | 40-60% | No summary run over 3 paragraphs |
+| Explanatory narrative | 15-30% | A scenic beat at least every 6-8 paragraphs |
+| Analytical report or memo | 5-15% | Scenes at openings, section heads, and the close only |
+
+These ratios are operational defaults derived for mechanization. They are not published figures from any craft text. Ship them as tunable config and say which values you used.
+
+**What S and C actually differ on:** summary is abstract, reaches across time and space, organizes by topic, and conveys outcome. Scene is concrete, sits in one location in real time, organizes by sequence, and reproduces process. Emotion comes from proximity; understanding comes from the bird's-eye view. Neither is better.
+
+## Summary in costume
+
+The X paragraph is almost always the same defect: a general practice described with sensory adjectives. It has sensory words, no date, no named actor, and no source. It feels scenic and cites nothing, which makes it the most common fabrication vector in machine-written narrative nonfiction.
+
+**Diagnostic markers:**
+- Habitual verb forms: "would gather", "used to run", "each morning the team would".
+- Plural unnamed actors: "traders", "engineers", "dispatchers", "the committee members".
+- A time span instead of a time stamp: "that spring", "through the summer", "in those months".
+- Sensory adjectives with no observer: "thick with tension", "the hum of the floor", "the smell of solder".
+
+**Resolution, one of two.** Demote it, or promote it. Never leave it.
+
+| Costume summary | Demote to clean summary | Promote to a real scene |
+|---|---|---|
+| "Traders would gather around the terminals each morning, the room thick with tension as the auction results printed." | "Auction results printed at 13:00; dealers had 30 minutes to reallocate before the cash close." | "At 13:02 on 15 May the results printed: the dealer take was 34.1%, against a 12-month average of 17.8%." |
+| "Through the summer, engineers grew used to the nightly alerts and stopped acting on them." | "Between June and August, 812 alerts fired on this service; 14 produced a ticket." | "On 4 August the 03:12 page went to a rotation retired in March, and no one acknowledged it for 41 minutes." |
+| "In those months she spent her evenings buried in the departmental correspondence." | "Her letters that spring refer repeatedly to departmental correspondence she was reading at home." | Only if a dated source exists. Otherwise there is no scene here, and the demotion is the answer. |
+
+Promotion requires a date, a place, and named actors, each with a pointer. If you cannot supply all three, promotion is not available and demotion is the only legal move.
+
+## The alternation rule
+
+Scene and summary must earn their adjacency:
+
+- After a scenic run, the next summary block must **explain something the scene made the reader want to know**.
+- After a summary run, the next scene must **instantiate the claim just made**.
+
+If neither holds, the alternation is decorative and one of the two blocks should be cut. A piece that alternates on a fixed rhythm regardless of content has implemented the shape of narrative and none of its function.
+
+**Closing move:** endings usually pull back one notch in distance from the piece's dominant mode. A scene-heavy piece closes at summary distance; a summary-heavy piece closes on one concrete instance.
+
+## Gap notes: the honest output when the record is thin
+
+Literary-journalism sensory technique does not transfer to unreported domains. A writer working from filings, commit logs, berth records, or archives was in no room, saw no light, and heard no hum. Any instruction to engage the senses is gated on whether sensory observation exists in the source. Absent that gate, the output is atmospheric fiction attached to real claims, which is worse than dry prose.
+
+When the record is thin, use one of these forms rather than a plausible specific:
+
+- **Declared absence:** "What the committee discussed between 3 and 17 March is not recorded."
+- **Bounded knowledge:** "The berth log gives arrival and discharge times. It does not record why the gap ran thirteen hours."
+- **Source conflict left open:** "The RCA puts the exit at 09:47:11; the vendor's timeline puts it at 09:49. Both are in the record and they are not reconciled." Never resolve a documented conflict silently by picking the better-sounding value.
+- **Refusal:** "This material supports an explanatory account with summary distance throughout. It does not support scenes: no dated moment in the corpus has a sourced setting, a sourced actor, and three ordered observable events."
+
+The refusal is a successful outcome of this skill. Micro craft cannot repair absent reporting, and an agent that tries will manufacture the missing elements.
+
+## Keeping systems out of the viewpoint chair
+
+The audit is also where anthropomorphic drift gets caught, because drift accumulates across paragraphs rather than inside single sentences.
+
+Count the intentional verbs attached to non-people: realized, decided, wanted, believed, chose, feared, learned, understood. Cap them. Personification is a legitimate framing device used once, explicitly. Used continuously it becomes an unfalsifiable causal claim distributed across every verb in the piece, and the causal claim never faces the citation discipline that an explicit claim would face.
+
+| Drifted | Repaired |
+|---|---|
+| "The market realized the supply would not arrive." | "Front-month futures repriced 9% over two sessions after the port notice." |
+| "The protocol wanted lower latency." | "The spec's stated design goal was sub-100ms confirmation (RFC draft s1.2)." |
+| "The codebase resisted the change." | "The change touched 214 files across four services; three of them had no test coverage." |
+| "The institution decided to look away." | "The board minutes for that quarter contain no reference to the audit finding." |
+
+An imputed institutional intent is permitted only when a filing, a minute, a transcript, or a quoted executive supplies it. Systems have states, constraints, and incentives. Only people have wants.

--- a/skills/scene-construction-scam/resources/evaluators/rubric_scene_construction_scam.json
+++ b/skills/scene-construction-scam/resources/evaluators/rubric_scene_construction_scam.json
@@ -1,0 +1,102 @@
+{
+  "name": "Scene Construction (SCAM) Rubric",
+  "description": "Evaluation criteria for whether a scene was reported rather than generated: SCAM gate discipline, provenance ledger completeness, detail selection, narrative distance, system-protagonist handling, and honest handling of a thin record. Minimum standard is an average score of 3.5.",
+  "criteria": [
+    {
+      "name": "SCAM Gate Discipline",
+      "description": "Whether all four slots were filled with sourced content and the four gates were applied in order, with Gate 4 (could this have been written without the source material?) actually run",
+      "weight": 1.5,
+      "scores": {
+        "1": "No gate run; the passage was drafted directly and called a scene",
+        "2": "Slots filled but with no source column, or gates named and not applied",
+        "3": "All four slots sourced and Gates 1-3 applied; Gate 4 skipped or run superficially",
+        "4": "All four gates applied per candidate with results recorded; Gate 4 genuinely tested against the hidden-pointer method",
+        "5": "All four gates applied, Gate 4 caused at least one candidate to be killed or reworked, and Gate 2 violations were moved to the following summary block rather than left in the scene"
+      }
+    },
+    {
+      "name": "Provenance and Ledger Completeness",
+      "description": "Whether every scene has a complete ledger row with pointers that resolve to external artifacts, and whether missing fields actually blocked the build",
+      "weight": 1.5,
+      "scores": {
+        "1": "No ledger; scenes drafted from memory or from the pipeline's own summaries",
+        "2": "Ledger present but pointers are coarse ('the 10-K', 'the incident report') or resolve into the pipeline's own outputs",
+        "3": "Most fields filled with resolvable pointers; some gaps were papered over rather than blocking",
+        "4": "All required fields filled, all pointers external and granular, missing fields blocked the build",
+        "5": "As 4, plus the interior-state classes are tagged with a zero D-count, class A/B material is unhedged, class C is marked in the prose, and blocked candidates were dispositioned rather than drafted-and-flagged"
+      }
+    },
+    {
+      "name": "Empty-Slot Handling and Honest Refusal",
+      "description": "Whether unfillable slots produced summary, research requests, declared absences, or refusal, rather than inference or plausible specifics",
+      "weight": 1.5,
+      "scores": {
+        "1": "Empty slots filled by inference; plausible specifics supplied where the record was thin",
+        "2": "Some inference-filling, some demotion; the choice between them tracked what the piece needed rather than what the record held",
+        "3": "Empty slots demoted to summary, but gaps are silent and the reader cannot tell the record ran out",
+        "4": "Every failed candidate has a recorded disposition; absences are declared in the text where they matter",
+        "5": "As 4, plus the output includes a defensible refusal or gap register where the corpus does not support scene, and source conflicts are left open in the text rather than resolved silently"
+      }
+    },
+    {
+      "name": "Detail Selection and Provenance Veto",
+      "description": "Whether the 1-of-20 cut was run with the seven tests, provenance treated as an absolute veto, and survivors held to one or two",
+      "weight": 1.0,
+      "scores": {
+        "1": "Details generated as needed while drafting; several have no source",
+        "2": "Candidates listed but all plausible ones kept, producing an inventory paragraph",
+        "3": "Cut performed and provenance respected, but three or more details survive and carry overlapping inferences",
+        "4": "Seven tests run per candidate, provenance vetoed at least one attractive detail, one or two survivors kept with no explanatory adjective",
+        "5": "As 4, plus the kept and cut details are recorded and reviewed as a set, and the representativeness test produced an on-page flag where the detail was extreme"
+      }
+    },
+    {
+      "name": "Scene Floor, Ceiling, and RUE",
+      "description": "Whether the scene meets the floor (one place, one time marker, one observable action), stops at the ceiling (2-4 concrete elements), and survived the RUE deletion",
+      "weight": 1.0,
+      "scores": {
+        "1": "No located moment, or an establishing shot of invented weather, light, and mood",
+        "2": "Floor met but the scene runs to a room inventory, or the meaning is carried entirely by explanation",
+        "3": "Floor and ceiling respected; RUE run but explanatory sentences were restored rather than the scene swapped",
+        "4": "Floor met, ceiling held at 2-4 elements, entry in medias res, RUE deletions permanent",
+        "5": "As 4, plus at least one scene was swapped rather than annotated when RUE removed its meaning, and any quoted dialogue is verbatim and internal to the scene"
+      }
+    },
+    {
+      "name": "Narrative Distance and Costume Summary",
+      "description": "Whether paragraphs were labeled S/C/X, the scenic share measured against the form's target, and every X resolved by demotion or promotion",
+      "weight": 1.0,
+      "scores": {
+        "1": "No audit; the piece drifts between modes and several paragraphs are sensory generalizations with no date or actor",
+        "2": "Audit attempted but X paragraphs were left in place as a third mode",
+        "3": "Labels applied and ratio computed; some costume summary survives",
+        "4": "Every paragraph labeled, ratio within the form's target, every X demoted to clean summary or promoted with a date, a place, and named actors",
+        "5": "As 4, plus the alternation rule holds in both directions, the ratio targets are stated as tunable defaults rather than published figures, and the close pulls back one notch in distance"
+      }
+    },
+    {
+      "name": "System Protagonist Handling",
+      "description": "Whether the CHARACTER slot for a non-human protagonist is observable state plus one distinguishing behavior, and whether intentional verbs were capped",
+      "weight": 1.2,
+      "scores": {
+        "1": "The system holds wants, beliefs, and decisions throughout; causal claims enter through metaphor",
+        "2": "Personification used repeatedly, with occasional mechanical repair",
+        "3": "CHARACTER slot uses observable state, but intentional verbs recur in the prose without being counted",
+        "4": "State-plus-behavior in the slot, intentional verbs counted and capped, personification used once as an explicit framing device",
+        "5": "As 4, plus every imputed institutional intent traces to a filing, minute, transcript, or quoted executive, and aggregates carry a persistent marker and never enter a scene"
+      }
+    },
+    {
+      "name": "Subtraction, Proportion, and Attribution Accuracy",
+      "description": "Whether cuts were reviewed as a set against the drift and proportion of the record, and whether the skill's own attribution caveats were carried",
+      "weight": 1.2,
+      "scores": {
+        "1": "No subtraction log; disconfirming material cut without trace; SCAM credited to Hart or thresholds presented as published figures",
+        "2": "Cuts logged but reviewed only individually; attribution caveats absent",
+        "3": "Subtraction log present and reviewed as a set; attribution mostly correct but one caveat dropped",
+        "4": "Cuts reviewed as a set with a proportion test, atypical scenes flagged on the page, SCAM attributed to journalism pedagogy rather than Hart, numeric thresholds labeled as derived defaults",
+        "5": "As 4, plus the note on sources is generated from the deviation log with named specifics rather than boilerplate, and the word 'verified' is used nowhere for facts that were only sourced"
+      }
+    }
+  ]
+}

--- a/skills/scene-construction-scam/resources/scam-gate.md
+++ b/skills/scene-construction-scam/resources/scam-gate.md
@@ -1,0 +1,97 @@
+# The SCAM Gate, Worked
+
+SCAM (Setting, Character, Action, Meaning) is a four-slot test for whether a candidate passage is a genuine scene. It is journalism-pedagogy shorthand from Dynamics of Writing. It is **not** Jack Hart's acronym. Do not attribute it to him or to Storycraft.
+
+## How to run it
+
+Build a 4x3 table per candidate: slot, filled content, source pointer. Then apply the four gates.
+
+```
+Scene ID: INC-0412
+Slot | Content                                      | Pointer
+S    | ...                                          | ...
+C    | ...                                          | ...
+A    | ...                                          | ...
+M    | ...                                          | ...
+Gate 1 (no empty slot):        pass / fail
+Gate 2 (M adds nothing new):   pass / fail
+Gate 3 (skeptical reader):     pass / fail
+Gate 4 (unwritable w/o source):pass / fail
+Disposition: built | demoted to summary | research request | declared absence | cut
+```
+
+## Gate 4 in practice
+
+Gate 4 is the load-bearing one and the one an agent will skip, because the other three can all be passed by a fluent invention. Run it like this: hide the pointer column. Read the passage. Ask whether a competent writer with no access to the corpus, holding only the topic and the date range, could have produced this paragraph from priors. If yes, the passage is generated, not reported, and it goes.
+
+The tell is that the details are *category-typical* rather than *instance-specific*. Anyone knows a data center hums. Nobody knows without a log that the 03:12 page went to the wrong rotation.
+
+## Worked candidate 1 — engineering post-mortem (PASSES)
+
+| Slot | Content | Pointer |
+|------|---------|---------|
+| S | The 12 April on-call rotation, US-East control plane; the deploy freeze had lifted 40 minutes earlier | change-calendar entry CH-8841; freeze notice, #ops-announce 09:20 |
+| C (system) | Control-plane API error rate at 0.02% at 09:41, 31% at 09:47; the service had never before failed closed on a config parse error | Grafana panel export, api-5xx, 09:30-10:00; RCA doc s3.2 |
+| A | 1. Config v412 merged at 09:44. 2. Rollout reached the third cell at 09:46. 3. The parser rejected the new key and the process exited at 09:47:11 | commit 7f2a9c1; rollout log lines 118-140; crash trace, node-31 |
+| M | The freeze was the only thing that had been catching this class of change | maps to the piece's claim about process substituting for tests |
+
+Gate 4: could this have been written without the corpus? No. The 09:47:11 exit and the "never before failed closed" behavior are instance-specific and both resolve to artifacts.
+
+## Worked candidate 2 — market history (PASSES, system CHARACTER)
+
+| Slot | Content | Pointer |
+|------|---------|---------|
+| S | The Tuesday afternoon Treasury auction, 15 May, at the 13:00 bidding deadline | auction results release, CUSIP 912810XX, p.1 |
+| C (system) | The 10-year cleared at 2 basis points above the when-issued yield; primary dealers took 34.1% of the issue against a 12-month average of 17.8% | results release, tables 1 and 3 |
+| A | 1. Indirect bids came in at 41.6%, the lowest of the eight auctions that year. 2. The auction tailed. 3. The when-issued market repriced 4bp within the hour | results release; TRACE prints 13:00-14:00 |
+| M | The dealer take is what the auction leaves behind when the buyers it was designed for do not show | maps to the claim about who absorbs supply |
+
+Note what the CHARACTER slot is here: a state (a clearing price, a share of issue) and a behavior (the tail). It is not "the market grew nervous". No intent verb appears anywhere in the row.
+
+## Worked candidate 3 — supply chain (PASSES)
+
+| Slot | Content | Pointer |
+|------|---------|---------|
+| S | Berth 6, Barbours Cut, 14 May 2021 | terminal berth log, entry 2214 |
+| C (system) | Yard utilization at 94% of TEU capacity; the terminal had been running single-shift gate hours since 2 May | PMSA monthly table 2; gate notice 21-14 |
+| A | 1. *Ever Lissome* logged in at 06:12. 2. Discharge began 19:40. 3. First container cleared the gate the following morning | berth log 2214; gate transaction file, 15 May |
+| M | Capacity had stopped being about cranes | maps to the claim about labor hours, not equipment |
+
+## Worked candidate 4 — biography (FAILS Gate 1, then Gate 4)
+
+| Slot | Content | Pointer |
+|------|---------|---------|
+| S | Her office in the spring of 1978, papers everywhere, late afternoon light | **none** |
+| C | She was known to be exacting | **none** for the physical detail |
+| A | She read the memo and set it aside | letter to her brother, 3 June 1978, mentions "the memo I ignored in March" |
+| M | She already knew the department would not back her | inference |
+
+Gate 1 fails: SETTING has no pointer and CHARACTER has no sourced physical detail. Gate 4 also fails: the papers, the light, and the exacting temperament are category-typical and could have been written by anyone. The A slot has one sourced event, not three ordered ones.
+
+**Correct disposition**: demote to summary. "In a letter that June she referred to a memo she had ignored in March; the departmental file for that spring does not survive." That sentence is honest, carries the same fact, and invents nothing. The gap ("the departmental file does not survive") is legitimate narrative material and often the most useful beat available.
+
+## Worked candidate 5 — ML writeup (FAILS Gate 2, salvageable)
+
+| Slot | Content | Pointer |
+|------|---------|---------|
+| S | Run 42, the 14:00 restart after the checkpoint at step 118k | run manifest; W&B run id 3ka9 |
+| C (system) | Loss at 2.31, flat for 6k steps; gradient norm spiking every 400 steps | W&B panels, loss and grad_norm |
+| A | 1. LR warm restart applied at step 118k. 2. Loss fell to 2.09 over 3k steps. 3. Grad-norm spikes stopped | run config diff; W&B panels |
+| M | The team had been chasing a data problem for two weeks and it was an optimizer problem, which is why the eval suite never caught it | **introduces the two weeks and the eval-suite claim, neither of which is in S/C/A** |
+
+Gate 2 fails: the MEANING sentence smuggles in new facts. This one is fixable without swapping the scene. Cut M back to what S/C/A support: "the instability was in the schedule, not the data." Move the two-week hunt and the eval-suite point into the summary paragraph that follows. Interpretation is licensed there, and it can carry its own pointers.
+
+## The demotion procedure
+
+When a candidate fails any gate, it does not become worse prose. It becomes a different unit. Pick one:
+
+1. **Demote to summary.** Write the sourced facts at summary distance, with no sensory grammar. This is the default and it is not a defeat.
+2. **Research request.** Emit a specific, answerable question: "Is there a berth log for 15 May?" Preferred when the corpus can still grow.
+3. **Declare the absence in the text.** "What the committee discussed between 3 and 17 March is not recorded." Absences are legitimate narrative material.
+4. **Cut.**
+
+There is no fifth disposition. "Draft it and flag it for review" is not a disposition: flagged drafted text survives review at high rates, because it reads well and the reviewer is checking rather than rewriting.
+
+## What the gate cannot do
+
+The gate checks that a claim points somewhere. It cannot check that the source is right. Write "sourced to the berth log"; never write "verified". An agent that reports verification it did not perform is worse than an agent that reports nothing, because unchecked output at least looks unchecked.

--- a/skills/scene-construction-scam/resources/scene-ledger.md
+++ b/skills/scene-construction-scam/resources/scene-ledger.md
@@ -1,0 +1,98 @@
+# The Scene Provenance Ledger
+
+Build the ledger before any prose. The ledger, not the corpus, is what a scene is allowed to be built on. A scene slot that cannot be filled from the ledger produces a gap entry, never prose.
+
+**Any missing required field BLOCKS the build of that scene.** Blocking is the normal case, not an exception. Real material always has holes; a run with zero blocked candidates is a red flag.
+
+## Schema
+
+| Field | Required | Content | Common defect |
+|-------|----------|---------|---------------|
+| `scene_id` | yes | Stable handle the draft cites | — |
+| `date_place` | yes | Exact as the source carries it | Implying finer precision than the source. A source that says "March 1978" does not license "early March" |
+| `actors` | yes | Named real people, or named systems | Composites; the unnamed engineer/trader/customer who exists to voice the thesis |
+| `setting_specifics` | yes | Two or more recorded physical or observable conditions of the place | Weather, light, and mood written because that is what scenes look like |
+| `system_state` | if protagonist is a system | Observable state at that moment: price, queue depth, latency, inventory, yield, error rate | A want, a belief, or a decision in this field |
+| `action_sequence` | yes | Three or more ordered observable events, each with its own pointer | A state of affairs recorded as an action |
+| `pointers` | yes | External artifacts only: page, section, timestamp, line number, table cell, commit hash, URL with retrieval date | "The 10-K" is not a pointer. "10-K FY2023 p.47, risk factors" is |
+| `interior_states` | yes if any appear | Per claim, a class: A / B / C / D (see below) | Class D present |
+| `drift_proportion` | yes | Typical of the period, or atypical? Plus the flag text that will appear on the page | Scene chosen because it was vivid, unflagged |
+| `subtraction_log` | yes | What was cut from this moment; whether the remainder implies a different frequency or magnitude than the record | Cuts reviewed one at a time instead of as a set |
+| `contested` | yes | Any conflicting source values, both retained | Silent resolution to the better-sounding value |
+| `disposition` | yes | built / demoted / research request / declared absence / cut | "Drafted and flagged", which is not a disposition |
+
+## Interior-state classes
+
+Applies to any claim about a thought, feeling, intention, belief, expectation, or motive.
+
+| Class | Basis | License in prose |
+|-------|-------|------------------|
+| **A** | The person stated this about that moment | Render as close third. No in-line hedge. Source in notes |
+| **B** | Contemporaneous document: email, memo, log, diary, filing, transcript | Render as close third. The document should be visible somewhere nearby in the text |
+| **C** | Behavioral inference from an observed or recorded action | Render the action only, or mark the inference in the prose: "which suggests", "he later described it as" |
+| **D** | No basis | **Refuse.** Delete, or convert to the action |
+
+A nonzero D-count blocks the build. There is a matching over-correction rule: class A and B material must **not** be hedged. Hedging every sourced thought destroys close third and makes the piece read as evasive. The hedge belongs to class C alone.
+
+For systems, the equivalent of interior state is imputed institutional intent. Same gate: a firm "expected" something only if a filing, minute, transcript, or quoted executive says so.
+
+## Composites and aggregates
+
+**Composites are prohibited, categorically.** Never merge two or more real people, firms, incidents, shifts, or datasets into one entity presented as singular. Not for privacy. Not for concision. Not for narrative economy. Not because the section needs one clean example.
+
+If privacy requires it, anonymize ("a senior engineer, who asked not to be named"). Never fuse. Pseudonyms are themselves a deviation requiring disclosure.
+
+**Aggregates are permitted, under constraint.** Analytical domains legitimately need the representative firm, the median user, the typical trade. The rule is not "no aggregates". The rule is that an aggregate may never acquire the properties of an individual.
+
+An aggregate must be labeled at first use and constructed transparently: "a representative 200mm fab", "the median advertiser in this cohort", "an aggregate computed across the twelve incidents in the dataset".
+
+**Never call an aggregate a "composite."** That word is reserved for the prohibited operation — fusing several real entities into one presented as singular. Reusing it for a permitted aggregate re-licenses the thing the bright line forbids, and the drafting agent will take the licence.
+
+An aggregate may **not**:
+- take a proper name
+- appear in a scene
+- be given dialogue
+- be given interiority or intent
+- be given a specific date or location
+- be described with sensory detail
+
+Every property attributed to the aggregate must hold for the aggregate as computed, not be a union of properties drawn from different members. A median firm does not have the largest member's revenue and the smallest member's headcount.
+
+The failure mode has a shape. The aggregate is honestly labeled at first use. Then over ten pages it accretes a founding date, a temperament, a decisive meeting. Narrative wants a character, and the aggregate is standing in the character slot. By then the disclosure is thirty paragraphs back and the reader is reading fiction. Carry a persistent marker on aggregates and treat any scene-level verb attached to one as a hard defect.
+
+If the piece needs a single vivid exemplar, find a real one and name it, or accept the aggregate's flatness. Refuse the third option.
+
+## Blocking checklist
+
+Run last. Any line that fires blocks the scene.
+
+- [ ] Every required ledger field is filled for this scene.
+- [ ] Every pointer resolves to an external artifact. No pointer resolves into this pipeline's own notes, summaries, or earlier drafts.
+- [ ] No SCAM slot was filled by inference.
+- [ ] Gate 4 passed: this passage could not have been written without the source material.
+- [ ] Interior-state D-count is zero. Class A and B material is unhedged; class C is marked in the prose.
+- [ ] No dialogue in quotation marks that is not verbatim from a recording, transcript, or contemporaneous written record. Remembered speech is paraphrased and marked as remembered.
+- [ ] No invented sensory material: weather, light, sound, clothing, gesture, room contents, physical sensation.
+- [ ] No number the sources do not contain, including a qualitative quantifier converted to a numeral ("several" to "six") and any figure exceeding the source's precision.
+- [ ] No composite person, firm, incident, or scene presented as singular. No aggregate carrying a name, a scene, dialogue, intent, a date, or sensory detail.
+- [ ] No duration compressed or expanded; no separate events merged into one moment.
+- [ ] No actor shown acting on information that post-dates their action.
+- [ ] Documented source conflicts are both in the text, not silently resolved.
+- [ ] The drift-and-proportion flag is on the page for any atypical scene.
+- [ ] The subtraction log was reviewed as a set, and the remainder does not imply a different frequency, magnitude, or balance than the full record.
+- [ ] No system holds a want, a belief, or a decision. Personification appears at most once, explicitly.
+- [ ] Transition and summary sentences carry pointers too. No unsourced abstract-state assertion ("by then the pressure was impossible to ignore").
+- [ ] The word "verified" appears nowhere. Facts were sourced, not checked.
+- [ ] The higher-truth rationalization was not used. "This is clearly what happened", "the reader will understand", "it is emotionally true", "it is a reasonable inference" are all the same move under different wording.
+
+## Generating the note on sources
+
+Generate the disclosure **from** the deviation log after the fact. Never write it in advance.
+
+Boilerplate ("some events have been compressed, some dialogue recreated") is worse than nothing in an automated pipeline. It is cheap to emit, it pre-authorizes the deviations, and it makes the reader believe a human weighed a trade-off that no one weighed. Disclosure is not a currency that buys deviations.
+
+A generated note names specifics:
+
+> Scenes are built from the berth logs, gate transaction files, and PMSA monthly tables cited in the endnotes. Times are as logged and are not adjusted for time zone drift in the 2021 records. No dialogue appears; no participant was interviewed. The 22-day dwell in section 3 is the longest in the sample, not a typical case. Discharge records for 11-13 May are missing from the terminal file and no substitute was found.
+
+Every clause in that note traces to a ledger field. If a clause cannot be traced to one, it does not belong in the note.

--- a/skills/systemic-protagonist/SKILL.md
+++ b/skills/systemic-protagonist/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: systemic-protagonist
+description: Renders a market, protocol, institution, codebase, supply chain, disease, or ecosystem as a legible protagonist without faking agency. Builds the POSIWID character sheet (revealed objective function vs. stated purpose), the agency ledger of verb repairs, the gateway-proxy admission test, the traveling-object device, the instrumented threshold scene, and climax by constraint violation. Use when the subject of a piece is a system rather than a person, when a draft says "the market decided" or "the industry learned", when analysis reads as a data dump with no protagonist, or when user mentions systemic narrative, system as character, POSIWID, anthropomorphism, agency laundering, follow the flow, or institution as protagonist.
+---
+
+# Systemic Protagonist
+
+## Table of Contents
+- [Core Principles](#core-principles)
+- [Workflow](#workflow)
+- [The POSIWID Character Sheet](#the-posiwid-character-sheet)
+- [The Agency Ledger](#the-agency-ledger)
+- [Climax Types for a Subject With No Battle](#climax-types-for-a-subject-with-no-battle)
+- [Domain Failure Profiles](#domain-failure-profiles)
+- [Guardrails](#guardrails)
+- [Quick Reference](#quick-reference)
+
+**Related skills:** Use `narrative-evidence-ledger` for typed claims before you start, `narrative-form-triage` for the story/explanatory/gathering decision, `narrative-fallacy-guard` for the inevitability and survivorship audit, `mcphee-structure-derivation` for arrangement when no dramatic engine exists, `narrative-opposition-web` for the opposition slot. This skill does not build that slot. In a system narrative corner B is a constraint, and its value cluster arrives by delegation to a documented human carrier.
+
+## Core Principles
+
+1. **A system is a character because it has a revealed objective function**: not because it has feelings. Constraints, feedback loops, and a consistent conversion of inputs into outputs are what make behaviour predictable, and predictable behaviour is what makes a subject dramatizable.
+2. **Purpose is deduced from behaviour, not rhetoric**: what a market pays for, what an institution promotes people for, what a codebase makes easy. The stated purpose is evidence about the speaker, not about the system.
+3. **The gap is the engine**: stated purpose minus revealed objective function. No gap means no narrative — it means a description, and you should say so rather than manufacture tension.
+4. **Agency is a grammatical property before it is a narrative one**: subject-verb-object smuggles intent. "The market wanted higher yields" is not a style problem, it is a false causal claim wearing a sentence.
+5. **Relocate agency, never delete it**: the repair is naming who or what actually acted. Agentless passive ("prices were observed to decline") obscures causation worse than the anthropomorphism it replaced.
+6. **Systemic framing must be additive to accountability, not a substitute**: "the system failed" is often a sentence written to avoid naming someone who had the authority and the information to do otherwise.
+7. **Humans in a systems piece are probes, not protagonists**: their arcs exist to map the shape of the constraint they collide with. When the probe eats the system, you have a character study wearing a systems title.
+
+## Workflow
+
+Copy this checklist and track your progress:
+
+```
+Systemic Protagonist Progress:
+- [ ] Step 1: Gate — confirm subject level, evidence depth, and domain failure profile
+- [ ] Step 2: Build the POSIWID character sheet (two regimes, mandatory residual)
+- [ ] Step 3: Admit the humans and the traveling object
+- [ ] Step 4: Stage perceptibility — threshold scenes and the constraint-violation peak
+- [ ] Step 5: Write the billboard; run agency ledger and responsibility check
+- [ ] Step 6: Drift check and handoff
+```
+
+**Step 1: Gate**
+
+Step 1.1: Declare the subject level in one line: is the protagonist the SYSTEM, or a named participant inside it? Do not oscillate. If it is a participant, stop — this is the wrong skill.
+
+Step 1.2: Run the material-depth gate. Threshold scenes, sense of place, and gateway arcs all require artefacts: timestamps, readings, transcripts, memos, logs, filings. Count them. If the corpus is entirely secondary and abstract, take the DOWNGRADE PATH: produce the character sheet and the billboard only, mark scene work as `INSUFFICIENT GROUND-LEVEL MATERIAL`, and recommend explanatory exposition. Never generate sensory detail that is not in the source.
+
+Step 1.3: Select the domain failure profile from [Domain Failure Profiles](#domain-failure-profiles) and name the dominant local error. One uniform checklist misses it.
+
+**Step 2: Build the POSIWID character sheet**
+
+Step 2.1: Answer all eight questions in [The POSIWID Character Sheet](#the-posiwid-character-sheet), citing evidence per line.
+
+Step 2.2: Apply the TWO-REGIME TEST. The character sentence must be supported by behaviour in at least two distinct regimes — boom and bust, peacetime and stress, normal operation and incident, funded and unfunded. Derived from one episode, the "revealed purpose" is a description of that episode dressed as a trait. One regime = `UNSUPPORTED`, go back to the material or widen the time window.
+
+Step 2.3: Fill the residual field: which outcomes does the revealed objective function FAIL to explain? At least one entry is mandatory and it must survive into the finished piece. A character sentence that explains 100% of outcomes with zero residual is fitted noise, and it converts a system that was merely incompetent, path-dependent, or unlucky into a coherent malign optimiser.
+
+Step 2.4: Name the gap in one sentence. If there is no gap, emit `NO DRAMATIC ENGINE` with the reason and recommend a different subject or a longer window. This is a successful outcome, not a failure.
+
+See [resources/posiwid-character-sheet.md](resources/posiwid-character-sheet.md) for the field-by-field procedure, three filled examples, and the reform-attempt ledger.
+
+**Step 3: Admit the humans and the traveling object**
+
+Step 3.1: Run the gateway-proxy admission test on every candidate human. Each gateway must map to ONE line of the character sheet, must have started wrong and updated, and must carry a written paragraph on what they got wrong or could not see.
+
+Step 3.2: Run the DELETION TEST and the RATIO TEST. Delete the gateway: does the systemic claim still stand on cited evidence? Count paragraphs of gateway interiority against paragraphs of mechanism.
+
+Step 3.3: Disclose the cast selection in the text. State how each person came to be in the story and who declined, refused, or was unreachable — and whether their absence flatters anyone. This is non-optional.
+
+Step 3.4: Choose the traveling object: the smallest concrete thing that moves end to end. Verify its four constraints and run the GIMMICK TEST.
+
+See [resources/entry-points-and-peaks.md](resources/entry-points-and-peaks.md) for both tests and the station-list procedure.
+
+**Step 4: Stage perceptibility**
+
+Step 4.1: Build the instrumented threshold scene at instrument resolution, constrained to what the observer could know at that timestamp, evidenced by a document created at or before it.
+
+Step 4.2: State whether the threshold is a property of the SYSTEM or of the MEASUREMENT.
+
+Step 4.3: Select the peak from the five legitimate climax types and run the TRANSFER-FUNCTION TEST: after this, do the same inputs produce different outputs? If no, it is a scene, not a climax.
+
+Step 4.4: Extract every REFORM ATTEMPT and include at least one that partially worked, or an explicit statement of the conditions under which this system has changed. Without it the piece becomes fatalism, which is inevitability with the sign flipped.
+
+**Step 5: Billboard, verbs, and responsibility**
+
+Step 5.1: Write the five-sentence stated-vs-revealed billboard. State the finding; do not tease it.
+
+Step 5.2: Emit the agency ledger as a binding verb-constraint sheet for the drafting stage. If a draft exists, run the repairs over it and then run the POST-PASS CHECK on agentless passives.
+
+Step 5.3: Run the responsibility-laundering reverse check on every systemic attribution: did a named actor have the authority AND the information to do otherwise? If yes, name them.
+
+**Step 6: Drift check and handoff**
+
+Step 6.1: Re-derive the billboard from the finished evidence. Any difference from the Step 5 version means the research changed the finding — surface that to the human explicitly rather than quietly editing it.
+
+Step 6.2: Confirm every admitted scene, node, and quote traces to a character-sheet line. Untraceable material is cut or the sheet is wrong.
+
+Step 6.3: Mark the character sheet as a PLANNING ARTEFACT. It must not leak into the prose as visible scaffolding — no "as the character sheet showed", no labelled strands, no rung tags. Readers are not supposed to notice the structure.
+
+Validate using [resources/evaluators/rubric_systemic_protagonist.json](resources/evaluators/rubric_systemic_protagonist.json). **Minimum standard**: average score >= 3.5.
+
+## The POSIWID Character Sheet
+
+Eight questions, answered from the record before any prose exists. Every line carries a citation.
+
+| # | Question | Fail condition |
+|---|----------|----------------|
+| 1 | What outcomes did this system reliably produce over the period? (Outcomes, not intentions.) | Fewer than five outcomes, or outcomes drawn from one year |
+| 2 | Complete: **"This system reliably converts ___ into ___."** That sentence is the character. | Not supported in two regimes |
+| 3 | What are the hard constraints — physical, legal, capital, information, latency, headcount — and where is each documented? | Any constraint asserted without a source |
+| 4 | What are the feedback loops? Per loop: reinforcing or balancing, the quantity that closes it, the delay. | A loop named without its delay |
+| 5 | What does the system not measure, and therefore not respond to? | Empty — blind spots are where the surprises live |
+| 6 | What is the STATED purpose, quoted verbatim from a charter, prospectus, mission statement, README, or launch post? | Paraphrased instead of quoted |
+| 7 | What is the gap between stated and revealed, in one sentence? | No gap: emit `NO DRAMATIC ENGINE` |
+| 8 | Which outcomes does the revealed objective function FAIL to explain? | Empty. At least one required, and it must appear in the finished piece |
+
+Attribution caveat: POSIWID ("the purpose of a system is what it does") is Stafford Beer's formulation. The phrasing used here — purposes are deduced by an observer from behaviour, not from rhetoric or stated goals — is Donella Meadows in *Thinking in Systems*. Do not credit the acronym to Meadows.
+
+## The Agency Ledger
+
+**This skill owns the verb-repair table.** `ladder-of-abstraction` and `narrative-opposition-web` both restate the four repairs inline, so the rule fires where drafting happens. Both should cite this section as the source, and any change to the repairs is made here first.
+
+First find every sentence whose grammatical subject is a system, market, technology, institution, disease, algorithm, or abstraction. Then flag it if the main verb is INTENTIONAL (wanted, decided, chose, sought, punished, rewarded, learned, realised, refused) or EVALUATIVE-TELEOLOGICAL (matured, advanced, evolved toward, progressed, naturally moved to). Mechanical verbs — rose, cleared, propagated, saturated, reallocated, queued — are allowed.
+
+Four repairs, in preference order:
+
+| Repair | Bad | Good |
+|--------|-----|------|
+| **Name the actor** | "The market punished the sector." | "Three of the four largest holders sold into the bid across two sessions." |
+| **Name the mechanism** | "The protocol wanted lower latency." | "The fee schedule paid 0.4 bps more on blocks confirmed inside 400 ms." |
+| **Name the selection pressure** | "The industry evolved toward outsourced fabrication." | "Firms that kept fabrication in-house lost 12 points of margin and exited by 1998; every survivor had outsourced." |
+| **Quote the human** | "The project decided to deprecate the plugin loader." | "Okonkwo closed the RFC on 12 March with 'we cannot support two loaders'; neither other committer with merge rights objected." |
+
+If none of the four can be made from the material, that is a RESEARCH GAP, not a style problem. Flag it. Do not substitute a metaphor for a missing mechanism.
+
+**Post-pass check (mandatory):** count agentless passives ("prices were observed to decline", "a decision was reached") before and after. If they rose, the pass failed — you removed agency instead of relocating it.
+
+**Personification budget:** at most one deliberate, flagged personification per major section, and only where you can state in one line what mechanism it stands in for. A hard anthropomorphism ban produces sterile passive prose and buys nothing, because agentless passive obscures causation rather than removing the claim. This skill's position is that the ledger is a CLAIM filter, not a purity filter. That is a derived judgement, not a research finding; no citation is offered because none is held.
+
+## Climax Types for a Subject With No Battle
+
+Systems have no showdowns. Peaks are built from genuinely irreversible state transitions.
+
+| Type | What happens | Example shape |
+|------|--------------|---------------|
+| **LOOP FLIP** | A balancing loop becomes reinforcing, or vice versa | Retention discounts that stabilised churn begin funding the competitor that causes it |
+| **BUFFER EXHAUSTION** | A slack resource reaches zero | Ward beds, chip inventory, dispatch headroom, maintainer hours |
+| **CONSTRAINT BINDING** | A limit that never mattered starts setting the outcome | Transformer capacity, not land, becomes the thing that sites a data centre |
+| **IRREVERSIBILITY** | An option is destroyed | A plant closes, a signing key is lost, a file format locks in, a species goes |
+| **LEGIBILITY** | The stated/revealed gap becomes undeniable to insiders, evidenced by a document | An internal memo that names the real objective function in plain language |
+
+**Transfer-function test:** after the peak, do the same inputs produce different outputs? If no, it is a scene, not a climax, and the piece should be explanatory rather than dramatic.
+
+**Famous-date check:** are you using a well-known date because it is well known? Check whether the state transition happened earlier and less visibly.
+
+**Denouement rule:** do not resolve. Re-state the new steady state — what is the objective function now, and what does the system now do to the same inputs? Refuse the prescriptive closing checklist unless the material contains one.
+
+## Domain Failure Profiles
+
+Domain transfer changes which failure dominates. Name yours in Step 1 and weight the checks accordingly.
+
+| Domain | Dominant local error | Extra check to run |
+|--------|---------------------|--------------------|
+| Market and financial history | Retrospective inevitability | Forecast-vs-outcome beat: a documented prediction from inside the material that turned out wrong |
+| Product / reliability post-mortems | Hindsight plus individual blame | Every blame sentence gets the authority-and-information test |
+| ML and research writeups | Intentional verbs on models; correlation laundered as mechanism | Verb sweep on "the model wants / knows / learned to"; ablation-vs-correlation typing |
+| Biography that is really institutional history | Systemic framing used to excuse the subject | Responsibility-laundering reverse check on every "the system" sentence |
+| Supply chain and logistics | A cherry-picked traversing unit presented as typical | State the unit's representativeness with a distributional fact |
+| Epidemiology and public health | Personifying the pathogen; war metaphor licensing fatalism | Agency ledger over disease-as-subject sentences specifically |
+
+## Guardrails
+
+**Requirements:**
+1. **Sequencing is hard**: character sheet → typed causal claims → node inventory → structure → scenes → prose. Never let scene selection precede claim typing. Every technique here makes systemic prose more compelling; none makes it more true, so drama-first selection produces competent, vivid, false causation.
+2. **Two regimes, always**: the character sentence needs behaviour across two distinct operating conditions. One episode is a description, not a trait.
+3. **Mandatory residual**: at least one outcome the objective function does not explain, present in the sheet and in the finished piece.
+4. **Cast disclosure is not optional**: state who talked, why, and who did not. A cast selected by who agreed to speak systematically flatters cooperative sources and indicts silent ones.
+5. **Relocate, do not delete**: post-pass agentless-passive count must not rise.
+6. **One partial success or one stated condition of change**: the institutions-as-Olympian-gods frame is a stance, not a discovery. Adopted by default it concludes every system is unreformable, which is teleology with the sign flipped.
+7. **Refusal is a valid output**: `NO DRAMATIC ENGINE`, `INSUFFICIENT GROUND-LEVEL MATERIAL`, and `UNSUPPORTED CHARACTER SENTENCE` are successful returns.
+
+**Common pitfalls:**
+- Functionalist overfit: reading every outcome as intended because the sheet asked what a designer would have optimised for
+- Gateway capture: the proxy human eats the system and the piece becomes a hero's arc
+- Manufactured epiphany: promoting an ordinary reading into a revelation and retro-fitting later knowledge into an earlier mind
+- Threshold fetish: treating one crossing as the moment the system changed when the underlying process was continuous
+- Unit anthropomorphism: the traveling object acquires wants ("the container sought the cheapest port")
+- Set dressing: sensory detail that evidences no line of the character sheet
+- Hedge fog: the anti-inevitability pass applied so thoroughly the piece asserts no causation at all
+- Structural residue: strand labels, rung tags, and "as we saw above" leaking from the planning artefact into the prose
+
+Numeric defaults in this skill (four traveling-object nodes, one personification per section, three-appearance strand minimum, five outcomes for the sheet) are operational thresholds derived for mechanisation, not published figures from any source. Treat them as tunable.
+
+## Quick Reference
+
+**Key resources:**
+- **[resources/posiwid-character-sheet.md](resources/posiwid-character-sheet.md)**: the eight fields in full, three filled examples across domains, the two-regime test, the reform-attempt ledger, the five-sentence billboard and its drift check
+- **[resources/agency-ledger.md](resources/agency-ledger.md)**: verb classification lists, the four repairs with paired bad/good examples, the banned-construction list, causal claim typing, the responsibility-laundering reverse check
+- **[resources/entry-points-and-peaks.md](resources/entry-points-and-peaks.md)**: gateway-proxy admission and capture tests, traveling-object constraints and gimmick test, instrumented threshold scene procedure, climax staging, sense-of-place extraction
+- **[resources/evaluators/rubric_systemic_protagonist.json](resources/evaluators/rubric_systemic_protagonist.json)**: quality scoring
+
+**Inputs required:**
+- A researched corpus with dated artefacts (documents, readings, transcripts, filings, logs)
+- The system's boundary in time and scope
+- A completed evidence ledger and form triage, if available
+- Charters, prospectuses, mission statements, or launch posts for the stated purpose
+
+**Outputs produced:**
+- POSIWID character sheet with citations, two-regime evidence, and the residual field
+- Gap sentence (the dramatic engine) or `NO DRAMATIC ENGINE`
+- Gateway roster with admission scores, deletion/ratio results, and the cast-selection disclosure
+- Traveling object with station list and representativeness statement
+- Threshold scenes and the selected climax type with transfer-function evidence
+- Agency ledger as a binding verb-constraint sheet for the drafting stage
+- Five-sentence billboard plus the drift-check diff

--- a/skills/systemic-protagonist/resources/agency-ledger.md
+++ b/skills/systemic-protagonist/resources/agency-ledger.md
@@ -1,0 +1,195 @@
+# The Agency Ledger
+
+A mechanical pass that finds sentences where a non-agentive subject takes an intentional verb, and forces a substitution that names the actual mechanism.
+
+The grounding claim: teleology enters through grammar. Subject-verb-object carries connotations of intent even in prose that is explicitly arguing against intent. So "the market wanted higher yields" is not a bad sentence. It is a false causal claim wearing a sentence.
+
+## Table of Contents
+- [What this pass is and is not](#what-this-pass-is-and-is-not)
+- [Verb classification](#verb-classification)
+- [The four repairs](#the-four-repairs)
+- [Banned without a named mechanism](#banned-without-a-named-mechanism)
+- [The post-pass check](#the-post-pass-check)
+- [The personification budget](#the-personification-budget)
+- [Causal claim typing](#causal-claim-typing)
+- [The responsibility-laundering reverse check](#the-responsibility-laundering-reverse-check)
+- [The inevitability audit](#the-inevitability-audit)
+
+## What this pass is and is not
+
+It is a CLAIM filter. It is not a purity filter.
+
+An agent told simply "don't anthropomorphise" overshoots into agentless passive prose, which is worse — passive voice obscures causation rather than clarifying it. Empirical work on anthropomorphism in science writing for non-experts found no measurable comprehension penalty and no significant misconception effect from anthropomorphic text, only that it was evocative and occasionally distracting.
+
+So the rule is not "remove agency." The rule is:
+
+> Relocate agency onto the entity that actually has it. Repair intentional verbs that assert false causation. Tolerate ones that are transparently figurative and locally unambiguous.
+
+## Verb classification
+
+Extract every sentence whose grammatical subject is a system, market, technology, institution, disease, algorithm, protocol, codebase, or abstraction. Classify the main verb.
+
+**(a) MECHANICAL — allowed.** rose, fell, cleared, settled, propagated, saturated, reallocated, queued, blocked, expanded, contracted, spread, accumulated, drained, routed.
+
+**(b) INTENTIONAL — must be repaired.** wanted, decided, chose, sought, aimed, tried, punished, rewarded, learned, realised, understood, refused, allowed, ignored, preferred, remembered, believed, knew.
+
+**(c) EVALUATIVE-TELEOLOGICAL — must be repaired.** matured, advanced, evolved toward, progressed, developed into, naturally moved to, grew up, came of age, found its footing, corrected itself.
+
+Class (c) is the sneakier one. It smuggles a value judgment and a direction of travel at the same time. "The standard matured" asserts that later is better and that the change was internally driven.
+
+## The four repairs
+
+Apply in preference order. The first that the material supports wins.
+
+### Repair 1 — NAME THE ACTOR
+
+Use when specific parties took specific actions.
+
+| Bad | Good |
+|-----|------|
+| "The market punished the sector." | "Three of the four largest holders sold into the bid across two sessions." |
+| "The board wanted a faster exit." | "Two directors, both from the 2019 preferred round, voted against the extension." |
+| "Regulators cracked down." | "The state banking department issued 14 consent orders in nine months, all naming the same disclosure clause." |
+
+### Repair 2 — NAME THE MECHANISM
+
+Use when a rule, price, schedule, or physical pathway did the work.
+
+| Bad | Good |
+|-----|------|
+| "The protocol wanted lower latency." | "The fee schedule paid 0.4 bps more on blocks confirmed inside 400 ms." |
+| "The scheduler prioritised long jobs." | "Jobs above 4 GB requested memory skipped the preemption queue, so they ran to completion while short jobs were evicted." |
+| "The disease targeted the lungs." | "The receptor the virus binds is densest in alveolar epithelium, so viral load concentrated there." |
+
+### Repair 3 — NAME THE SELECTION PRESSURE
+
+Use when the population shifted and nobody decided. Selection claims must never be written in intentional grammar. "The industry moved to X" is a selection claim disguised as a decision.
+
+| Bad | Good |
+|-----|------|
+| "The industry evolved toward outsourced fabrication." | "Firms that kept fabrication in-house lost 12 points of margin and exited by 1998; every survivor had outsourced." |
+| "Newsrooms learned to chase traffic." | "Sections whose pages fell below the traffic floor lost their staff line in the next budget; the sections that remained were the ones already above it." |
+| "The codebase converged on the async API." | "Modules still using the blocking API broke on every release after 4.2 and were rewritten or deleted; nobody wrote a migration policy." |
+
+### Repair 4 — QUOTE THE HUMAN
+
+Use when a person decided and the record names them. Name the person, the meeting, the date, and the document.
+
+| Bad | Good |
+|-----|------|
+| "The company decided to ship." | "Vargas approved the release at the 3 October go/no-go, over the objection recorded by the reliability lead in the same minutes." |
+| "The project decided to deprecate the plugin loader." | "Okonkwo closed the RFC on 12 March with 'we cannot support two loaders'; neither other committer with merge rights objected." |
+| "The agency chose not to inspect." | "The regional administrator's 2017 memo reassigned all four inspectors to permitting, citing the hiring freeze." |
+
+### When no repair is possible
+
+If none of the four can be made from the material, that is a RESEARCH GAP, not a style problem. Emit it as a gap entry:
+
+```
+AGENCY GAP
+  Sentence: "the exchange tightened margin requirements"
+  Needed:   who set the requirement, under what rule, on what date
+  Searched: rulebook amendments, board minutes, member notices
+  Status:   UNRESOLVED — do not draft this sentence
+```
+
+Do not substitute a metaphor for a missing mechanism. A metaphor in this slot reads as an explanation and is not one.
+
+## Banned without a named mechanism
+
+- "the market wanted / expected / demanded"
+- "the economy needed"
+- "the technology sought"
+- "incentives conspired"
+- "the system decided"
+- "nature designed"
+- "the model wants / knows / believes / learned to deceive"
+- "the algorithm figured out"
+- "the institution remembered"
+- "capital flowed to where it was treated best" (a metaphor doing the work of an argument)
+
+The ML case deserves separate emphasis because it is the most common live instance. "The model learned to X" is defensible only where X is a measured behaviour on a stated eval and the sentence says so. "The model wanted to X" is never defensible.
+
+## The post-pass check
+
+Mandatory. Count agentless passive constructions before and after the pass.
+
+Agentless passive means a passive with no by-phrase and no recoverable actor: "prices were observed to decline", "a decision was reached", "the threshold was lowered", "concerns were raised".
+
+If the count rose, the pass FAILED. You removed agency instead of relocating it. Go back and apply Repair 1 or Repair 4 to the sentences you passivised.
+
+Report as:
+
+```
+AGENCY LEDGER RESULT
+  Flagged intentional/teleological subjects: 34
+  Repaired by actor: 11  mechanism: 14  selection: 6  quote: 2
+  Unresolved research gaps: 1
+  Agentless passives before: 9   after: 7   VERDICT: PASS
+```
+
+## The personification budget
+
+At most one deliberate, flagged personification per major section. Two conditions:
+
+1. It is transparently figurative — no reader will mistake it for a causal claim.
+2. You can state in one line what mechanism it stands in for.
+
+An admissible one, in a piece about a legacy mainframe: "The batch window is the building's heartbeat." Stands in for: every downstream SLA is defined relative to the 02:00–05:30 job, per the operations runbook.
+
+Example of an inadmissible one: "The market lost patience with the sector" — stands in for nothing specific, and asserts a cause.
+
+The budget number is an operational default derived for mechanisation, not a published figure. Tune it.
+
+## Causal claim typing
+
+Type every causal claim before writing the sentence, and write the sentence in the grammar of its type.
+
+| Type | Definition | Grammar requirement |
+|------|-----------|---------------------|
+| **MECHANISM** | A described physical, contractual, or computational pathway from X to Y | Must state the DELAY |
+| **INCENTIVE** | X changed a payoff and named actors responded as documented | Must name the actors and cite the response |
+| **SELECTION** | Entities doing X survived, entities not doing X exited; the population shifted with nobody deciding | Never intentional grammar |
+| **CORRELATION** | X and Y moved together, pathway unknown | Sentence contains its own uncertainty and names at least one alternative explanation |
+| **ATTRIBUTION** | A named participant SAYS X caused Y | Narrated as a fact about the participant, never as mechanism |
+
+**Back-reference check.** No later reference may upgrade a claim's type. "As we saw, the fee change drove the migration" is illegitimate when the original claim was a correlation. This is the single most common integrity failure in long analytical narrative, and it is fully mechanical to detect: list every back-reference, find the original, compare types.
+
+**Aggregate check.** Count claim types. A systems piece dominated by ATTRIBUTION claims is a piece about what people believe about the system, not about the system. Retitle it or return to the material.
+
+## The responsibility-laundering reverse check
+
+"The system failed" is often a sentence written to avoid naming a person who made a decision. Personifying the pathogen as an invisible enemy let governments off the hook; the same move works on boards, agencies, and engineering orgs.
+
+Run this on every systemic attribution in the draft:
+
+1. Quote the systemic sentence.
+2. Ask: did a specific named actor have the AUTHORITY to do otherwise?
+3. Ask: did that actor have the INFORMATION to know it mattered, at the time, evidenced by a document dated at or before the decision?
+4. If both are yes, name them in the text. The systemic account stays; the name is added to it.
+5. If authority yes and information no, say that explicitly — it is a different and more interesting finding.
+6. If authority no, the systemic attribution stands, and you should say what the constraint was.
+
+Worked example:
+
+> Draft: "The warehouse management system had no way to flag expired lots, so expired product shipped for eleven months."
+>
+> Check: The 2018 vendor scoping document lists lot-expiry flagging as a deferred module, signed by the VP of operations. Authority: yes. Information: yes, the same document notes the compliance risk.
+>
+> Repaired: "The warehouse management system had no way to flag expired lots. The module that would have done it was scoped in 2018 and deferred by the VP of operations, whose sign-off page notes the compliance risk in one line. Expired product shipped for eleven months."
+
+Systemic explanation must be ADDITIVE to individual accountability, not a substitute for it. The reverse also holds: naming a person does not discharge the obligation to describe the constraint that made their decision the locally rational one.
+
+## The inevitability audit
+
+Run over every causal sentence. Systemic narrative and hindsight are natural allies, because in retrospect we situate an action against what actually followed, while the people at the time were projecting different futures.
+
+1. Extract every sentence containing: because, led to, resulted in, set the stage for, inevitably, was bound to, the seeds of, paved the way.
+2. For each: what did the actors AT THE TIME believe would happen? Cite a contemporaneous forecast, plan, budget, or projection.
+3. For each: name one live alternative genuinely available and being advocated by someone in the material.
+4. If no live alternative exists, say so explicitly and give the binding reason — a physical or accounting constraint. Do not leave overdetermination implied.
+5. Banned without a licence from step 3: "inevitably", "was always going to", "the writing was on the wall", "in retrospect it is obvious", "primitive", "advanced", "matured into", "the seeds of its own destruction".
+6. Replace with: "happened to", "persisted given", "survived the conditions of", "no one on the desk expected".
+7. Insert at least one FORECAST-VS-OUTCOME beat: a documented prediction from inside the material that turned out wrong, with the reasoning that made it reasonable at the time. This single move does more anti-inevitability work than any amount of hedging.
+
+**Overshoot check.** Does the piece contain at least one confidently asserted "X caused Y"? If not, the brake has become hedge fog. That is not honesty, it is abdication. The correct output is a small number of confidently asserted causal claims each with its counterfactual stated, not a large number of hedged ones.

--- a/skills/systemic-protagonist/resources/entry-points-and-peaks.md
+++ b/skills/systemic-protagonist/resources/entry-points-and-peaks.md
@@ -1,0 +1,207 @@
+# Entry Points and Peaks
+
+How a reader gets into a system, and how a system that has no battle gets a climax.
+
+## Table of Contents
+- [Gateway proxies](#gateway-proxies)
+- [The traveling object](#the-traveling-object)
+- [The instrumented threshold scene](#the-instrumented-threshold-scene)
+- [Climax by constraint violation](#climax-by-constraint-violation)
+- [Institutional sense of place](#institutional-sense-of-place)
+- [Node braid: when there is no single line](#node-braid-when-there-is-no-single-line)
+
+## Gateway proxies
+
+A human character is the reader's point of entry and emotional anchor. The subject remains the system. What makes a non-human subject relatable is a human gateway who cares about it and understands it.
+
+This is the most useful and most dangerous technique in the set. It is the engine of the best long-form systems journalism, and it fails exactly where it is most seductive: a hero's arc replacing a structural account, with a cast selected by who agreed to talk.
+
+### Admission test
+
+Run per candidate. Every question must be answered before the person gets a scene.
+
+1. **Which single line of the character sheet does this person evidence?** No line, no scene. One person, one line — a gateway assigned to three lines is a narrator, and narrators become protagonists.
+2. **PROXIMITY.** Were they physically or organisationally at the point where the system's behaviour was visible? A person who heard about it is a source, not a gateway.
+3. **MISCALIBRATION.** Did they start wrong and update? A gateway who was right from the start cannot dramatize learning. They can only be vindicated, which is a different and much weaker shape.
+4. **DOCUMENTATION.** Is their sequence of belief states recoverable from documents created at the time — notebooks, emails, commit messages, depositions, memos, order tickets? Recovered from a later interview, a belief sequence is a memory of a belief sequence, and memory reorders toward the outcome.
+5. **NON-REPRESENTATIVENESS RISK.** Would treating them as typical mislead? If yes, you must state the respect in which they are atypical.
+6. **The wrongness paragraph.** Have you written the paragraph stating what this person got wrong or could not see? This is the anti-hero-arc valve and it is mandatory.
+7. **Selection disclosure.** Have you stated in the text how they came to be in the story — volunteered, deposed, published, subpoenaed?
+
+### The arc is epistemic, not moral
+
+Write the gateway as: what they believed at t0 → what evidence hit them → what they believed at t1. The payload is the change in the model, not the change in the person.
+
+Bad: "Chen had always known something was wrong with the settlement window, and by that spring she could no longer stay silent."
+
+Good: "In January, Chen's own reconciliation memo attributes the breaks to a vendor timestamp bug. She reran the same query in April with the counterparty's file and found the breaks clustered on the two days a month the netting batch slipped past 16:00. Her May memo abandons the vendor theory in the first paragraph."
+
+### Capture tests, run on the draft
+
+**DELETION TEST.** Remove the gateway entirely. Does the systemic claim still stand on cited evidence? If not, the gateway is load-bearing and you have a character study, not a systems piece. Relabel it or go back to the material.
+
+**RATIO TEST.** Count paragraphs of gateway interiority against paragraphs of mechanism. If interiority wins in a piece titled as a systems piece, capture has occurred.
+
+**ABSENCE TEST.** List who declined to speak, refused, was unreachable, or was legally barred. Then check whether their absence flatters anyone. People who kept their mouths shut end up looking a lot better than their colleagues, purely because the writer's cast was assembled from volunteers. State this in the text. It is not a disclosure footnote, it is a finding about the evidence.
+
+Sample disclosure line: "Four of the six people on the desk that quarter spoke to us. The two who did not are the two named in the consent order; nothing here should be read as evidence that the four who talked were more responsible than the two who did not."
+
+### Borrowing a speaker
+
+Where the subject cannot speak, borrow a speaker and attribute the interpretation by name. Some person usually has to serve the function of speaking for the phenomenon — for the aquifer, for the protocol, for the failing subsystem. Attribute it; do not let their interpretation float as narration.
+
+Bad: "The aquifer had perhaps thirty years left."
+Good: "Ruiz, who has logged the district's wells since 1994, put it at thirty years at current draw, and said the number assumes no new permits."
+
+## The traveling object
+
+Instead of organising by chronology or by actor, follow a single unit as it traverses the system. The system is revealed by the sequence of places the unit passes through. Movement between stations supplies the transitions for free, which is the whole reason the technique works.
+
+The canonical newspaper instance is Rich Read's "The French Fry Connection", edited by Jack Hart, which explained the Asian financial crisis by following one load of Northwest potatoes from a Columbia Basin farm to Indonesia.
+
+### Choosing the unit
+
+Candidates: one container, one packet, one dollar of a fee, one blood sample, one wafer, one purchase order, one training batch, one building permit, one insurance claim, one bug report, one kilowatt-hour.
+
+Prefer units that are (a) countable, (b) traceable in the records, (c) transformed rather than merely relocated. Choose the one whose path crosses the most boundaries between subsystems. Boundaries are where the interesting behaviour is.
+
+### The four constraints
+
+1. It touches at least four distinct nodes of the system.
+2. At each node there is a NAMED human whose documented actions touch it.
+3. Its journey spans the time period the piece needs.
+4. Its representativeness is stateable with a distributional fact.
+
+Constraint 4 is the guard against path cherry-picking. Following one atypical unit and presenting its path as the system's typical behaviour is a quiet lie of enormous leverage. Required sentence form: "Roughly 70% of orders take this path; the exceptions are covered in section 4." If you cannot state the distribution, say that you cannot.
+
+### Station list
+
+Map the full path as a station list. Per station record: the transformation, the price or state change, the named humans, and the LOCAL objective function of that station (which is usually not the system's).
+
+Worked fragment, one blood sample through a diagnostic pipeline:
+
+| Station | Transformation | Local objective function |
+|---------|---------------|--------------------------|
+| Draw station | Whole blood into two labelled tubes | Patients per hour |
+| Courier | Tubes into a cooled tote, 40 min transit | On-time pickup rate |
+| Accessioning | Tube into a record with an ID | Accessioning error rate |
+| Analyser | Sample into a number | Instrument uptime |
+| Result release | Number into a flagged/unflagged result | Turnaround time |
+| Clinician inbox | Result into an action or no action | Inbox volume |
+
+The system's behaviour is legible in the mismatch between the six local objective functions and the sheet's global one.
+
+Completeness rule: follow the unit through to the point where it really matters. Do not stop at the boundary of your comfort or your sourcing. Name the last station you could verify and say why you stopped.
+
+### The unit is a camera, not an agent
+
+Do not give the unit intentions. "The container sought the cheapest port" reintroduces exactly the error the whole lens exists to prevent, through the back door of the device meant to avoid it. Its "point of view" means the sequence of environments it passes through, not desires. Run the agency ledger specifically over every sentence whose subject is the unit.
+
+### GIMMICK TEST
+
+Cut every traveling-object passage. If the explanation still stands complete, the device was decoration. Integrate it or remove it. A frame the piece returns to for atmosphere while the actual explanation happens elsewhere is worse than no frame, because it spends the reader's attention on nothing.
+
+## The instrumented threshold scene
+
+Abstract, slow, or diffuse forces become visible at the exact moment and place where a person or an instrument first registered them. The scene is built around the reading, the alarm, the anomalous number, the empty shelf, the first case — not around the force itself.
+
+### Procedure
+
+1. Search the material for FIRST-DETECTION events: the first measurement outside tolerance, the first customer complaint, the first failed settlement, the first sequenced sample, the first line in a log.
+2. Choose the one with the best combination of: precise timestamp, named human present, an attached NUMBER, a documented reaction.
+3. Write at instrument resolution. What did the screen, dial, spreadsheet, or shelf actually show? What were the units? What was the normal range? What did the observer do in the next ten minutes?
+4. State the THRESHOLD explicitly — the value at which the reading stopped being noise. If no threshold exists in the material, say so. Do not invent one.
+5. State whether the threshold is a property of the SYSTEM or of the MEASUREMENT.
+6. Climb exactly ONE rung: state what the reading was a reading OF, at system scale. Then stop. Do not climb two rungs at once.
+
+### The two failure modes
+
+**MANUFACTURED EPIPHANY.** Wanting a scene, a writer promotes an ordinary reading into a revelation and implies the observer understood the whole system at that moment. This retro-fits later knowledge into an earlier mind. Guard: the scene may contain only what the observer could know at that timestamp, and you must be able to cite a document created at or before that timestamp showing their actual interpretation.
+
+Bad: "At 03:12 Okafor saw the p99 spike to 4,200 ms and knew the retry storm had begun."
+Good: "At 03:12 the dashboard showed p99 at 4,200 ms against a band that had not left 240–310 ms in six weeks. Okafor's first message in the incident channel, at 03:14, says 'probably the flaky node again.' The retry loop was not named until 06:40."
+
+**THRESHOLD FETISH.** Treating one crossing as the moment the system changed, when the underlying process was continuous and the threshold was an artefact of the instrument's sensitivity. Required line, stated plainly: is this a property of the system or of the measurement? A grid frequency limit is a property of the system. A CVE severity cutoff of 7.0 is a property of the measurement.
+
+### When the material will not support a scene
+
+Emit `INSUFFICIENT GROUND-LEVEL MATERIAL` and downgrade to explanatory exposition. This technique requires artefacts. If the corpus is entirely secondary and abstract, attempting the scene induces invention — the model will generate plausible sensory detail fluently and verify none of it. Never generate sensory detail that is not in the source material.
+
+## Climax by constraint violation
+
+### The form gate comes first
+
+Before choosing a climax, ask: does the material contain a continuous sequence of actions by a consistent set of actors with a resolution?
+
+- **Yes** → story narrative is available.
+- **No** — which is the usual case for systemic subjects → choose EXPLANATORY NARRATIVE: a narrative line with frequent digressions into abstract context. Do not force an arc.
+
+Writers routinely have material that would be great for an explanatory narrative and try to turn it into a full-blown story narrative with an arc, a climax, and a denouement. They turn a potential silk purse into a sow's ear: great material, wrong structure. Returning "this material does not support an arc" is a successful outcome.
+
+### The five legitimate types
+
+| Type | Signature | Domain examples |
+|------|-----------|-----------------|
+| **LOOP FLIP** | A balancing loop becomes reinforcing, or vice versa | Contributor onboarding that had replaced departures starts consuming the reviewer time that made onboarding possible |
+| **BUFFER EXHAUSTION** | A slack resource reaches zero | Ward beds, spare transformers, chassis pool, maintainer hours, deferred-maintenance budget |
+| **CONSTRAINT BINDING** | A limit that never mattered starts setting the outcome | Interconnection queue length replaces land cost as the thing that decides where generation gets built |
+| **IRREVERSIBILITY** | An option is destroyed | A plant closes, a signing key is lost, a format locks in, a seed bank burns, the last person who understood the batch job retires |
+| **LEGIBILITY** | The stated/revealed gap becomes undeniable to insiders, evidenced by a document | The internal deck that states the real objective function in plain language |
+
+Whichever type you pick, stage it as an instrumented threshold scene: specific timestamp, specific place, specific number, specific named witness.
+
+### The tests
+
+**TRANSFER-FUNCTION TEST.** After the climax, do the same inputs produce different outputs? If no, it is a scene, not a climax, and the piece should be explanatory rather than dramatic. State the before and after transfer function explicitly in your working notes:
+
+```
+Before: a 200-basis-point rate move produced 3-5 days of elevated settlement fails
+After:  the same move produces 12-20 days, because the two dealers who absorbed
+        the imbalance in 2019 no longer make markets in the instrument
+```
+
+**ARC-FORCING CHECK.** The most common manufacture is promoting a person's dramatic moment into the system's turning point. That produces hero/villain flattening of a diffuse process. Ask: did the system's behaviour change, or did one person's day change?
+
+**FAMOUS-DATE CHECK.** Are you using a well-known date because it is well known? Check whether the state transition actually happened earlier and less visibly. The famous date is usually the day the transition became public, which is a fact about disclosure, not about the system.
+
+### Denouement
+
+Do not resolve. Re-state the new steady state: what is the objective function now, and what does the system now do to the same inputs?
+
+Refuse the prescriptive ending. Closing checklists of solutions are usually self-contradictory and usually not in the material. If the material genuinely contains a remedy that was tried and held, that is a finding and belongs in the reform-attempt ledger, not in a closing sermon.
+
+## Institutional sense of place
+
+Abstract power is rendered by describing, at physical resolution, the rooms and objects and geographies where it operated.
+
+1. For each key decision or state change, locate the PHYSICAL SITE: the room, the floor, the terminal, the exchange, the plant, the server hall.
+2. Interrogate the material with the literal extraction prompt — WHAT WOULD I SEE? — against transcripts, depositions, memoirs, photographs, floor plans, filings. Extract: light, sound, who sat where, what was on the walls, what the paperwork physically looked like, how long the walk was, what was on the screens.
+3. Render the site BEFORE the decision, so the reader occupies the space in which it was made.
+4. Show power through the powerless. Find the person at the far end of the system's output and let them testify in their own words at ground level.
+5. For a number too large to feel, give it a FORM — a list, a catalogue, a physical comparison — not an adjective.
+
+**LOAD-BEARING TEST.** For each descriptive passage, name the character-sheet line it evidences or the comprehension problem it solves. Neither, cut. Otherwise you get set dressing: novelistic padding around a thin analysis.
+
+**SYNECDOCHE GUARD.** Pair every ground-level testimony with the distributional fact. One vivid case standing for a heterogeneous distribution is a real distortion, and it is undetectable to the reader. "Of the roughly 250,000 displaced, this block's experience was typical in X and atypical in Y."
+
+Never let the place description carry an argument the evidence does not support. The site's job is to make the reader present, not to imply guilt by décor.
+
+## Node braid: when there is no single line
+
+For a system with no single storyline, compose the piece from viewpoint nodes — people, places, instruments, documents, transactions — braided rather than sequenced.
+
+1. **Centrepiece first.** The single most consequential moment or state of the system. Everything else is positioned relative to it.
+2. **Inventory nodes.** Per node: which character-sheet line it evidences, its time coordinate, its scale (individual / firm / market / era), its viewpoint holder.
+3. **Reject** any node duplicating an admitted node's character-sheet line without adding a new scale or a new time.
+4. **Group into three or four strands**, each with a stated job. Usual set: MECHANISM, HUMAN CONSEQUENCE, CHRONOLOGY, and optionally COUNTER-EVIDENCE. Fewer than three collapses into a linear report; more than four exceeds reader tracking.
+5. **Question pairs at every cut.** Write, before drafting, the question the previous strand raised and the question the new one opens. No cut without a question pair.
+6. **Re-orientation clause** in the first sentence of every strand switch: time, place, strand.
+7. **Name the convergence beat** in advance. If you cannot name the beat where all strands meet, they are parallel, not braided, and the piece will read as three articles stapled together.
+
+**ORPHAN CHECK.** Any strand appearing fewer than three times, or absent from the final third, is orphaned. Promote it or cut it entirely.
+
+**ADJACENCY CHECK.** For any two adjacent nodes from different causal domains, state explicitly whether a causal link is being claimed. Unstated adjacency will be read as causation. Placing a node about a layoff next to a node about a stock buyback claims something whether you meant it or not.
+
+**NO SCAFFOLDING IN THE PROSE.** Strand labels, node IDs, and "as we saw above" are planning instruments. They must not appear in the finished text. Readers are not supposed to notice the structure; a piece that shows its braid reads as an outline that learned to talk.
+
+The strand counts and appearance minimums here are operational defaults derived for mechanisation, not published figures.

--- a/skills/systemic-protagonist/resources/evaluators/rubric_systemic_protagonist.json
+++ b/skills/systemic-protagonist/resources/evaluators/rubric_systemic_protagonist.json
@@ -1,0 +1,102 @@
+{
+  "name": "Systemic Protagonist Rubric",
+  "description": "Evaluation criteria for rendering a system as a legible protagonist without faking agency: character-sheet rigour, agency repair, gateway discipline, perceptibility, climax legitimacy, and accountability.",
+  "criteria": [
+    {
+      "name": "Revealed Objective Function Rigour",
+      "description": "Whether the character sentence is derived from outcomes across multiple regimes with citations, rather than from rhetoric or a single episode",
+      "weight": 1.3,
+      "scores": {
+        "1": "No character sentence, or the revealed purpose is just the stated purpose restated",
+        "2": "Character sentence asserted with no outcome list or citations",
+        "3": "Outcome list present with citations, but the sentence rests on a single regime or episode",
+        "4": "Character sentence supported by cited behaviour in two distinct regimes; constraints and loops documented",
+        "5": "Two-regime support plus per-loop delay and quantity, constraints sourced individually, and a stated result code (confirmed / unsupported / regime split)"
+      }
+    },
+    {
+      "name": "Residual and Overfit Control",
+      "description": "Whether outcomes the objective function fails to explain are named, classified, and carried into the finished piece",
+      "weight": 1.2,
+      "scores": {
+        "1": "Every outcome is read as intended; the system is written as a coherent malign optimiser",
+        "2": "Residual field left empty or filled with a token disclaimer",
+        "3": "At least one unexplained outcome named, but it does not appear in the finished piece",
+        "4": "Unexplained outcomes named, classified as incompetence / path dependence / noise, and present in the piece",
+        "5": "As 4, plus the fit is explicitly interrogated — the analysis states what would falsify the character sentence and shows it was checked"
+      }
+    },
+    {
+      "name": "Agency Repair Quality",
+      "description": "Whether intentional and teleological verbs on non-agentive subjects were relocated to real actors, mechanisms, or selection pressures rather than deleted",
+      "weight": 1.3,
+      "scores": {
+        "1": "Systems want, decide, learn, and punish throughout; no ledger run",
+        "2": "Some flagged verbs removed, but replaced with agentless passives; the post-pass passive count rose",
+        "3": "Most intentional verbs repaired; repairs skew to one type and some are vague ('incentives shifted')",
+        "4": "All flagged verbs repaired using the four named repairs; agentless passive count did not rise; unrepairable ones logged as research gaps",
+        "5": "As 4, plus claim typing applied (mechanism / incentive / selection / correlation / attribution) with a back-reference check showing no type upgrades, and a personification budget honoured with each instance's mechanism stated"
+      }
+    },
+    {
+      "name": "Gateway Discipline and Cast Disclosure",
+      "description": "Whether human entry points stay probes rather than protagonists, and how the cast came to be assembled is stated in the text",
+      "weight": 1.2,
+      "scores": {
+        "1": "The piece is a hero's arc with systemic vocabulary; no admission test, no disclosure",
+        "2": "Gateways admitted informally; no wrongness paragraph and no statement of who declined",
+        "3": "Gateways mapped to character-sheet lines and a wrongness paragraph written, but no deletion or ratio test",
+        "4": "Full admission test run including miscalibration and contemporaneous documentation; deletion and ratio tests reported; who declined is stated",
+        "5": "As 4, plus the absence check is analysed — the text says whether the silence of non-participants flatters anyone, and gateway arcs are written epistemically rather than morally"
+      }
+    },
+    {
+      "name": "Perceptibility Without Invention",
+      "description": "Whether abstract forces are made visible through sourced instrument-resolution scenes constrained to contemporaneous knowledge",
+      "weight": 1.1,
+      "scores": {
+        "1": "Sensory detail generated that is not in the source material",
+        "2": "Scenes drawn from material but retro-fit later understanding into the observer's mind at the time",
+        "3": "Scenes sourced and time-constrained, but no threshold stated or no units and normal range given",
+        "4": "Instrument resolution with units, normal range, threshold, and a contemporaneous document evidencing the observer's actual interpretation",
+        "5": "As 4, plus the threshold is classified as a property of the system or of the measurement, and a traveling object with representativeness stated and the gimmick test passed"
+      }
+    },
+    {
+      "name": "Climax and Form Legitimacy",
+      "description": "Whether the peak is a real state transition of the chosen type, or an arc was refused when the material did not support one",
+      "weight": 1.2,
+      "scores": {
+        "1": "An arc forced onto material that does not support one; a person's dramatic moment promoted to the system's turning point",
+        "2": "A climax chosen but of no named type and with no evidence of a state change",
+        "3": "One of the five legitimate types chosen and staged with a timestamp and a witness",
+        "4": "Type chosen, staged concretely, and the transfer-function test passed with before/after stated; famous-date check run",
+        "5": "As 4, plus the form gate is documented, refusal was genuinely available, the denouement re-states the new steady state rather than resolving, and no prescriptive ending was appended"
+      }
+    },
+    {
+      "name": "Accountability and Anti-Fatalism",
+      "description": "Whether systemic framing is additive to named responsibility, and whether the piece admits that the system has ever changed",
+      "weight": 1.2,
+      "scores": {
+        "1": "Systemic framing used to avoid naming decision-makers; every reform attempt fails and unreformability is the conclusion",
+        "2": "One of the two problems present: either no reverse check or no partial success",
+        "3": "Reverse check run on some systemic attributions; at least one reform attempt described",
+        "4": "Every systemic attribution tested for authority and information with named actors added where both hold; at least one partial success or a stated condition of change",
+        "5": "As 4, plus the reform-attempt ledger records what would have had to be different for each attempt to hold, and the inevitability audit includes a forecast-vs-outcome beat"
+      }
+    },
+    {
+      "name": "Artefact Hygiene and Refusal Handling",
+      "description": "Whether planning scaffolding stays out of the prose and whether refusal codes are used honestly when the material is thin",
+      "weight": 1.0,
+      "scores": {
+        "1": "Strand labels, rung tags, and sheet references leak into the prose; thin material papered over with invention",
+        "2": "Some scaffolding removed; no refusal codes considered even where the corpus was clearly abstract",
+        "3": "Prose is clean of scaffolding; refusal codes available but not exercised",
+        "4": "Scaffolding removed, and NO DRAMATIC ENGINE / INSUFFICIENT GROUND-LEVEL MATERIAL / UNSUPPORTED codes used where warranted, with reasons",
+        "5": "As 4, plus billboard drift check run against the finished evidence with any change surfaced to the human as a decision, and every admitted scene traced to a character-sheet line"
+      }
+    }
+  ]
+}

--- a/skills/systemic-protagonist/resources/posiwid-character-sheet.md
+++ b/skills/systemic-protagonist/resources/posiwid-character-sheet.md
@@ -1,0 +1,184 @@
+# The POSIWID Character Sheet
+
+The system gets a character sheet the way a novelist gives one to a person. The fields are different: objective function, constraints, feedback loops, blind spots, and behaviour under stress.
+
+Attribution note. POSIWID — "the purpose of a system is what it does" — is Stafford Beer's formulation. The working phrasing used here, that purposes are deduced by an observer from behaviour rather than from rhetoric or stated goals, is Donella Meadows in *Thinking in Systems*. Do not attribute the acronym to Meadows, and do not present either as a quoted rule you have not checked.
+
+## Table of Contents
+- [The eight fields, in order](#the-eight-fields-in-order)
+- [The two-regime test](#the-two-regime-test)
+- [Functionalist overfit and the residual field](#functionalist-overfit-and-the-residual-field)
+- [Three filled examples](#three-filled-examples)
+- [The reform-attempt ledger](#the-reform-attempt-ledger)
+- [Character dimensioning: the system translation](#character-dimensioning-the-system-translation)
+- [The stated-vs-revealed billboard](#the-stated-vs-revealed-billboard)
+
+## The eight fields, in order
+
+**Field 1 — Outcomes.** List every outcome the system reliably produced over the period covered. Outcomes, not intentions. Each carries a citation and a date. Five is the working minimum; fewer usually means the window is too short.
+
+Do not list events. List outcomes that recurred. "The exchange halted on 6 May 2010" is an event. "Retail orders routed through the exchange were filled at worse prices than institutional orders in 11 of 12 quarters" is an outcome.
+
+**Field 2 — The character sentence.** Ask what a designer would have had to be optimising for to produce exactly this outcome set. Write it as one sentence:
+
+> This system reliably converts ___ into ___.
+
+Examples across domains:
+- A municipal permitting office: "converts applicant persistence into approvals, and applicant inexperience into indefinite delay."
+- A package registry: "converts download counts into maintainer obligation, without converting either into maintainer income."
+- A regional grid operator: "converts winter peak demand into fuel-cost pass-through, and converts transmission scarcity into siting decisions nobody voted on."
+
+The sentence is the character. Everything downstream is evidence for it or against it.
+
+**Field 3 — Constraints.** Physical, legal, capital, information, latency, headcount. Per constraint: what it is, what it binds, and where it is documented. An undocumented constraint is a hypothesis, and must be labelled as one.
+
+**Field 4 — Feedback loops.** Per loop record three things: reinforcing or balancing, the quantity that closes the loop, and the delay. Delay is the field most often skipped and the one that most often explains why a piece feels wrong. Systems stories go wrong at the timescale: causes and effects separated by months read as unrelated, and effects that arrive instantly are usually not caused by the thing that just happened.
+
+**Field 5 — Blind spots.** What does the system not measure, and therefore not respond to? This field is where the surprises in your piece live. A hospital that measures length of stay but not readmission. A CI pipeline that measures test pass rate but not flake rate. A port that measures container throughput but not dwell time on the chassis.
+
+**Field 6 — Stated purpose.** Quoted verbatim from a real document: charter, prospectus, mission statement, README, standards RFC, launch post, enabling legislation. Paraphrase fails this field. You need the exact words because sentence 2 of the billboard quotes them.
+
+**Field 7 — The gap.** One sentence naming the difference between Field 6 and Field 2. This is the dramatic engine.
+
+If there is no gap — if the system does roughly what it says it does — emit `NO DRAMATIC ENGINE` with the evidence. That is a legitimate and under-written finding. The options are: choose a different subject, widen the time window until a regime change appears, or write it as explanation rather than narrative. Do not manufacture a gap by reading the stated purpose uncharitably.
+
+**Field 8 — The residual.** Which outcomes does the revealed objective function FAIL to explain? At least one entry is mandatory. See below.
+
+## The two-regime test
+
+A revealed objective function inferred from a single episode is a description of that episode wearing a character trait's clothes.
+
+Require behaviour in at least two distinct regimes:
+
+| Domain | Regime A | Regime B |
+|--------|----------|----------|
+| Market or exchange | Rising liquidity | Stress or halt |
+| Public agency | Funded, staffed | Budget cut, hiring freeze |
+| Open-source project | Corporate sponsorship active | Sponsorship withdrawn |
+| Supply chain | Slack capacity | Capacity binding |
+| Hospital or clinic | Normal census | Surge |
+| Codebase | Feature growth | Freeze or migration |
+
+Procedure: state the character sentence, then show that it predicts observed behaviour in both regimes. If the system converts A into B during expansion but converts A into C under stress, you have two characters and must either narrow the period or make the regime switch itself the subject.
+
+Result codes: `TWO-REGIME CONFIRMED` (cite both), `SINGLE REGIME — UNSUPPORTED` (go back to the material), `REGIME SPLIT` (the switch is your story).
+
+## Functionalist overfit and the residual field
+
+The sheet asks what a designer would have optimised for. That question quietly invites you to read every outcome as intended. A system that was merely incompetent, path-dependent, or unlucky then gets written as a coherent malign optimiser — which is a more satisfying story and a worse account.
+
+Detection: if the character sentence explains 100% of the outcome list with zero residual, it is fitted noise.
+
+Countermeasure, mandatory: Field 8 carries at least one outcome the objective function does not explain, and that outcome must appear in the finished piece. Name which of the three it is:
+
+- **Incompetence** — the outcome served nobody, including the system's own beneficiaries
+- **Path dependence** — the outcome follows from a decision made under conditions that no longer obtain
+- **Noise** — the outcome did not recur, and the record shows no mechanism
+
+Worked example. A national vaccine registry converts local reporting effort into national coverage statistics. Residual: between 2016 and 2019 it also produced duplicate records at a rate of roughly 4%, serving nobody, traceable to two counties that had merged their case-management systems and never reconciled the identifiers. That is path dependence, not design, and saying so is what keeps the character sentence honest.
+
+## Three filled examples
+
+### Example A — A container port (supply chain)
+
+| Field | Entry |
+|-------|-------|
+| Outcomes | Berth productivity rose 18% 2015–2021; truck turn times rose from 41 to 96 minutes; chassis dwell doubled; three drayage firms of nine exited |
+| Character sentence | Converts vessel-side efficiency into landside queueing, and converts drayage-firm working capital into terminal buffer |
+| Constraints | Berth count (physical, port authority filings); labour agreement crane-hours (legal, contract text); gate hours (regulatory) |
+| Loops | Reinforcing: faster discharge → more boxes on yard → longer truck turn → more boxes on yard. Quantity: yard utilisation. Delay: 2–5 days |
+| Blind spots | Does not measure driver wait time; measures moves per crane hour |
+| Stated purpose | Port authority charter: "to promote the efficient movement of commerce through the harbor" |
+| Gap | The charter's "commerce" stops at the fence line; the measured objective function stops at the crane |
+| Residual | The 2019 chassis shortage was national and hit ports with the opposite yard policy equally. Not explained by this objective function |
+
+### Example B — A hospital sepsis protocol (health system)
+
+| Field | Entry |
+|-------|-------|
+| Outcomes | Time-to-antibiotic fell 31%; ICU transfers unchanged; alert volume rose 6x; nurse override rate reached 71% by month 14 |
+| Character sentence | Converts documented alert compliance into audit-passing records, and converts clinician attention into override clicks |
+| Constraints | EHR vendor alert framework (technical); reporting requirement (regulatory); night-shift staffing ratio (headcount) |
+| Loops | Balancing: alert fires → override → threshold unchanged → alert fires. Quantity: override rate. Delay: minutes |
+| Blind spots | Does not measure whether the override was correct |
+| Stated purpose | Quality committee minutes: "to ensure every patient meeting sepsis criteria receives antibiotics within one hour" |
+| Gap | The protocol optimised the documented hour, not the patient selection |
+| Residual | Two units achieved both faster antibiotics and lower ICU transfer. The objective function does not explain them. Both had a dedicated response nurse, which the protocol never specified |
+
+### Example C — A programming-language package registry (software)
+
+| Field | Entry |
+|-------|-------|
+| Outcomes | Package count grew 9x in six years; median time-to-patch for critical CVEs stayed near 19 days; four of the top-50 packages had a single maintainer for the whole period; two typosquat incidents |
+| Character sentence | Converts download counts into maintainer obligation, without converting either into maintainer income |
+| Constraints | Storage and bandwidth cost (capital); namespace immutability (design, documented in RFC); one paid staff member (headcount) |
+| Loops | Reinforcing: popularity → dependents → issue load → maintainer burnout → transfer or abandonment → supply-chain surface |
+| Blind spots | Does not measure maintainer count per package or bus factor |
+| Stated purpose | Launch post: "a place to share and reuse code, freely, forever" |
+| Gap | "Freely" was priced for consumers and not for producers |
+| Residual | The two typosquat incidents were both caught within 48 hours by unpaid volunteers with no formal role. The objective function predicts nobody would look |
+
+## The reform-attempt ledger
+
+Systemic subjects are dramatized by people who push against them and reveal the shape of the wall. Extract every reform attempt in the material — failed, partial, and successful.
+
+Per attempt record:
+1. What they tried to change
+2. Which constraint or feedback loop they were actually pushing against (name the field number)
+3. What the system did in response
+4. How long the change persisted
+5. What would have had to be different — which loop, which constraint, which measurement — for it to hold
+
+Select two or three attempts that push against DIFFERENT constraints. These become probe arcs. Write each to end at the constraint, not at a moral verdict. The payload is the shape of the wall, not the character's virtue.
+
+**Balance requirement, mandatory.** At least one attempt that partially worked, or an explicit statement of the conditions under which this system has changed historically.
+
+Why this is not optional: the institutions-as-Olympian-gods frame is powerful precisely because it is a stance, not a discovery. Adopted as a default it concludes that every system is unreformable — which is the same error as the inevitable march of progress, with the sign flipped. Outcome treated as foreordained is teleology either way. If every probe arc in your piece fails, the frame has become the argument rather than the finding.
+
+Refuse the redemption default too. Do not grant a person a transformation the record does not show.
+
+## Character dimensioning: the system translation
+
+A longer reporting instrument, adapted from Hart's character checklist. Roughly 90% never appears in the prose; it exists so the 10% that does appear is chosen rather than defaulted. Fill from material only. Empty slots stay empty and go to the gap register.
+
+| Person slot | System translation |
+|-------------|--------------------|
+| Physical distinguishing traits | Observable signatures: a characteristic latency, a fee structure, a seasonal shape, a recurring failure mode |
+| Education and work history | Origin and design lineage: what it was built from, and what it was built against |
+| Enemies, and why | Competing systems, substitutes, regulators, adversaries — with the why |
+| Present problem | The binding constraint right now |
+| Greatest fear | The failure the system is architected to avoid |
+| How the problem gets worse | The trend that breaks the current equilibrium |
+| Strongest / weakest trait | What it does better than any alternative / its structural fragility |
+| Sees self as vs. seen as | Stated purpose vs. revealed function. The richest slot; often generates the whole piece |
+| Speech tags and idioms | The system's characteristic vocabulary and its euphemisms |
+| Description of home | The physical and institutional environment, and the feel of it |
+
+Warning: this is a REPORTING instrument, not a generation template. A fluent model will invent a "greatest fear" for a payments network from priors. If the record does not answer the slot, the slot stays blank.
+
+## The stated-vs-revealed billboard
+
+The systemic nut graf. Five sentences, in this order, placed after the opening concrete scene:
+
+1. Name the system and its boundary in time and scope.
+2. Its stated purpose, quoted from a real document.
+3. Its revealed objective function, from Field 2.
+4. The consequence of the gap, with one number.
+5. The basis of the account — what evidence the reader is about to be shown, and its limits.
+
+**Contract rule.** Every later section must be traceable to one of the five sentences. Sections that are not traceable are cut, or the billboard is wrong.
+
+**Anti-tease rule.** The billboard states the finding. Withholding it to build suspense is a fiction move that damages analytical credibility.
+
+**Anti-false-balance rule.** Refuse "the truth is complicated." If the material does not support a gap, the honest billboard says the system did roughly what it claimed.
+
+**Drift check (last step before delivery).** Re-derive the billboard from the finished draft's evidence. Diff it against the version written in Step 5. Any change must be surfaced to the human explicitly, because it usually means the research changed the finding and nobody noticed. Report as:
+
+```
+BILLBOARD DRIFT
+  Sentence 3 (revealed objective function)
+  Written:  converts applicant persistence into approvals
+  Derived:  converts applicant legal representation into approvals
+  Cause:    fields 1 and 5 updated after the 2019 case file was added
+  Action:   REQUIRES HUMAN DECISION — the thesis changed
+```

--- a/skills/writing-structure-planner/SKILL.md
+++ b/skills/writing-structure-planner/SKILL.md
@@ -13,7 +13,7 @@ description: Guides writing architecture planning using McPhee's structural diag
 - [Guardrails](#guardrails)
 - [Quick Reference](#quick-reference)
 
-**Related skills:** Use `writing-revision` for revising existing prose, `writing-stickiness` for memorable messaging, `writing-pre-publish-checklist` for final quality checks.
+**Related skills:** Use `mcphee-structure-derivation` first when you hold a raw research corpus and no structure yet. It runs McPhee's coding-and-sorting pass to derive and name a shape. It then hands the sorted components here, for diagramming and gold-coin placement. Use `writing-revision` for revising existing prose, `writing-stickiness` for memorable messaging, `writing-pre-publish-checklist` for final quality checks.
 
 ## Core Principles
 


### PR DESCRIPTION
Adds a 2-agent narrative team and the 13-skill toolkit underneath it. Domain-agnostic — works when the protagonist is a person and when it is a market, protocol, institution, codebase, or supply chain.

| Agent | Consumes | Emits |
|---|---|---|
| `narrative-architect` | A researched corpus | A validated architecture. Never drafts. |
| `scenewright` | An architecture + its claims | Prose, a citation map, a subtraction log. Escalates what it cannot fix. |

Together with the existing `writing-assistant`, these form a three-agent writing team, grouped as contiguous rows in the Orchestrating Agents table so they can be pulled in together.

## The problem being solved

Truby gives you 22 slots: the hero, the flaw, the enemy, the turning point. Hand a model 22 empty slots and a pile of research and it fills all 22 — whether or not the research supports them. An empty slot reads as unfinished work, so the model finishes it. The output reads well and is partly invented.

Everything here is downstream of stopping that.

## Load-bearing decisions

**Structure selection is a refusal gate, not a mapping step.** `DO NOT NARRATE` is a first-class success with its own deliverable, plus a five-rung downgrade ladder where each rung ships a research-request list for the rung above. A refusal that returns nothing gets re-prompted with "just try anyway", which is how a careful agent gets talked into the failure it was built to prevent.

**A two-phase wall.** Truby derives backward from the ending. Deriving backward from a *known* ending is precisely how teleology enters — it manufactures a starting deficiency chosen to make the ending look inevitable. So: Phase 1 builds the fact inventory outcome-blind and freezes it; Phase 2 derives over the frozen set, and every backward-filled slot needs a source predating the outcome. The diff between starting hypothesis and derived spine ships with the artifact.

**The guardrail is a validator, not a sentence.** "Never draft prose" decays as context fills; a character cap does not. `validate_architecture.py` enforces three things a prompt can only request:

| Enforced | Prevents |
|---|---|
| `evidence[]` non-empty, not `value` | A fluent sentence standing in for a finding |
| `status: ABSENT` passes; all-filled warns | 22 slots producing 22 inventions |
| Hard cap on scene lines | The macro agent quietly drafting |

16 mutation tests, 16 caught.

**Rigor is typing, not hedging.** Causal claims carry L1–L5 tiers with permitted verbs per tier, so the epistemic status rides in the annotation while the sentence still reads like English. Over-hedged output gets switched off wholesale; that is a documented failure, not a hypothetical.

## On McPhee

`mcphee-structure-derivation` fills a genuine gap. `writing-structure-planner` carries McPhee's eight finished shapes and his principles, but not his coding-and-sorting *procedure* — code every chunk, sort by chronology and by theme, resolve the disagreements, name the shape. That procedure is the step that turns a research pile into a spine, and it is what you need when the material has no dramatic engine at all, which is the normal case for analytical corpora. It derives, then hands off to the existing skill for diagramming.

## How it was built

A nine-lens research sweep (132 techniques, 79 checklists, 145 sources) covering Truby, Hart, the wider nonfiction canon, data narrative, systemic protagonists, narrative-fallacy red-teaming, nonfiction ethics, explanatory structures, and agent-authoring practice. Each skill was written against its own lenses' **warnings** — the sections describing how a skill built on that material goes wrong — with a rule that every applicable warning must be answered by something in the skill.

Then cross-audited. Four blocking defects fixed, including two uncited claims dressed as published findings, inside skills whose entire job is catching exactly that. Twelve overlaps and nineteen missing cross-references resolved, including a real correctness bug where two skills carried incompatible likelihood lexicons.

## Verified

- 13 SKILL.md files, all under the 300-line house limit, all with rubrics
- Every resource link and deep anchor resolves
- Every skill declared in agent frontmatter is explicitly invoked at a named pipeline step
- Both agent descriptions under 1024 chars; all tools survive the background-subagent filter
- README counts consistent: 261 skills, 75 agents

## Known gap

**Not benchmarked against a no-agent baseline.** Shipping first was a deliberate call. The eval set — three domains × three corpus conditions (real arc / thin evidence / no story), measuring slot-warrant rate, fabricated-detail rate, and false-refusal rate — is the next piece of work. Worth knowing before anyone downloads this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sjxvex2RAY2VPPAs8xSuAh
