### PR TITLE
Add reader-first-prose skill (generic writing lens)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Skills](https://img.shields.io/badge/skills-261-blue) ![Agents](https://img.shields.io/badge/agents-75-blue) ![Status](https://img.shields.io/badge/status-active-brightgreen) [![Run in Smithery](https://smithery.ai/badge/skills/lyndonkl)](https://smithery.ai/skills?ns=lyndonkl&utm_source=github&utm_medium=badge)
 
-A production-ready library of **261 skills** and **75 orchestrating agents** for Claude Code — covering thinking frameworks, research, writing, design, data/ML, corporate finance, game theory, fantasy baseball, an evolutionary 10-agent FIFA World Cup fantasy backroom, household personal finance, a 9-agent team for growing a Substack publication, and a 9-agent learning studio for becoming a contributor to ML-driven crop genetics / genomic selection. Also included: five reusable primitives for gated, verifiable research pipelines, and a 3-agent narrative team that turns researched evidence into structured long-form nonfiction.
+A production-ready library of **262 skills** and **75 orchestrating agents** for Claude Code — covering thinking frameworks, research, writing, design, data/ML, corporate finance, game theory, fantasy baseball, an evolutionary 10-agent FIFA World Cup fantasy backroom, household personal finance, a 9-agent team for growing a Substack publication, and a 9-agent learning studio for becoming a contributor to ML-driven crop genetics / genomic selection. Also included: five reusable primitives for gated, verifiable research pipelines, and a 3-agent narrative team that turns researched evidence into structured long-form nonfiction.
 
 **Install in 30 seconds:**
 
@@ -65,7 +65,7 @@ flowchart LR
     D -->|Plan a conference| CONF[conf-director<br/>+ 5 specialists]
     D -->|Gated research pipeline| RP[market-era-historian<br/>series-archaeologist<br/>mechanism-analyst<br/>claim-verifier<br/>stage-auditor]
     D -->|One-off tool| SK[Skills Index ▾]
-    CA & PS & WA & NA & SF & CD & MLB & WC & HF & GR & GDL & MI & LSC & BIO & CONF & RP --> S[(261 skills)]
+    CA & PS & WA & NA & SF & CD & MLB & WC & HF & GR & GDL & MI & LSC & BIO & CONF & RP --> S[(262 skills)]
     SK --> S
 ```
 
@@ -181,7 +181,7 @@ If you run `product-strategist` without `pandoc` or `xelatex` installed, the age
 
 ## Skills Index
 
-**261 skills** across 8 super-categories. Every skill's full methodology, templates, and evaluation rubric live in its `SKILL.md` — click any entry to drill in.
+**262 skills** across 8 super-categories. Every skill's full methodology, templates, and evaluation rubric live in its `SKILL.md` — click any entry to drill in.
 
 <details>
 <summary><b>🧠 Thinking & Decisions</b> — decision-making, problem-solving, estimation, dialogue, ideation, learning (37 skills)</summary>
@@ -277,7 +277,7 @@ Domain-neutral primitives for any weekly paper-digest workflow. Powers the `lite
 </details>
 
 <details>
-<summary><b>✍️ Communication & Writing</b> — writing pipeline, narrative architecture and craft, scientific writing, audience adaptation, analyst voice, PDF rendering (28 skills)</summary>
+<summary><b>✍️ Communication & Writing</b> — writing pipeline, narrative architecture and craft, scientific writing, audience adaptation, analyst voice, PDF rendering (29 skills)</summary>
 
 ### General writing
 
@@ -292,7 +292,7 @@ Domain-neutral primitives for any weekly paper-digest workflow. Powers the `lite
 - **[strategist-voice](skills/strategist-voice/SKILL.md)** — Apply the analyst-grade house style for long-form strategist reports: no em dashes, footnoted citations, opinion via phrasing.
 - **[markdown-to-pdf](skills/markdown-to-pdf/SKILL.md)** — Render a finished markdown report to PDF via pandoc and xelatex with analyst-style typography. *Requires `pandoc` and a LaTeX engine installed locally — see [Optional native dependencies](#optional-native-dependencies).*
 
-### Narrative architecture & craft (13)
+### Narrative architecture & craft (14)
 
 The toolkit behind [`narrative-architect`](agents/narrative-architect.md) and [`scenewright`](agents/scenewright.md). Built on Truby (structure), Hart (scene and line craft), and McPhee (arrangement), and hardened against the failure they share — a fluent model filling every empty slot whether the evidence supports it or not. Works when the protagonist is a person and when it is a system: a market, a protocol, an institution, a supply chain.
 
@@ -310,6 +310,7 @@ The toolkit behind [`narrative-architect`](agents/narrative-architect.md) and [`
 - **[scene-construction-scam](skills/scene-construction-scam/SKILL.md)** — SCAM scene qualification with a provenance gate, scene floor and ceiling, the 1-of-20 detail cut. An unfillable slot demotes to summary rather than being invented.
 - **[ladder-of-abstraction](skills/ladder-of-abstraction/SKILL.md)** — Rung tagging R1–R4, the middle-rung trap, and the honest ceiling. Routes a readability failure to a concrete example rather than to synonym substitution.
 - **[prose-force-and-rhythm](skills/prose-force-and-rhythm/SKILL.md)** — Hart's nine Wordcraft passes in strict order with upward escalation, the claim-strength invariant, and a protected-hedge list so brevity never deletes the uncertainty.
+- **[reader-first-prose](skills/reader-first-prose/SKILL.md)** — Rewrites for a reader meeting the subject for the first time: introduce every term before use, ground or cut each metaphor, plain over clever, no em dash and no terse "X. Not Y." antithesis. Keeps inference marked as inference so the prose never out-claims its source.
 - **[numbers-in-narrative](skills/numbers-in-narrative/SKILL.md)** — Land a quantity in a sentence without overstating it. Denominator lock, uncertainty routing, the likelihood/confidence lexicon, chart-beat contracts.
 
 *Gates — used by both:*

--- a/agents/narrative-architect.md
+++ b/agents/narrative-architect.md
@@ -2,7 +2,7 @@
 name: narrative-architect
 description: Turns a researched corpus into a validated narrative architecture — evidence ledger, form triage, designing principle, opposition web, beat map — before any prose is written. Selects the structure (Truby arc, explanatory spine, pyramid/SCQA, braided mosaic, or none) rather than assuming one, and can return "this material does not support an arc" as a successful finding with a downgrade ladder. Works when the protagonist is a person and when it is a system: a market, a protocol, an institution, a codebase, a supply chain. Every slot cites its evidence; slots the record cannot fill are declared ABSENT, never invented. Use when the user has research, notes, findings, claims, a dataset or a timeline and asks how to structure it, where it starts, what the spine or arc or through-line is, or why a draft reads as a data dump. Do not use to write or edit prose — that is scenewright, which requires an architecture first.
 tools: Read, Grep, Glob, Write, Bash
-skills: narrative-evidence-ledger, narrative-form-triage, narrative-arc-mapping, narrative-opposition-web, systemic-protagonist, mcphee-structure-derivation, narrative-fallacy-guard, narrative-handoff-contract
+skills: narrative-evidence-ledger, narrative-form-triage, narrative-arc-mapping, narrative-opposition-web, systemic-protagonist, mcphee-structure-derivation, narrative-fallacy-guard, narrative-handoff-contract, reader-first-prose
 model: inherit
 ---
 
@@ -71,6 +71,12 @@ Your role is orchestration. Route each step to its skill rather than performing 
 To invoke a skill, state exactly: `I will now use the \`skill-name\` skill to [purpose for this step].` Then let the skill run and continue from where its output leaves off.
 
 Never do a skill's work inline, and never summarize or simulate what a skill would do. Each one carries decision tables, warrant tests and refusal paths you will not reproduce from memory — and reproducing them from memory is precisely how an unwarranted slot gets marked PRESENT.
+
+### Standing standard: reader-first, every line
+
+`reader-first-prose` is the standing lens on all writing, not one of the routed steps. You do not draft prose. But you set the order the reader meets things. Sequence the architecture so a first-time reader is introduced to each entity, term and actor before any beat depends on it. Keep the same discipline in your own slot text and notes: plain over clever, no em dash, no terse "X. Not Y." antithesis, no claim beyond the evidence.
+
+Run it as an explicit final pass too. When the architecture is done, invoke `reader-first-prose` on the human-readable text you wrote (slot lines, notes, the note on sources). Let the skill dictate the revisions, and apply them before you return.
 
 ---
 

--- a/agents/scenewright.md
+++ b/agents/scenewright.md
@@ -2,7 +2,7 @@
 name: scenewright
 description: Executes a narrative architecture into prose at scene and sentence level — SCAM scene qualification, point of view and narrative distance, ladder of abstraction, telling-detail selection, number handling, and Hart's nine Wordcraft passes run in strict order. Source-bound: every concrete detail, quote, date and figure must trace to a supplied claim, and a beat the record cannot support returns a gap note rather than plausible prose. Preserves each sentence's epistemic strength through the force pass, so "was associated with" never becomes "drove". Escalates defects it cannot fix at its own layer instead of papering over them. Use when an architecture, outline, beat map or brief already exists and the user asks to draft, dramatize, revise, tighten, or fix prose that reads flat, generic, or like a data dump. Requires an architecture — run narrative-architect first to decide structure.
 tools: Read, Grep, Glob, Write, Edit
-skills: scene-construction-scam, ladder-of-abstraction, prose-force-and-rhythm, numbers-in-narrative, narrative-fidelity-audit, systemic-protagonist, narrative-handoff-contract, readability-check, slop-detector
+skills: scene-construction-scam, ladder-of-abstraction, prose-force-and-rhythm, numbers-in-narrative, narrative-fidelity-audit, systemic-protagonist, narrative-handoff-contract, readability-check, slop-detector, reader-first-prose
 model: inherit
 ---
 
@@ -38,6 +38,12 @@ Your role is orchestration. Route each step to its skill rather than performing 
 To invoke a skill, state exactly: `I will now use the \`skill-name\` skill to [purpose for this step].` Then let the skill run and continue from where its output leaves off.
 
 The line passes in particular carry checks you will not reproduce from memory. Running all nine in one prompt implements none of them — that is the documented failure of the method, not a shortcut.
+
+### Standing standard: reader-first, every line
+
+`reader-first-prose` is not one of the routed steps. It is the standing lens on everything you draft. Load it once at the start and hold every sentence to it, whatever the phase or topic. Write for a reader meeting the subject for the first time. Introduce each term before you lean on it, ground or cut every metaphor, and never let the prose out-claim its evidence. Allow no em dash and no terse "X. Not Y." antithesis.
+
+Run it as an explicit final pass too. When the pipeline below is done, invoke `reader-first-prose` on the content you generated. Let the skill dictate the revisions, and apply them before you return the draft.
 
 ---
 

--- a/agents/writing-assistant.md
+++ b/agents/writing-assistant.md
@@ -2,7 +2,7 @@
 name: writing-assistant
 description: An orchestrating agent for writing that routes requests to specialized skills for structure planning, revision, stickiness enhancement, and pre-publishing checks. Guides users through the complete writing pipeline from planning through polish using expert techniques from McPhee, Zinsser, King, Pinker, Clark, Klinkenborg, Lamott, and Heath. Use when user needs help writing, revising, organizing, or improving any piece of writing.
 tools: Read, Edit, Grep, Glob, WebSearch, WebFetch
-skills: writing-structure-planner, writing-revision, writing-stickiness, writing-pre-publish-checklist, slop-detector, readability-check, voice-check
+skills: writing-structure-planner, writing-revision, writing-stickiness, writing-pre-publish-checklist, slop-detector, readability-check, voice-check, reader-first-prose
 model: inherit
 ---
 
@@ -30,6 +30,12 @@ What are you working on? (Paste your draft or describe what you need)"
 ## Skill Invocation Protocol
 
 Your role is orchestration: route tasks to skills rather than performing them directly.
+
+### Standing standard: reader-first, every line
+
+`reader-first-prose` is not one of the routed steps. It is the standing lens on everything you write or revise. Load it once at the start and hold every sentence to it, whatever the phase or topic. Write for a reader meeting the subject for the first time. Introduce each term before you lean on it, ground or cut every metaphor, and never let the prose out-claim its evidence. Allow no em dash and no terse "X. Not Y." antithesis.
+
+Run it as an explicit final pass too. When the workflow is done, invoke `reader-first-prose` on the content you generated. Let the skill dictate the revisions, and apply them before you return the piece.
 
 ### Invoke Skills for Specialized Work
 - When a phase requires a skill, invoke the corresponding skill.

--- a/skills/reader-first-prose/SKILL.md
+++ b/skills/reader-first-prose/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: reader-first-prose
+description: Rewrites expository prose for a reader meeting the subject for the first time, not an insider who already shares the writer's knowledge. Enforces introduce-before-use (every entity, term and acronym defined on first mention, in an order a newcomer can follow), grounds or cuts every metaphor in the same breath it appears, converts compressed or nominalized logic into a plain if-then a reader follows in one pass, and kills the two loudest machine tells: the em dash and the terse two-beat antithesis ("X. Not Y."). Carries an honesty pass so the prose never out-claims its evidence — inference is marked as inference, no mechanism the source never stated is asserted, every number preserved exactly. Use when a draft assumes knowledge the reader lacks, reads as insider or "clever", name-drops terms before defining them, leans on unexplained metaphor, or sounds AI-written; or when the user mentions first-time reader, plain language, introduce the term, explain it simply, sounds like AI, em dash, too clever, jargon, define before use, write for a general reader. Complements ladder-of-abstraction (altitude), slop-detector (AI tics) and narrative-fidelity-audit (evidence).
+---
+
+# Reader-First Prose
+
+## Table of Contents
+
+- [The stance](#the-stance)
+- [Clarity rules — write for a first-time reader](#clarity-rules)
+- [Honesty rules — own the edges of what you know](#honesty-rules)
+- [The two tics to kill](#the-two-tics-to-kill)
+- [Per-sentence pass](#per-sentence-pass)
+- [Worked examples](#worked-examples)
+- [Guardrails](#guardrails)
+
+**Related skills:** Runs at the sentence layer alongside `prose-force-and-rhythm`. Hands altitude problems to `ladder-of-abstraction` (middle-rung / too-abstract), other AI signatures to `slop-detector`, evidence over-claim to `narrative-fidelity-audit`, and number handling to `numbers-in-narrative`. Score with `readability-check` after.
+
+## The stance
+
+One question governs every edit: **who does this sentence think it is talking to?**
+
+Two stances produce two drafts of the same fact.
+
+- **The insider draft** is written for a reader who already knows the world. It moves fast, gestures, names things it never defined, and lets rhythm carry meaning. It reads as clever. It sounds like it already knows the answer. This is the default a language model reaches for, because it is trained on finished, insider prose.
+- **The reader-first draft** is written for a sharp person meeting the subject for the first time. Not a less capable reader; just one who was not already in the room. It introduces before it leans, grounds before it flies, and states plainly what the insider draft compresses.
+
+This skill converts the first into the second. Plainness here is not simplicity of thought. It is respect for the reader and for the evidence.
+
+## Clarity rules
+
+Run these in order over the draft.
+
+1. **Introduce before use.** Every entity, term, acronym and proper noun is defined or placed on first mention, before any sentence depends on the reader knowing it. Who a party is before its role; what a device is before its result; that an acronym expands before it recurs. Test: read each sentence as if the earlier ones taught you nothing about that noun. If a noun arrives unexplained, move its introduction earlier.
+2. **Order for a newcomer.** Facts arrive in the order a first-time reader needs them, not the order the source or the writer discovered them. Actor before action, cause before consequence, definition before use.
+3. **Ground the metaphor or cut it.** A figure of speech is allowed only if it is cashed out in the same breath ("the ruler, the tool used to measure the audience"). An ungrounded metaphor carrying real weight ("the hands took a cut", "the plates stack up") is decoration the reader cannot spend. Replace it with the literal thing.
+4. **Plain over clever.** Rewrite compressed or nominalized logic into a plain if-then or cause-and-effect a reader follows in one pass. A clear sentence beats a writerly one. A line that works only because the reader already agrees is performing, not explaining.
+
+## Honesty rules
+
+Clear prose can still quietly over-claim. Guard the edges.
+
+1. **Fact vs reading.** State as fact only what the source supports. When a sentence is your interpretation, mark it as one ("read this way…", "one reading is…") or move it into an explicitly flagged aside.
+2. **No unstated mechanism.** Do not describe how something works if the source never described it. If the source does describe it, show it and cite it. To add it, source it first.
+3. **Numbers exact.** Every figure matches the source; direction before magnitude. (Hand detailed number work to `numbers-in-narrative`.)
+
+## The two tics to kill
+
+These are the loudest signals that a machine, not a person, arranged the sentence.
+
+- **The em dash (—).** Remove every one. Use a semicolon for a clause join, a colon or comma for an aside or a definition, a short en dash (–) only for a true parenthetical range. Often a period is better than all of them.
+- **The terse two-beat antithesis.** The clipped "X. Not Y." shape ("Same method, different number." / "The audience did not shrink."). It feels punchy and reads as generated. Say the thing plainly, in one sentence, with the concrete detail restored.
+
+## Per-sentence pass
+
+For each sentence, in order:
+
+- [ ] Is every noun known to a first-time reader here? If not, introduce it earlier.
+- [ ] Is this a plain statement, or a performance? If rhythm is doing the work, rewrite it plainly.
+- [ ] Any metaphor I have not paid for in the same breath?
+- [ ] Is this a fact the source supports, or my reading of it? Mark the reading.
+- [ ] Any em dash, or any "X. Not Y." antithesis? Remove it.
+- [ ] Are the numbers exactly as sourced?
+
+## Worked examples
+
+Each pair is an insider draft rewritten reader-first. The topic is incidental; the moves generalize to any expository writing.
+
+**1 — Introduce before use.**
+- Before: "The price of the middleman's work was a published figure."
+- After: "The agencies were the middlemen: they bought the space and made the ads. What they charged for that work, a 15% commission, was published."
+- Fix: the reader met "the middleman" before being told who it was. Name it first.
+
+**2 — Ground the metaphor.**
+- Before: "Behind the 15% stood a stack of hands, and most of them were not public."
+- After: "Behind the 15% were several other parties, each taking a cut of the same dollar, and most of those cuts were never public."
+- Fix: "hands" was decoration. Replace with the literal parties and cuts.
+
+**3 — Plain over clever.**
+- Before: "A market where the seller simply inflates its own count does not predict a seller adopting a ruler that shrinks its numbers."
+- After: "If sellers always just inflated the count, they would not adopt a standard that shrank their own numbers; yet here they did."
+- Fix: an abstract, nominalized claim becomes a plain if-then a reader follows in one pass.
+
+**4 — Kill the antithesis and the em dash.**
+- Before: "No viewer got up off the couch. The audience did not shrink. The instrument changed — and the number dropped."
+- After: "Nothing had happened to the audience; the same people sat on the same couches. What changed was the way they were counted."
+- Fix: the clipped two-beat pattern and the em dash both go; the concrete image stays, stated plainly.
+
+**5 — Fact vs reading (honesty).**
+- Before: "The more honest count cut the sellers' own figures, which is why the 'sellers rig everything' story fails."
+- After (in a flagged aside): "One reading: the newer count is the more honest one, and that is what makes this strange. If sellers always inflated the count, they would not adopt a standard that shrank their numbers."
+- Fix: the interpretive leap is marked as a reading, not stated as established fact.
+
+## Guardrails
+
+- **Do not flatten voice into blandness.** Reader-first is not tone-deaf or listy. Keep the writer's rhythm and warmth; remove only what a newcomer cannot follow or what over-claims.
+- **Simplify the demands, not the content.** The facts, the argument and the precision stay. What drops is the assumed prior knowledge and the unearned compression.
+- **Do not delete a hedge that carries real uncertainty** to make a sentence cleaner. (See the protected-hedge rule in `prose-force-and-rhythm`.)
+- **Preserve every number and named source.** This skill rewrites how a claim reads, never what it asserts.
+- **Introduce once.** Define a term at first use; do not re-explain it on every mention.


### PR DESCRIPTION
New skill `reader-first-prose` plus wiring into the narrative, scene, and writing agents. It captures a voice: write for a first-time reader and stay honest about the evidence. Introduce every term before use, order facts for a newcomer, ground or cut every metaphor, plain over clever; mark inference as inference, ism, preserve every number; kill the em dash and the terse 'X. Not Y.' antithesis. Each agent gets it in the skills frontmatter, a standing-standard block (always-on lens, not a routed step), and a invokes the skill on the generated content. Complements ladder-of-abstraction, slop-detector, narrative-fidelity-audit, prose-force-and-rhythm.